### PR TITLE
Fix last_synced_ad on DHIS2 content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 Changelog
 =========
 
+Version 0.20
+------------
+
+January 18, 2022
+
+### Fixed
+
+- Fixed last_synced_at on DHIS2 content
+
 Version 0.19
 ------------
+
+January 11, 2022
 
 ### Added
 
@@ -20,6 +31,8 @@ Version 0.19
 Version 0.18
 ------------
 
+January 4, 2022
+
 ### Updated
 
 - Removed the notion of orphans from S3 data model
@@ -35,7 +48,7 @@ Version 0.18
 Version 0.17
 ------------
 
-December 28 2021
+December 28, 2021
 
 ### Added
 
@@ -57,7 +70,7 @@ December 28 2021
 Version 0.16
 ------------
 
-December 21 2021
+December 21, 2021
 
 ### Updated
 
@@ -75,7 +88,7 @@ December 21 2021
 Version 0.15
 ------------
 
-December 14 2021
+December 14, 2021
 
 ### Added
 
@@ -97,7 +110,7 @@ December 14 2021
 Version 0.14
 ------------
 
-December 7 2021
+December 7, 2021
 
 ### Added
 

--- a/hexa/plugins/connector_dhis2/models.py
+++ b/hexa/plugins/connector_dhis2/models.py
@@ -121,6 +121,7 @@ class Instance(Datasource):
 
         # Sync data elements
         with transaction.atomic():
+            self.last_synced_at = timezone.now()
             info = client.fetch_info()
             self.sync_log("fetch info done: %s", info)
             self.name = info["systemName"]
@@ -171,7 +172,6 @@ class Instance(Datasource):
 
             # Flag the datasource as synced
             self.sync_log("end of fetching resources")
-            self.last_synced_at = timezone.now()
             self.save()
 
         self.sync_log("end of syncing")

--- a/hexa/plugins/connector_dhis2/tests/test_models.py
+++ b/hexa/plugins/connector_dhis2/tests/test_models.py
@@ -176,6 +176,15 @@ class DHIS2SyncTest(test.TestCase):
         for model in (DataElement, IndicatorType, Indicator, DataSet):
             self.assertTrue(model.objects.all().count() > 0)
 
+        # Let's make sure that the last_synced_at at the index level matches the instance last_synced_at
+        first_data_element = DataElement.objects.filter(
+            instance=self.DHIS2_INSTANCE_PLAY
+        ).first()
+        self.assertEqual(
+            first_data_element.index.last_synced_at,
+            self.DHIS2_INSTANCE_PLAY.last_synced_at,
+        )
+
 
 class DHIS2SyncInstanceSplitTest(test.TestCase):
     @classmethod


### PR DESCRIPTION
DHIS2 last_synced_at should be set on instance before syncing their content, otherwise their index will keep the previous last_synced_at value