### PR TITLE
Add default CRS on country in Graph

### DIFF
--- a/hexa/user_management/graphql/schema.graphql
+++ b/hexa/user_management/graphql/schema.graphql
@@ -230,6 +230,7 @@ type Country {
     alpha3: String!
     name: String!
     flag: String!
+    defaultCRS: Int!
 }
 input CountryInput {
     code: String!

--- a/hexa/user_management/schema.py
+++ b/hexa/user_management/schema.py
@@ -256,15 +256,23 @@ country_object = ObjectType("Country")
 
 
 @country_object.field("alpha3")
-def resolve_alpha3(obj: Country, *_):
+def resolve_country_alpha3(obj: Country, *_):
     return obj.alpha3
 
 
 @country_object.field("flag")
-def resolve_flag(obj: Country, info):
+def resolve_country_flag(obj: Country, info):
     request: HttpRequest = info.context["request"]
 
     return request.build_absolute_uri(obj.flag)
+
+
+@country_object.field("defaultCRS")
+def resolve_country_default_crs(obj: Country, info):
+    if obj.alpha3 == "BFA":
+        return 6933
+
+    return 4326
 
 
 organization_object = ObjectType("Organization")

--- a/hexa/user_management/tests/test_schema.py
+++ b/hexa/user_management/tests/test_schema.py
@@ -641,3 +641,23 @@ class SchemaTest(GraphQLTestCase):
             },
             r["data"]["createMembership"],
         )
+
+    def test_countries(self):
+        self.client.force_login(self.USER_JIM)
+        r = self.run_query(
+            """
+              query {
+                countries {
+                  code
+                  name
+                  alpha3
+                  defaultCRS
+                }
+              }
+            """,
+        )
+
+        self.assertEqual(
+            {"name": "Burkina Faso", "code": "BF", "alpha3": "BFA", "defaultCRS": 6933},
+            next(c for c in r["data"]["countries"] if c["alpha3"] == "BFA"),
+        )


### PR DESCRIPTION
@yannforget @qgerome if we have to hardcode CRS, I'd prefer to hardcode it in the backend.

@yannforget what other "quick wins" can I implement until we have a table with country data?

Checklist:

- [x] Simple `defaultCRS`field with default value
- [ ] Check appropriate fallback value
- [ ] Add query for WHO regions