### PR TITLE
Improve datagrid width

### DIFF
--- a/hexa/core/datagrids.py
+++ b/hexa/core/datagrids.py
@@ -15,6 +15,7 @@ class ActivityGrid(Datagrid):
         detail_url="get_datasource_url",
         bold=False,
         mark_safe=True,
+        width="40%",
     )
     status = StatusColumn(value="status")
     date = DateColumn(date="occurred_at")

--- a/hexa/ui/datagrid.py
+++ b/hexa/ui/datagrid.py
@@ -429,12 +429,13 @@ class DurationColumn(Column):
 
 
 class LinkColumn(Column):
-    def __init__(self, *, text, url=None, **kwargs):
+    def __init__(self, *, text, url=None, width=None, **kwargs):
         super().__init__(**kwargs, hide_label=True)
         self.text = text
         if url is None:
             url = "get_absolute_url"
         self.url = url
+        self.width = width if width is not None else "120"
 
     @property
     def template(self):


### PR DESCRIPTION
I'm not really confortable with the default width of the `LinkColumn` but it's better to limit the size of this cell to leave more room for the other as all the cells without explicit width receives an equal width.