### PR TITLE
Enable async datasource refresh for all catalogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ refresh with the settings ```DATASOURCE_ASYNC_REFRESH```.If you have slow dataso
 to decrease the latency of the web server. In that case, a queue will be used to dispatch the refresh request to a
 background worker. This worker is called ```sync_datasources_worker```, callable like this:
 ```bash
-./manage.py sync_datasources_worker
+python manage.py sync_datasources_worker
 ```
 
 Building the Docker image

--- a/README.md
+++ b/README.md
@@ -273,6 +273,14 @@ If you need to run a command in a pod, you can use the following:
 kubectl exec -it deploy/app-deployment -n hexa-app -- bash
 ```
 
+By default, the datasource refresh (synchronization) is done in the web server. You can activate an asynchronous
+refresh with the settings ```DATASOURCE_ASYNC_REFRESH```.If you have slow datasources, it could be used
+to decrease the latency of the web server. In that case, a queue will be used to dispatch the refresh request to a
+background worker. This worker is called ```sync_datasources_worker```, callable like this:
+```bash
+./manage.py sync_datasources_worker
+```
+
 Building the Docker image
 -------------------------
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -56,6 +56,7 @@ INSTALLED_APPS = [
     "hexa.plugins.connector_s3.apps.S3ConnectorConfig",
     "hexa.plugins.connector_airflow.apps.ConnectorAirflowConfig",
     "hexa.plugins.connector_postgresql.apps.PostgresqlConnectorConfig",
+    "dpq",
 ]
 
 MIDDLEWARE = [
@@ -229,6 +230,9 @@ if all([EMAIL_HOST, EMAIL_PORT, EMAIL_HOST_USER, EMAIL_HOST_PASSWORD]):
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 else:
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+# Sync settings: sync datasource with a worker (good for scaling) or in the web serv (good for dev)
+DATASOURCE_ASYNC_REFRESH = os.environ.get("DATASOURCE_ASYNC_REFRESH") == "true"
 
 if DEBUG:
     INSTALLED_APPS.append("debug_toolbar")

--- a/hexa/catalog/management/commands/sync_datasources_worker.py
+++ b/hexa/catalog/management/commands/sync_datasources_worker.py
@@ -1,0 +1,7 @@
+from dpq.commands import Worker
+
+from hexa.catalog.queue import datasource_sync_queue
+
+
+class Command(Worker):
+    queue = datasource_sync_queue

--- a/hexa/catalog/models.py
+++ b/hexa/catalog/models.py
@@ -266,7 +266,7 @@ class WithIndex:
 class DatasourceQuerySet(models.QuerySet):
     def filter_for_user(self, user):
         raise NotImplementedError(
-            "Datasource QuerySet should implement the filter_for_user() property"
+            "Datasource QuerySet should implement the filter_for_user() method"
         )
 
 

--- a/hexa/catalog/models.py
+++ b/hexa/catalog/models.py
@@ -263,9 +263,18 @@ class WithIndex:
         raise NotImplementedError
 
 
+class DatasourceQuerySet(models.QuerySet):
+    def filter_for_user(self, user):
+        raise NotImplementedError(
+            "Datasource QuerySet should implement the filter_for_user() property"
+        )
+
+
 class Datasource(WithIndex, models.Model):
     class Meta:
         abstract = True
+
+    objects = DatasourceQuerySet.as_manager()
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/hexa/catalog/queue.py
+++ b/hexa/catalog/queue.py
@@ -1,0 +1,38 @@
+from logging import getLogger
+
+from dpq.queue import AtLeastOnceQueue
+from django.contrib.contenttypes.models import ContentType
+
+
+logger = getLogger(__name__)
+
+
+def datasource_sync(queue, job):
+    try:
+        # permission and db existing are checked by views -> but may change since, so assume failure is possible
+        logger.info(
+            "start datasource sync, type: %s, id: %s",
+            job.args["contenttype_id"],
+            job.args["object_id"],
+        )
+        datasource_type = ContentType.objects.get_for_id(id=job.args["contenttype_id"])
+        datasource = datasource_type.get_object_for_this_type(id=job.args["object_id"])
+        sync_result = datasource.sync()
+        logger.info(
+            "end datasource sync type: %s, id: %s, result: %s",
+            job.args["contenttype_id"],
+            job.args["object_id"],
+            sync_result,
+        )
+    except Exception:
+        logger.exception("datasource sync failed")
+
+
+# task queue for the postgresql connector
+# AtLeastOnceQueue + try/except: if the worker fail, restart the task. if the task fail, drop it + log
+datasource_sync_queue = AtLeastOnceQueue(
+    tasks={
+        "datasource_sync": datasource_sync,
+    },
+    notify_channel="datasource_sync_queue",
+)

--- a/hexa/catalog/tests/test_sync.py
+++ b/hexa/catalog/tests/test_sync.py
@@ -1,0 +1,105 @@
+from django import test
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+from mock import patch
+
+from hexa.plugins.connector_postgresql.models import (
+    Database,
+    DatasourceSyncResult,
+)
+from hexa.catalog.queue import datasource_sync_queue
+from hexa.user_management.models import User
+
+
+class AsyncRefreshTest(test.TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.SUPER_USER = User.objects.create_user(
+            "jim@bluesquarehub.com",
+            "jim2021__",
+            is_superuser=True,
+        )
+        cls.DATABASE_1 = Database.objects.create(
+            hostname="localhost", username="db1", password="db1", database="db1"
+        )
+
+    @test.override_settings(DATASOURCE_ASYNC_REFRESH=False)
+    def test_sync_refresh(self):
+        self.client.force_login(self.SUPER_USER)
+        synced = False
+
+        def mock_sync(self):
+            nonlocal synced
+            synced = True
+            return DatasourceSyncResult(
+                datasource=self,
+                created=10,
+                updated=11,
+                identical=12,
+                orphaned=13,
+            )
+
+        with patch("hexa.plugins.connector_postgresql.models.Database.sync", mock_sync):
+            url = reverse(
+                "catalog:datasource_sync",
+                args=[
+                    ContentType.objects.get_for_model(Database).id,
+                    self.DATABASE_1.id,
+                ],
+            )
+            response = self.client.post(url, HTTP_REFERER="/", follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(synced)
+
+    @test.override_settings(DATASOURCE_ASYNC_REFRESH=True)
+    def test_async_refresh(self):
+        self.client.force_login(self.SUPER_USER)
+        synced = False
+
+        def mock_sync(self):
+            nonlocal synced
+            synced = True
+            return DatasourceSyncResult(
+                datasource=self,
+                created=10,
+                updated=11,
+                identical=12,
+                orphaned=13,
+            )
+
+        with patch("hexa.plugins.connector_postgresql.models.Database.sync", mock_sync):
+            url = reverse(
+                "catalog:datasource_sync",
+                args=[
+                    ContentType.objects.get_for_model(Database).id,
+                    self.DATABASE_1.id,
+                ],
+            )
+            response = self.client.post(url, HTTP_REFERER="/", follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(synced)
+
+        with patch("hexa.plugins.connector_postgresql.models.Database.sync", mock_sync):
+            while datasource_sync_queue.run_once():
+                pass
+
+        self.assertTrue(synced)
+
+    @test.override_settings(DATASOURCE_ASYNC_REFRESH=True)
+    def test_sync_errors(self):
+        self.client.force_login(self.SUPER_USER)
+        url = reverse("catalog:datasource_sync", args=[55555, self.DATABASE_1.id])
+        response = self.client.post(url, HTTP_REFERER="/", follow=True)
+        assert response.status_code == 404
+
+        url = reverse(
+            "catalog:datasource_sync",
+            args=[
+                ContentType.objects.get_for_model(Database).id,
+                "766c1165-2335-4108-885d-4b038839f264",
+            ],
+        )
+        response = self.client.post(url, HTTP_REFERER="/", follow=True)
+        assert response.status_code == 404

--- a/hexa/catalog/urls.py
+++ b/hexa/catalog/urls.py
@@ -8,4 +8,9 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("quick-search", views.quick_search, name="quick_search"),
     path("search", views.search, name="search"),
+    path(
+        "sync/<int:datasource_contenttype>/<str:datasource_id>",
+        views.datasource_sync,
+        name="datasource_sync",
+    ),
 ]

--- a/hexa/plugins/connector_dhis2/datacards.py
+++ b/hexa/plugins/connector_dhis2/datacards.py
@@ -1,3 +1,4 @@
+from django.contrib.contenttypes.models import ContentType
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
@@ -45,7 +46,13 @@ class InstanceCard(Datacard):
 
     def get_sync_url(self, instance: Instance):
         return reverse(
-            "connector_dhis2:instance_sync", kwargs={"instance_id": instance.id}
+            "catalog:datasource_sync",
+            kwargs={
+                "datasource_id": instance.id,
+                "datasource_contenttype": ContentType.objects.get_for_model(
+                    Instance
+                ).id,
+            },
         )
 
 

--- a/hexa/plugins/connector_dhis2/models.py
+++ b/hexa/plugins/connector_dhis2/models.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext_lazy as _
 
 from hexa.catalog.models import (
     Datasource,
+    DatasourceQuerySet,
     Entry,
     Index,
     IndexPermission,
@@ -64,7 +65,7 @@ class Credentials(Base):
                 raise ValidationError("DHIS2 URL is invalid")
 
 
-class InstanceQuerySet(models.QuerySet):
+class InstanceQuerySet(DatasourceQuerySet):
     def filter_for_user(self, user):
         if user.is_active and user.is_superuser:
             return self

--- a/hexa/plugins/connector_dhis2/urls.py
+++ b/hexa/plugins/connector_dhis2/urls.py
@@ -37,11 +37,6 @@ urlpatterns = [
         name="indicator_extract",
     ),
     path(
-        "<str:instance_id>/sync",
-        views.instance_sync,
-        name="instance_sync",
-    ),
-    path(
         "extract/<str:extract_id>",
         views.extract_detail,
         name="extract_detail",

--- a/hexa/plugins/connector_dhis2/views.py
+++ b/hexa/plugins/connector_dhis2/views.py
@@ -225,16 +225,6 @@ def indicator_extract(
     return redirect(request.META.get("HTTP_REFERER"))
 
 
-def instance_sync(request, instance_id):
-    instance = get_object_or_404(
-        Instance.objects.filter_for_user(request.user), pk=instance_id
-    )
-    sync_result = instance.sync()
-    messages.success(request, sync_result)
-
-    return redirect(request.META.get("HTTP_REFERER"))
-
-
 def extract_detail(request, extract_id):
     extract = get_object_or_404(
         Extract.objects.filter_for_user(request.user), id=extract_id

--- a/hexa/plugins/connector_postgresql/datacards.py
+++ b/hexa/plugins/connector_postgresql/datacards.py
@@ -1,3 +1,4 @@
+from django.contrib.contenttypes.models import ContentType
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
@@ -86,8 +87,13 @@ class DatabaseCard(Datacard):
 
     def get_sync_url(self, database: Database):
         return reverse(
-            "connector_postgresql:datasource_sync",
-            kwargs={"datasource_id": database.id},
+            "catalog:datasource_sync",
+            kwargs={
+                "datasource_id": database.id,
+                "datasource_contenttype": ContentType.objects.get_for_model(
+                    Database
+                ).id,
+            },
         )
 
 

--- a/hexa/plugins/connector_postgresql/models.py
+++ b/hexa/plugins/connector_postgresql/models.py
@@ -18,6 +18,7 @@ from hexa.catalog.models import (
     Index,
     IndexPermission,
     Datasource,
+    DatasourceQuerySet,
     Entry,
 )
 from hexa.catalog.sync import DatasourceSyncResult
@@ -31,7 +32,7 @@ class ExternalType(Enum):
     TABLE = "table"
 
 
-class DatabaseQuerySet(models.QuerySet):
+class DatabaseQuerySet(DatasourceQuerySet):
     def filter_for_user(self, user):
         if user.is_active and user.is_superuser:
             return self

--- a/hexa/plugins/connector_postgresql/urls.py
+++ b/hexa/plugins/connector_postgresql/urls.py
@@ -16,9 +16,4 @@ urlpatterns = [
         views.table_detail,
         name="table_detail",
     ),
-    path(
-        "<str:datasource_id>/sync",
-        views.datasource_sync,
-        name="datasource_sync",
-    ),
 ]

--- a/hexa/plugins/connector_postgresql/views.py
+++ b/hexa/plugins/connector_postgresql/views.py
@@ -116,13 +116,3 @@ def table_detail(request, datasource_id, table_id):
             "breadcrumbs": breadcrumbs,
         },
     )
-
-
-def datasource_sync(request, datasource_id):
-    datasource = get_object_or_404(
-        Database.objects.filter_for_user(request.user), pk=datasource_id
-    )
-    sync_result = datasource.sync()
-    messages.success(request, sync_result)
-
-    return redirect(request.META.get("HTTP_REFERER"))

--- a/hexa/plugins/connector_s3/datacards.py
+++ b/hexa/plugins/connector_s3/datacards.py
@@ -1,3 +1,4 @@
+from django.contrib.contenttypes.models import ContentType
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
@@ -89,8 +90,11 @@ class BucketCard(Datacard):
 
     def get_sync_url(self, bucket: Bucket):
         return reverse(
-            "connector_s3:datasource_sync",
-            kwargs={"datasource_id": bucket.id},
+            "catalog:datasource_sync",
+            kwargs={
+                "datasource_id": bucket.id,
+                "datasource_contenttype": ContentType.objects.get_for_model(Bucket).id,
+            },
         )
 
 

--- a/hexa/plugins/connector_s3/models.py
+++ b/hexa/plugins/connector_s3/models.py
@@ -18,6 +18,7 @@ import os
 from hexa.catalog.models import (
     Base,
     Datasource,
+    DatasourceQuerySet,
     Entry,
     Index,
     IndexPermission,
@@ -53,7 +54,7 @@ class Credentials(Base):
         return self.role_arn != ""
 
 
-class BucketQuerySet(models.QuerySet):
+class BucketQuerySet(DatasourceQuerySet):
     def filter_for_user(self, user):
         if user.is_active and user.is_superuser:
             return self

--- a/hexa/plugins/connector_s3/urls.py
+++ b/hexa/plugins/connector_s3/urls.py
@@ -7,11 +7,6 @@ app_name = "connector_s3"
 urlpatterns = [
     path("<str:datasource_id>", views.datasource_detail, name="datasource_detail"),
     path(
-        "<str:datasource_id>/sync",
-        views.datasource_sync,
-        name="datasource_sync",
-    ),
-    path(
         "<str:bucket_id>/object/<path:path>",
         views.object_detail,
         name="object_detail",

--- a/hexa/plugins/connector_s3/views.py
+++ b/hexa/plugins/connector_s3/views.py
@@ -39,16 +39,6 @@ def datasource_detail(request, datasource_id):
     )
 
 
-def datasource_sync(request, datasource_id):
-    datasource = get_object_or_404(
-        Bucket.objects.filter_for_user(request.user), pk=datasource_id
-    )
-    sync_result = datasource.sync()
-    messages.success(request, sync_result)
-
-    return redirect(request.META.get("HTTP_REFERER"))
-
-
 def object_detail(request, bucket_id, path):
     bucket = get_object_or_404(
         Bucket.objects.filter_for_user(request.user), pk=bucket_id

--- a/requirements.in
+++ b/requirements.in
@@ -7,9 +7,11 @@ Django
 django-cors-headers
 django-countries
 django-ltree
+django-postgres-queue
 django-tailwind
 gunicorn
 markdown
+mock
 pandas
 psycopg2-binary
 stringcase

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,7 @@ django==3.2.7
     #   django-cors-headers
     #   django-debug-toolbar
     #   django-ltree
+    #   django-postgres-queue
     #   django-tailwind
 django-cors-headers==3.8.0
     # via -r requirements.in
@@ -64,6 +65,8 @@ django-countries==7.2.1
 django-debug-toolbar==3.2.2
     # via -r requirements.in
 django-ltree==0.5.3
+    # via -r requirements.in
+django-postgres-queue==1.0.0
     # via -r requirements.in
 django-tailwind==2.2.0
     # via -r requirements.in
@@ -96,6 +99,8 @@ markupsafe==2.0.1
     # via
     #   jinja2
     #   moto
+mock==4.0.3
+    # via -r requirements.in
 more-itertools==8.9.0
     # via moto
 moto[s3]==2.2.6


### PR DESCRIPTION
This PR enables openhexa to delay ```sync()``` for all catalogs, and do the work in a separate process (called ```sync_datasources_worker```). This change of behavior is activated with a new settings, ```DATASOURCE_ASYNC_REFRESH```, which is False by default (no change of behavior, no change of deploy settings needed). It use the django-postgres-queue because it doesnt need a lot of new infrastructure (like celery or something else) and is suffisant for the immediate future.

Notes:
- add a new test, which set the ASYNC_REFRESH to both values to see if queued sync or immediate sync works. use package "mock" to check when datasource.sync() is called
- test pass localy, but not on GH because of dockerhub credentials, sorry :/
- it needs a new worker to run the postgresql task queue, but not by default
- since we check perm on manager of each subtype (```filter_for_user()```), i created a DatasourceQuerySet to use for all datasources's querysets. 

README update coming