### PR TITLE
Fix for permission conflicts in S3 bucket

### DIFF
--- a/hexa/plugins/connector_s3/models.py
+++ b/hexa/plugins/connector_s3/models.py
@@ -72,13 +72,28 @@ class BucketQuerySet(BaseQuerySet):
             # If requested mode is read-only, we don't want to return any bucket
             return self.none() if mode == PermissionMode.VIEWER else self
 
+        # Note about the join happening behind the scenes: we need to filter on team AND mode in the same filter call
+        # (see https://docs.djangoproject.com/en/4.0/topics/db/queries/#spanning-multi-valued-relationships)
         filter_kwargs = {"bucketpermission__team__in": user.team_set.all()}
         if mode is not None:
             filter_kwargs["bucketpermission__mode"] = mode
         elif mode__in is not None:
             filter_kwargs["bucketpermission__mode__in"] = mode__in
+        queryset = self.filter(**filter_kwargs)
 
-        return self.filter(**filter_kwargs).distinct()
+        # When querying for buckets with "VIEWER" permission mode, we want to exclude buckets for which the user has
+        # higher privileges - otherwise the VIEWER mode will supersede EDITOR / OWNER modes in generated permissions
+        if mode == PermissionMode.VIEWER:
+            queryset = queryset.exclude(
+                id__in=[
+                    b.id
+                    for b in self.filter_for_user(
+                        user, mode__in=[PermissionMode.EDITOR, PermissionMode.OWNER]
+                    )
+                ]
+            )
+
+        return queryset.distinct()
 
 
 class Bucket(Datasource):

--- a/hexa/plugins/connector_s3/models.py
+++ b/hexa/plugins/connector_s3/models.py
@@ -84,14 +84,10 @@ class BucketQuerySet(BaseQuerySet):
         # When querying for buckets with "VIEWER" permission mode, we want to exclude buckets for which the user has
         # higher privileges - otherwise the VIEWER mode will supersede EDITOR / OWNER modes in generated permissions
         if mode == PermissionMode.VIEWER:
-            queryset = queryset.exclude(
-                id__in=[
-                    b.id
-                    for b in self.filter_for_user(
-                        user, mode__in=[PermissionMode.EDITOR, PermissionMode.OWNER]
-                    )
-                ]
+            editor_or_owner_buckets = self.filter_for_user(
+                user, mode__in=[PermissionMode.EDITOR, PermissionMode.OWNER]
             )
+            queryset = queryset.exclude(id__in=[b.id for b in editor_or_owner_buckets])
 
         return queryset.distinct()
 

--- a/hexa/plugins/connector_s3/models.py
+++ b/hexa/plugins/connector_s3/models.py
@@ -72,16 +72,13 @@ class BucketQuerySet(BaseQuerySet):
             # If requested mode is read-only, we don't want to return any bucket
             return self.none() if mode == PermissionMode.VIEWER else self
 
-        queryset = self.filter(
-            bucketpermission__team__in=[t.pk for t in user.team_set.all()],
-        ).distinct()
-
+        filter_kwargs = {"bucketpermission__team__in": user.team_set.all()}
         if mode is not None:
-            queryset = queryset.filter(bucketpermission__mode=mode)
+            filter_kwargs["bucketpermission__mode"] = mode
         elif mode__in is not None:
-            queryset = queryset.filter(bucketpermission__mode__in=mode__in)
+            filter_kwargs["bucketpermission__mode__in"] = mode__in
 
-        return queryset
+        return self.filter(**filter_kwargs).distinct()
 
 
 class Bucket(Datasource):


### PR DESCRIPTION
This PR fixes a bad query that was causing conflicts within bucket permissions - especially when generating notebook credentials.