### PR TITLE
Update fileset status before generating geojson

### DIFF
--- a/hexa/plugins/connector_accessmod/queue.py
+++ b/hexa/plugins/connector_accessmod/queue.py
@@ -126,11 +126,11 @@ def validate_health_facilities(fileset: Fileset, filename: str):
         # invalid by previous checks
         return
 
-    generate_geojson(fileset, filename)
-
     # end of processing -> validated
     fileset.status = FilesetStatus.VALID
     fileset.save()
+    
+    generate_geojson(fileset, filename)
 
 
 def validate_water(fileset: Fileset, filename: str):
@@ -141,11 +141,11 @@ def validate_water(fileset: Fileset, filename: str):
         # invalid by previous checks
         return
 
-    generate_geojson(fileset, filename)
-
     # end of processing -> validated
     fileset.status = FilesetStatus.VALID
     fileset.save()
+    
+    generate_geojson(fileset, filename)
 
 
 def validate_transport(fileset: Fileset, filename: str):
@@ -155,8 +155,6 @@ def validate_transport(fileset: Fileset, filename: str):
     if fileset.status == FilesetStatus.INVALID:
         # invalid by previous checks
         return
-
-    generate_geojson(fileset, filename)
 
     # extract roads categories & validate
     if fileset.metadata is None:
@@ -178,6 +176,8 @@ def validate_transport(fileset: Fileset, filename: str):
 
     fileset.status = FilesetStatus.VALID
     fileset.save()
+    
+    generate_geojson(fileset, filename)
 
 
 def generate_geojson(fileset: Fileset, filename: str, **options):


### PR DESCRIPTION
Set fileset status to `VALID` just before generating GeoJSON files to speed up the validation process.