### PR TITLE
Cache busting for js

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -32,6 +32,8 @@ ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "").split(",")
 
 # Application definition
 INSTALLED_APPS = [
+    # http://whitenoise.evans.io/en/stable/django.html#using-whitenoise-in-development
+    "whitenoise.runserver_nostatic",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -183,6 +185,10 @@ USE_TZ = True
 STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "static"
 STATICFILES_DIRS = [BASE_DIR / "hexa" / "static"]
+
+# Whitenoise
+# http://whitenoise.evans.io/en/stable/django.html#add-compression-and-caching-support
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 # Comments
 COMMENTS_APP = "hexa.comments"

--- a/config/settings.py
+++ b/config/settings.py
@@ -248,3 +248,6 @@ if DEBUG:
     DEBUG_TOOLBAR_CONFIG = {
         "SHOW_TOOLBAR_CALLBACK": lambda request: request.user.is_staff,
     }
+
+# Custom test runner
+TEST_RUNNER = "hexa.core.test.runner.DiscoverRunner"

--- a/config/settings.py
+++ b/config/settings.py
@@ -188,7 +188,7 @@ STATICFILES_DIRS = [BASE_DIR / "hexa" / "static"]
 
 # Whitenoise
 # http://whitenoise.evans.io/en/stable/django.html#add-compression-and-caching-support
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # Comments
 COMMENTS_APP = "hexa.comments"

--- a/hexa/core/test/runner.py
+++ b/hexa/core/test/runner.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+from django.test.runner import DiscoverRunner as BaseDiscoverRunner
+
+
+class DiscoverRunner(BaseDiscoverRunner):
+    def setup_test_environment(self, **kwargs):
+        super().setup_test_environment(**kwargs)
+        # ManifestStaticFileStorage & friends are not well-suited for tests, as they would required
+        # collectstatic to be run before each test run
+        settings.STATICFILES_STORAGE = (
+            "django.contrib.staticfiles.storage.StaticFilesStorage"
+        )


### PR DESCRIPTION
This PR enables Whitenoise caching / cache busting/

See https://whitenoise.evans.io/en/stable/django.html#add-compression-and-caching-support and https://docs.djangoproject.com/en/3.2/ref/contrib/staticfiles/#manifeststaticfilesstorage.

In a nutshell:

- `collectstatic` will generate static files with a unique hash
- using the `static` template tag will generate a link to the file names with hashes