### PR TITLE
Generic auto-refresh component

### DIFF
--- a/hexa/pipelines/templates/pipelines/index.html
+++ b/hexa/pipelines/templates/pipelines/index.html
@@ -6,9 +6,13 @@
 {% block page_content %}
     {{ environment_grid }}
     {% url "pipelines:index_refresh" as refresh_url %}
-    {% embed "ui/section/section_autorefresh.html" with title=_("Last pipeline runs") url=refresh_url %}
+    {% embed "ui/dynamic/autorefresh.html" with url=refresh_url %}
         {% slot content %}
-            {{ run_grid }}
+            {% embed "ui/section/section.html" with title=_("Last pipeline runs") %}
+                {% slot content %}
+                    {{ run_grid }}
+                {% endslot %}
+            {% endembed %}
         {% endslot %}
     {% endembed %}
 {% endblock %}

--- a/hexa/plugins/connector_airflow/datacards.py
+++ b/hexa/plugins/connector_airflow/datacards.py
@@ -68,7 +68,7 @@ class DAGCard(Datacard):
 
     def get_run_url(self, dag):
         return reverse(
-            "connector_airflow:new_dag_run",
+            "connector_airflow:dag_run_create",
             kwargs={
                 "cluster_id": dag.cluster.id,
                 "dag_id": dag.id,

--- a/hexa/plugins/connector_airflow/templates/connector_airflow/cluster_detail.html
+++ b/hexa/plugins/connector_airflow/templates/connector_airflow/cluster_detail.html
@@ -6,9 +6,13 @@
 {% block page_content %}
     {{ cluster_card }}
     {% url "connector_airflow:cluster_detail_refresh" cluster.id as refresh_url %}
-    {% embed "ui/section/section_autorefresh.html" with title=_("DAGs") url=refresh_url %}
+    {% embed "ui/dynamic/autorefresh.html" with url=refresh_url %}
         {% slot content %}
-            {{ dag_grid }}
+            {% embed "ui/section/section.html" with title=_("DAGs") %}
+                {% slot content %}
+                    {{ dag_grid }}
+                {% endslot %}
+            {% endembed %}
         {% endslot %}
     {% endembed %}
 {% endblock %}

--- a/hexa/plugins/connector_airflow/templates/connector_airflow/dag_detail.html
+++ b/hexa/plugins/connector_airflow/templates/connector_airflow/dag_detail.html
@@ -11,9 +11,13 @@
         {% endslot %}
     {% endembed %}
     {% url "connector_airflow:dag_detail_refresh" dag.cluster.id dag.id as refresh_url %}
-    {% embed "ui/section/section_autorefresh.html" with title=_("Runs") url=refresh_url %}
+    {% embed "ui/dynamic/autorefresh.html" with url=refresh_url %}
         {% slot content %}
-            {{ run_grid }}
+            {% embed "ui/section/section.html" with title=_("Runs") %}
+                {% slot content %}
+                    {{ run_grid }}
+                {% endslot %}
+            {% endembed %}
         {% endslot %}
     {% endembed %}
 {% endblock %}

--- a/hexa/plugins/connector_airflow/templates/connector_airflow/dag_run_detail.html
+++ b/hexa/plugins/connector_airflow/templates/connector_airflow/dag_run_detail.html
@@ -1,8 +1,13 @@
 {% extends "layouts/page.html" %}
 {% load embed %}
 
-{% block page_title %}{{ dag.dag_id }}{% endblock %}
+{% block page_title %}{{ dag_run.dag.dag_id }}{% endblock %}
 
 {% block page_content %}
-    {{ dag_run_card }}
+    {% url "connector_airflow:dag_run_detail_refresh" dag_run.dag.cluster.id dag_run.dag.id dag_run.id as refresh_url %}
+    {% embed "ui/dynamic/autorefresh.html" with url=refresh_url %}
+        {% slot content %}
+            {{ dag_run_card }}
+        {% endslot %}
+    {% endembed %}
 {% endblock %}

--- a/hexa/plugins/connector_airflow/urls.py
+++ b/hexa/plugins/connector_airflow/urls.py
@@ -27,17 +27,22 @@ urlpatterns = [
     ),
     path(
         "<uuid:cluster_id>/<uuid:dag_id>/run",
-        views.new_dag_run,
-        name="new_dag_run",
-    ),
-    path(
-        "<uuid:cluster_id>/sync",
-        views.sync,
-        name="sync",
+        views.dag_run_create,
+        name="dag_run_create",
     ),
     path(
         "<uuid:cluster_id>/<uuid:dag_id>/runs/<uuid:dag_run_id>",
         views.dag_run_detail,
         name="dag_run_detail",
+    ),
+    path(
+        "<uuid:cluster_id>/<uuid:dag_id>/runs/<uuid:dag_run_id>/refresh",
+        views.dag_run_detail_refresh,
+        name="dag_run_detail_refresh",
+    ),
+    path(
+        "<uuid:cluster_id>/sync",
+        views.sync,
+        name="sync",
     ),
 ]

--- a/hexa/plugins/connector_airflow/views.py
+++ b/hexa/plugins/connector_airflow/views.py
@@ -169,8 +169,7 @@ def dag_run_detail(
         request,
         "connector_airflow/dag_run_detail.html",
         {
-            "cluster": cluster,
-            "dag": dag,
+            "dag_run": dag_run,
             "dag_run_card": dag_run_card,
             "breadcrumbs": breadcrumbs,
         },
@@ -184,14 +183,19 @@ def dag_run_detail_refresh(
     dag_run_id: uuid.UUID,
 ) -> HttpResponse:
     get_object_or_404(Cluster.objects.filter_for_user(request.user), pk=cluster_id)
-    dag = get_object_or_404(DAG.objects.filter_for_user(request.user), pk=dag_id)
-    for run in dag.dagrun_set.filter_for_refresh():
-        try:
-            run.refresh()
-        except AirflowAPIError:
-            logger.exception(f"Refresh failed for DAGRun {run.id}")
+    get_object_or_404(DAG.objects.filter_for_user(request.user), pk=dag_id)
+    dag_run = get_object_or_404(
+        DAGRun.objects.filter_for_user(request.user), pk=dag_run_id
+    )
 
-    return dag_detail(request, cluster_id=cluster_id, dag_id=dag_id)
+    try:
+        dag_run.refresh()
+    except AirflowAPIError:
+        logger.exception(f"Refresh failed for DAGRun {dag_run.id}")
+
+    return dag_run_detail(
+        request, cluster_id=cluster_id, dag_id=dag_id, dag_run_id=dag_run_id
+    )
 
 
 @require_http_methods(["POST"])

--- a/hexa/plugins/connector_airflow/views.py
+++ b/hexa/plugins/connector_airflow/views.py
@@ -112,9 +112,24 @@ def dag_detail(
     )
 
 
-def new_dag_run(
+def dag_detail_refresh(
     request: HttpRequest, cluster_id: uuid.UUID, dag_id: uuid.UUID
 ) -> HttpResponse:
+    get_object_or_404(Cluster.objects.filter_for_user(request.user), pk=cluster_id)
+    dag = get_object_or_404(DAG.objects.filter_for_user(request.user), pk=dag_id)
+    for run in dag.dagrun_set.filter_for_refresh():
+        try:
+            run.refresh()
+        except AirflowAPIError:
+            logger.exception(f"Refresh failed for DAGRun {run.id}")
+
+    return dag_detail(request, cluster_id=cluster_id, dag_id=dag_id)
+
+
+def dag_run_create(
+    request: HttpRequest, cluster_id: uuid.UUID, dag_id: uuid.UUID
+) -> HttpResponse:
+    get_object_or_404(Cluster.objects.filter_for_user(request.user), pk=cluster_id)
     dag = get_object_or_404(DAG.objects.filter_for_user(request.user), pk=dag_id)
     dag_run = dag.run()
 
@@ -162,8 +177,11 @@ def dag_run_detail(
     )
 
 
-def dag_detail_refresh(
-    request: HttpRequest, cluster_id: uuid.UUID, dag_id: uuid.UUID
+def dag_run_detail_refresh(
+    request: HttpRequest,
+    cluster_id: uuid.UUID,
+    dag_id: uuid.UUID,
+    dag_run_id: uuid.UUID,
 ) -> HttpResponse:
     get_object_or_404(Cluster.objects.filter_for_user(request.user), pk=cluster_id)
     dag = get_object_or_404(DAG.objects.filter_for_user(request.user), pk=dag_id)

--- a/hexa/ui/templates/ui/dynamic/autorefresh.html
+++ b/hexa/ui/templates/ui/dynamic/autorefresh.html
@@ -1,10 +1,10 @@
 {% load embed %}
 
-{% embed "ui/section/section.html" %}
-    {% slot extra_wrapper_attrs %}
+<div
         x-data="AutoRefresh('{{ url }}', {{ delay|default:10 }})"
         x-init="init($el)"
         x-html="refreshedHtml"
         x-refresh-id="{{ url }}"
-    {% endslot %}
-{% endembed %}
+>
+    {% slot content %}{% endslot %}
+</div>


### PR DESCRIPTION
The initial goal of the PR was to auto-refresh the DAG run detail screen.

We already had some auto-refresh parts, but the implementation was linked to the section component and could not be used as-is for the cluster card.

This PR moves auto-refresh behaviour in its own independent component.

It also adds a bunch of tests for airflow screens.