### PR TITLE
Simplify project permissions

### DIFF
--- a/hexa/plugins/connector_accessmod/graphql/schema.graphql
+++ b/hexa/plugins/connector_accessmod/graphql/schema.graphql
@@ -111,8 +111,10 @@ type CreateAccessmodProjectPermissionResult {
     errors: [CreateAccessmodProjectPermissionError!]!
 }
 enum CreateAccessmodProjectPermissionError {
+    ALREADY_EXISTS
     PERMISSION_DENIED
     NOT_FOUND
+    NOT_IMPLEMENTED
 }
 input UpdateAccessmodProjectPermissionInput {
     id: String!
@@ -126,6 +128,7 @@ type UpdateAccessmodProjectPermissionResult {
 enum UpdateAccessmodProjectPermissionError {
     PERMISSION_DENIED
     NOT_FOUND
+    NOT_IMPLEMENTED
 }
 input DeleteAccessmodProjectPermissionInput {
     id: String!
@@ -137,6 +140,7 @@ type DeleteAccessmodProjectPermissionResult {
 enum DeleteAccessmodProjectPermissionError {
     PERMISSION_DENIED
     NOT_FOUND
+    NOT_IMPLEMENTED
 }
 
 enum AccessmodProjectOrder {

--- a/hexa/plugins/connector_accessmod/models.py
+++ b/hexa/plugins/connector_accessmod/models.py
@@ -169,10 +169,17 @@ class ProjectPermissionManager(models.Manager):
         project: Project,
         mode: PermissionMode,
     ):
+        if mode != PermissionMode.OWNER:
+            raise NotImplementedError(
+                "Only OWNER permissions are implemented for AccessMod projects"
+            )
+
         if not principal.has_perm(
-            "connector_accessmod.create_project_permission", project
+            "connector_accessmod.create_project_permission", [project, user, team]
         ):
             raise PermissionDenied
+
+        self.filter(project=project).delete()
 
         permission = self.create(
             user=user,
@@ -228,24 +235,30 @@ class ProjectPermission(Permission):
         self.project.build_index()
 
     def update_if_has_perm(self, principal: User, **kwargs):
-        if not principal.has_perm(
-            "connector_accessmod.update_project_permission", self.project
-        ):
-            raise PermissionDenied
-
-        for key in ["mode"]:
-            if key in kwargs:
-                setattr(self, key, kwargs[key])
-
-        return self.save()
+        raise NotImplementedError(
+            "Permissions updates are not implemented yet on AccessMod projects"
+        )
+        # if not principal.has_perm(
+        #     "connector_accessmod.update_project_permission", self.project
+        # ):
+        #     raise PermissionDenied
+        #
+        # for key in ["mode"]:
+        #     if key in kwargs:
+        #         setattr(self, key, kwargs[key])
+        #
+        # return self.save()
 
     def delete_if_has_perm(self, principal: User):
-        if not principal.has_perm(
-            "connector_accessmod.delete_project_permission", self.project
-        ):
-            raise PermissionDenied
-
-        return super().delete()
+        raise NotImplementedError(
+            "Permissions deletions are not implemented yet on AccessMod projects"
+        )
+        # if not principal.has_perm(
+        #     "connector_accessmod.delete_project_permission", self.project
+        # ):
+        #     raise PermissionDenied
+        #
+        # return super().delete()
 
     def __str__(self):
         return f"Permission for team '{self.team}' on AM project '{self.project}'"


### PR DESCRIPTION
This PR drastically simplifies project permissions - this is temporary.

With this approach :

- We only have one project owner at a time
- Create a new owner permission will replace the previous one