### PR TITLE
Recursion issue when bucket contains a "/" directory

### DIFF
--- a/hexa/plugins/connector_s3/models.py
+++ b/hexa/plugins/connector_s3/models.py
@@ -144,7 +144,7 @@ class Bucket(Datasource):
             # S3fs adds the bucket name in the Key, we remove it to be consistent with the S3 documentation
             object_data["true_key"] = object_data["Key"].split("/", 1)[1]
 
-            if object_data["Key"] == f"{path}" and object_data["type"] != "directory":
+            if object_data["Key"] == f"{path}":
                 # Detects the current directory. Ignore it as we already got it from the parent listing
                 continue
 


### PR DESCRIPTION
Fix for our annoying recursion issue when syncing s3 buckets with `/` directories.

There was a strange `!= "directory"` test in the sync that prevented the sync to skip "self-replicating syncs". Added a test to make sure.