### PR TITLE
Accessmod project creation mutation changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 Version 0.40
 ------------
 
-June 19, 2022
+June 21, 2022
 
 ### Added
 

--- a/hexa/plugins/connector_accessmod/graphql/schema.graphql
+++ b/hexa/plugins/connector_accessmod/graphql/schema.graphql
@@ -14,7 +14,7 @@ type AccessmodProject implements AccessmodOwnership {
     country: Country!
     author: User!
     owner: AccessmodOwner
-    extent: [[Float!]]
+    extent: [[Float!]!]
     dem: AccessmodFileset
     authorizedActions: [AccessmodProjectAuthorizedActions!]!
     permissions: [AccessmodProjectPermission!]!

--- a/hexa/plugins/connector_accessmod/graphql/schema.graphql
+++ b/hexa/plugins/connector_accessmod/graphql/schema.graphql
@@ -14,7 +14,7 @@ type AccessmodProject implements AccessmodOwnership {
     country: Country!
     author: User!
     owner: AccessmodOwner
-    extent: String
+    extent: [[Float!]]
     dem: AccessmodFileset
     authorizedActions: [AccessmodProjectAuthorizedActions!]!
     permissions: [AccessmodProjectPermission!]!
@@ -35,12 +35,13 @@ type AccessmodProjectPage {
     totalItems: Int!
     items: [AccessmodProject!]!
 }
-input CreateAccessmodProjectByCountryInput {
+input CreateAccessmodProjectInput {
     name: String!
     description: String
     spatialResolution: Int!
     crs: Int!
     country: CountryInput!
+    extent: [[Float!]!]
 }
 type CreateAccessmodProjectResult {
     success: Boolean!
@@ -55,8 +56,6 @@ input UpdateAccessmodProjectInput {
     id: String!
     name: String
     description: String
-    extent: String
-    demId: String
 }
 type UpdateAccessmodProjectResult {
     success: Boolean!
@@ -155,7 +154,7 @@ extend type Query {
     accessmodProjects(term: String, countries: [String!], teams: [String!], page: Int, perPage: Int, orderBy: AccessmodProjectOrder): AccessmodProjectPage!
 }
 extend type Mutation {
-    createAccessmodProjectByCountry(input: CreateAccessmodProjectByCountryInput!): CreateAccessmodProjectResult!
+    createAccessmodProject(input: CreateAccessmodProjectInput!): CreateAccessmodProjectResult!
     updateAccessmodProject(input: UpdateAccessmodProjectInput!): UpdateAccessmodProjectResult!
     deleteAccessmodProject(input: DeleteAccessmodProjectInput!): DeleteAccessmodProjectResult!
     createAccessmodProjectPermission(input: CreateAccessmodProjectPermissionInput!): CreateAccessmodProjectPermissionResult!


### PR DESCRIPTION
This PR :

- [x] Renames `createAccessmodProjectByCountry` to `createAccessmodProject` and makes it suitable for both use cases (create project by country or by raster)
- [x] Cleans up the `updateAccessmodProject` mutation