### PR TITLE
Permissions Refactoring

### DIFF
--- a/hexa/app.py
+++ b/hexa/app.py
@@ -66,7 +66,9 @@ class ConnectorAppConfig(AppConfig):
     NOTEBOOKS_CREDENTIALS = []
     PIPELINES_CREDENTIALS = []
     LAST_ACTIVITIES = None
-    EXTRA_GRAPHQL_ME_AUTHORIZED_ACTIONS_RESOLVER = None
+    EXTRA_GRAPHQL_ME_AUTHORIZED_ACTIONS_RESOLVER = (
+        None  # FIXME: To remove once authorizedActions are completely deprecated
+    )
 
     def __init_subclass__(cls) -> None:
         """Django does not play super nicely with multiple nested AppConfig subclasses. To make sure that a "concrete"
@@ -138,6 +140,7 @@ class ConnectorAppConfig(AppConfig):
 
         return ActivityList()
 
+    # FIXME: To remove once authorizedActions are completely deprecated
     def get_extra_graphql_me_authorized_actions_resolver(self):
         """Check if this app has an extra resolver for the "authorizedActions" field on the "Me" type.
         The base resolver will loop through all plugins and extend the authorized actions list with any extra

--- a/hexa/data_collections/graphql/schema.graphql
+++ b/hexa/data_collections/graphql/schema.graphql
@@ -8,7 +8,8 @@ type Collection {
     description: String
     summary: String
     elements (page: Int, perPage: Int): CollectionElementPage!
-    authorizedActions: CollectionAuthorizedActions!
+    authorizedActions: CollectionAuthorizedActions! @deprecated(reason: "authorizedActions is deprecated. Use permissions instead.")
+    permissions: CollectionPermissions!
     createdAt: DateTime!
     updatedAt: DateTime!
 }
@@ -18,10 +19,18 @@ type CollectionPage {
     totalItems: Int!
     items: [Collection!]!
 }
+
+# FIXME: To remove once authorizedActions are completely deprecated
 type CollectionAuthorizedActions {
     canUpdate: Boolean!
     canDelete: Boolean!
 }
+
+type CollectionPermissions {
+    update: Boolean!
+    delete: Boolean!
+}
+
 input CreateCollectionInput {
     name: String!
     authorId: String
@@ -134,6 +143,6 @@ type CollectionElementPage {
 }
 
 # App-specific permissions
-extend type AuthorizedActions {
+extend type MePermissions {
     createCollection: Boolean!
 }

--- a/hexa/data_collections/schema.py
+++ b/hexa/data_collections/schema.py
@@ -109,19 +109,27 @@ def resolve_collection_authorized_actions(collection: Collection, info):
     return collection
 
 
+# FIXME: To remove once authorizedActions are completely deprecated
 collection_authorized_actions = ObjectType("CollectionAuthorizedActions")
 
+collection_permissions = ObjectType("CollectionPermissions")
 
-@collection_authorized_actions.field("canUpdate")
-def resolve_collection_can_update(collection: Collection, info):
+
+@collection_permissions.field("update")
+def resolve_collection_update(collection: Collection, info):
     request: HttpRequest = info.context["request"]
     return request.user.has_perm("data_collections.update_collection", collection)
 
 
-@collection_authorized_actions.field("canDelete")
-def resolve_collection_can_delete(collection: Collection, info):
+@collection_permissions.field("delete")
+def resolve_collection_delete(collection: Collection, info):
     request: HttpRequest = info.context["request"]
     return request.user.has_perm("data_collections.delete_collection", collection)
+
+
+@collection_object.field("permissions")
+def resolve_collection_permissions(collection: Collection, info):
+    return collection
 
 
 @collections_mutations.field("createCollection")
@@ -274,4 +282,5 @@ collections_bindables = [
     collection_element_object,
     collections_mutations,
     collection_authorized_actions,
+    collection_permissions,
 ]

--- a/hexa/plugins/connector_accessmod/apps.py
+++ b/hexa/plugins/connector_accessmod/apps.py
@@ -8,6 +8,8 @@ class AccessmodConnectorConfig(ConnectorAppConfig):
     verbose_name = "Accessmod Connector"
 
     ANONYMOUS_URLS = ["connector_accessmod:webhook"]
+
+    # FIXME: To remove once authorizedActions are completely deprecated
     EXTRA_GRAPHQL_ME_AUTHORIZED_ACTIONS_RESOLVER = (
         "hexa.plugins.connector_accessmod.schema.extra_resolve_me_authorized_actions"
     )

--- a/hexa/plugins/connector_accessmod/graphql/schema.graphql
+++ b/hexa/plugins/connector_accessmod/graphql/schema.graphql
@@ -16,12 +16,22 @@ type AccessmodProject implements AccessmodOwnership {
     owner: AccessmodOwner
     extent: [[Float!]!]
     dem: AccessmodFileset
-    authorizedActions: [AccessmodProjectAuthorizedActions!]!
-    permissions: [AccessmodProjectPermission!]!
+    authorizedActions: [AccessmodProjectAuthorizedActions!]! @deprecated(reason: "authorizedActions is deprecated. Use permissions instead.")
+    permissions: AccessmodProjectPermissions!
+    members: [AccessmodProjectMember!]!
     createdAt: DateTime!
     updatedAt: DateTime!
 }
 
+type AccessmodProjectPermissions {
+    update: Boolean!
+    delete: Boolean!
+    createFileset: Boolean!
+    createAnalysis: Boolean!
+    createMember: Boolean!
+}
+
+#FIXME To remove once authorizedActions are completely deprecated
 enum AccessmodProjectAuthorizedActions {
     UPDATE
     DELETE
@@ -78,65 +88,67 @@ enum DeleteAccessmodProjectError {
     NOT_FOUND
     PERMISSION_DENIED
 }
-type AccessmodProjectPermissionPage {
-    pageNumber: Int!
-    totalPages: Int!
-    totalItems: Int!
-    items: [AccessmodProjectPermission!]!
-}
-type AccessmodProjectPermission {
+type AccessmodProjectMember {
     id: String!
     user: User
     team: Team
     project: AccessmodProject!
     mode: PermissionMode!
-    authorizedActions: [AccessmodProjectPermissionAuthorizedActions!]!
+    authorizedActions: [AccessmodProjectPermissionAuthorizedActions!]! @deprecated(reason: "authorizedActions is deprecated. Use permissions instead.")
+    permissions: AccessmodProjectMemberPermissions!
     createdAt: DateTime!
     updatedAt: DateTime!
 }
+
+type AccessmodProjectMemberPermissions {
+    update: Boolean!
+    delete: Boolean!
+}
+
+#FIXME To remove once authorizedActions are completely deprecated
 enum AccessmodProjectPermissionAuthorizedActions {
     UPDATE
     DELETE
 }
-input CreateAccessmodProjectPermissionInput {
+input CreateAccessmodProjectMemberInput {
     userId: String
     teamId: String
     projectId: String!
     mode: PermissionMode!
 }
-type CreateAccessmodProjectPermissionResult {
+type CreateAccessmodProjectMemberResult {
     success: Boolean!
-    permission: AccessmodProjectPermission
-    errors: [CreateAccessmodProjectPermissionError!]!
+    member: AccessmodProjectMember
+    errors: [CreateAccessmodProjectMemberError!]!
 }
-enum CreateAccessmodProjectPermissionError {
+enum CreateAccessmodProjectMemberError {
     ALREADY_EXISTS
     PERMISSION_DENIED
     NOT_FOUND
     NOT_IMPLEMENTED
 }
-input UpdateAccessmodProjectPermissionInput {
+input UpdateAccessmodProjectMemberInput {
     id: String!
     mode: PermissionMode!
 }
-type UpdateAccessmodProjectPermissionResult {
+type UpdateAccessmodProjectMemberResult {
     success: Boolean!
-    permission: AccessmodProjectPermission
-    errors: [UpdateAccessmodProjectPermissionError!]!
+    member: AccessmodProjectMember
+    errors: [UpdateAccessmodProjectMemberError!]!
 }
-enum UpdateAccessmodProjectPermissionError {
+enum UpdateAccessmodProjectMemberError {
     PERMISSION_DENIED
     NOT_FOUND
     NOT_IMPLEMENTED
 }
-input DeleteAccessmodProjectPermissionInput {
+input DeleteAccessmodProjectMemberInput {
     id: String!
 }
-type DeleteAccessmodProjectPermissionResult {
+type DeleteAccessmodProjectMemberResult {
     success: Boolean!
-    errors: [DeleteAccessmodProjectPermissionError!]!
+    errors: [DeleteAccessmodProjectMemberError!]!
 }
-enum DeleteAccessmodProjectPermissionError {
+enum DeleteAccessmodProjectMemberError {
     PERMISSION_DENIED
     NOT_FOUND
     NOT_IMPLEMENTED
@@ -157,9 +169,9 @@ extend type Mutation {
     createAccessmodProject(input: CreateAccessmodProjectInput!): CreateAccessmodProjectResult!
     updateAccessmodProject(input: UpdateAccessmodProjectInput!): UpdateAccessmodProjectResult!
     deleteAccessmodProject(input: DeleteAccessmodProjectInput!): DeleteAccessmodProjectResult!
-    createAccessmodProjectPermission(input: CreateAccessmodProjectPermissionInput!): CreateAccessmodProjectPermissionResult!
-    updateAccessmodProjectPermission(input: UpdateAccessmodProjectPermissionInput!): UpdateAccessmodProjectPermissionResult!
-    deleteAccessmodProjectPermission(input: DeleteAccessmodProjectPermissionInput!): DeleteAccessmodProjectPermissionResult!
+    createAccessmodProjectMember(input: CreateAccessmodProjectMemberInput!): CreateAccessmodProjectMemberResult!
+    updateAccessmodProjectMember(input: UpdateAccessmodProjectMemberInput!): UpdateAccessmodProjectMemberResult!
+    deleteAccessmodProjectMember(input: DeleteAccessmodProjectMemberInput!): DeleteAccessmodProjectMemberResult!
 }
 
 # Filesets
@@ -173,10 +185,18 @@ type AccessmodFileset implements AccessmodOwnership {
     owner: AccessmodOwner
     files: [AccessmodFile!]!
     metadata: AccessmodFilesetMetadata!
-    authorizedActions: [AccessmodFilesetAuthorizedActions!]!
+    authorizedActions: [AccessmodFilesetAuthorizedActions!]! @deprecated(reason: "authorizedActions is deprecated. Use permissions instead.")
+    permissions: AccessmodFilesetPermissions!
     createdAt: DateTime!
     updatedAt: DateTime!
 }
+
+type AccessmodFilesetPermissions {
+    update: Boolean!
+    delete: Boolean!
+    createFile: Boolean!
+}
+
 enum AccessmodFilesetMode {
     USER_INPUT
     AUTOMATIC_ACQUISITION
@@ -189,6 +209,8 @@ enum AccessmodFilesetStatus {
     TO_ACQUIRE
 }
 scalar AccessmodFilesetMetadata
+
+#FIXME To remove once authorizedActions are completely deprecated
 enum AccessmodFilesetAuthorizedActions {
     UPDATE
     DELETE
@@ -354,10 +376,19 @@ interface AccessmodAnalysis {
     status: AccessmodAnalysisStatus!
     name: String!
     author: User!
-    authorizedActions: [AccessmodAnalysisAuthorizedActions!]!
+    authorizedActions: [AccessmodAnalysisAuthorizedActions!]! @deprecated(reason: "authorizedActions is deprecated. Use permissions instead.")
+    permissions: AccessmodAnalysisPermissions!
     createdAt: DateTime!
     updatedAt: DateTime!
 }
+
+type AccessmodAnalysisPermissions {
+    update: Boolean!
+    delete: Boolean!
+    run: Boolean!
+}
+
+#FIXME To remove once authorizedActions are completely deprecated
 enum AccessmodAnalysisAuthorizedActions {
     UPDATE
     DELETE
@@ -377,7 +408,8 @@ type AccessmodAccessibilityAnalysis implements AccessmodAnalysis & AccessmodOwne
     name: String!
     owner: AccessmodOwner
     author: User!
-    authorizedActions: [AccessmodAnalysisAuthorizedActions!]!
+    authorizedActions: [AccessmodAnalysisAuthorizedActions!]! @deprecated(reason: "authorizedActions is deprecated. Use permissions instead.")
+    permissions: AccessmodAnalysisPermissions!
     createdAt: DateTime!
     updatedAt: DateTime!
     landCover: AccessmodFileset
@@ -404,7 +436,8 @@ type AccessmodGeographicCoverageAnalysis implements AccessmodAnalysis & Accessmo
     name: String!
     owner: AccessmodOwner
     author: User!
-    authorizedActions: [AccessmodAnalysisAuthorizedActions!]!
+    authorizedActions: [AccessmodAnalysisAuthorizedActions!]! @deprecated(reason: "authorizedActions is deprecated. Use permissions instead.")
+    permissions: AccessmodAnalysisPermissions!
     createdAt: DateTime!
     updatedAt: DateTime!
     population: AccessmodFileset
@@ -470,7 +503,8 @@ type AccessmodZonalStatistics implements AccessmodAnalysis & AccessmodOwnership 
     name: String!
     owner: AccessmodOwner
     author: User!
-    authorizedActions: [AccessmodAnalysisAuthorizedActions!]!
+    authorizedActions: [AccessmodAnalysisAuthorizedActions!]! @deprecated(reason: "authorizedActions is deprecated. Use permissions instead.")
+    permissions: AccessmodAnalysisPermissions!
     createdAt: DateTime!
     updatedAt: DateTime!
     population: AccessmodFileset
@@ -610,7 +644,13 @@ extend type Mutation {
     denyAccessmodAccessRequest(input: DenyAccessmodAccessRequestInput!): DenyAccessmodAccessRequestResult!
 }
 
+extend type MePermissions {
+    createAccessmodProject: Boolean!
+    manageAccessmodAccessRequests: Boolean!
+}
+
 # Connector-specific permissions
+#FIXME To remove once authorizedActions are completely deprecated
 extend enum MeAuthorizedActions {
     CREATE_ACCESSMOD_PROJECT
     MANAGE_ACCESSMOD_ACCESS_REQUESTS

--- a/hexa/plugins/connector_accessmod/graphql/schema.graphql
+++ b/hexa/plugins/connector_accessmod/graphql/schema.graphql
@@ -29,6 +29,7 @@ type AccessmodProjectPermissions {
     createFileset: Boolean!
     createAnalysis: Boolean!
     createMember: Boolean!
+    createPermission: Boolean!
 }
 
 #FIXME To remove once authorizedActions are completely deprecated

--- a/hexa/plugins/connector_accessmod/schema.py
+++ b/hexa/plugins/connector_accessmod/schema.py
@@ -155,6 +155,14 @@ def resolve_accessmod_project_permissions_update(project: Project, info):
     return request.user.has_perm("connector_accessmod.update_project", project)
 
 
+@project_permissions_object.field("createPermission")
+def resolve_accessmod_project_permissions_create_permission(project: Project, info):
+    request: HttpRequest = info.context["request"]
+    return request.user.has_perm(
+        "connector_accessmod.create_project_permission", [project, request.user, None]
+    )
+
+
 @project_permissions_object.field("delete")
 def resolve_accessmod_project_permissions_delete(project: Project, info):
     request: HttpRequest = info.context["request"]
@@ -432,6 +440,11 @@ fileset_object = ObjectType("AccessmodFileset")
 @fileset_object.field("files")
 def resolve_accessmod_fileset_files(fileset: Fileset, info, **kwargs):
     return [f for f in fileset.file_set.all()]
+
+
+@fileset_object.field("permissions")
+def resolve_accessmod_fileset_permissions(fileset: Fileset, info, **kwargs):
+    return fileset
 
 
 # FIXME To remove once authorizedActions are completely deprecated
@@ -797,6 +810,11 @@ def resolve_analysis_type(analysis: Analysis, *_):
         return "AccessmodZonalStatistics"
 
     return None
+
+
+@analysis_interface.field("permissions")
+def resolve_analysis_permissions(analysis: Analysis, info, **kwargs):
+    return analysis
 
 
 # FIXME To remove once authorizedActions are completely deprecated

--- a/hexa/plugins/connector_accessmod/tests/schema/test_project.py
+++ b/hexa/plugins/connector_accessmod/tests/schema/test_project.py
@@ -107,7 +107,7 @@ class ProjectTest(GraphQLTestCase):
                   author {
                     email
                   }
-                  permissions {
+                  members {
                     user { id }
                     team { id }
                     project { id }
@@ -131,7 +131,7 @@ class ProjectTest(GraphQLTestCase):
                 },
                 "author": {"email": "jim@bluesquarehub.com"},
                 "owner": {"__typename": "User", "id": str(self.USER_JIM.id)},
-                "permissions": [
+                "members": [
                     {
                         "user": {"id": str(self.USER_JIM.id)},
                         "team": None,
@@ -557,15 +557,15 @@ class ProjectTest(GraphQLTestCase):
         )
         self.assertIsNone(Project.objects.filter(id=self.SAMPLE_PROJECT.id).first())
 
-    def test_create_accessmod_project_permission(self):
+    def test_create_accessmod_project_member(self):
         self.client.force_login(self.USER_JIM)
 
         r = self.run_query(
             """
-                mutation createAccessmodProjectPermission($input: CreateAccessmodProjectPermissionInput!) {
-                  createAccessmodProjectPermission(input: $input) {
+                mutation createAccessmodProjectMember($input: CreateAccessmodProjectMemberInput!) {
+                  createAccessmodProjectMember(input: $input) {
                     success
-                    permission {
+                    member {
                       project {
                         id
                       }
@@ -592,14 +592,14 @@ class ProjectTest(GraphQLTestCase):
         self.assertEqual(
             {
                 "success": True,
-                "permission": {
+                "member": {
                     "project": {"id": str(self.SAMPLE_PROJECT.id)},
                     "user": None,
                     "team": {"id": str(self.TEAM.id)},
                 },
                 "errors": [],
             },
-            r["data"]["createAccessmodProjectPermission"],
+            r["data"]["createAccessmodProjectMember"],
         )
         # We should end with a single "OWNER" permission
         permission = ProjectPermission.objects.get(project=self.SAMPLE_PROJECT)
@@ -608,15 +608,15 @@ class ProjectTest(GraphQLTestCase):
         self.assertEqual(PermissionMode.OWNER, permission.mode)
         self.assertIsNone(permission.user)
 
-    def test_create_accessmod_project_permission_errors(self):
+    def test_create_accessmod_project_member_errors(self):
         self.client.force_login(self.USER_JIM)
 
         r = self.run_query(
             """
-                mutation createAccessmodProjectPermission($input: CreateAccessmodProjectPermissionInput!) {
-                  createAccessmodProjectPermission(input: $input) {
+                mutation createAccessmodProjectMember($input: CreateAccessmodProjectMemberInput!) {
+                  createAccessmodProjectMember(input: $input) {
                     success
-                    permission {
+                    member {
                     id
                     }
                     errors
@@ -635,18 +635,18 @@ class ProjectTest(GraphQLTestCase):
         self.assertEqual(
             {
                 "success": False,
-                "permission": None,
+                "member": None,
                 "errors": ["PERMISSION_DENIED"],
             },
-            r["data"]["createAccessmodProjectPermission"],
+            r["data"]["createAccessmodProjectMember"],
         )
 
         r = self.run_query(
             """
-                mutation createAccessmodProjectPermission($input: CreateAccessmodProjectPermissionInput!) {
-                  createAccessmodProjectPermission(input: $input) {
+                mutation createAccessmodProjectMember($input: CreateAccessmodProjectMemberInput!) {
+                  createAccessmodProjectMember(input: $input) {
                     success
-                    permission {
+                    member {
                     id
                     }
                     errors
@@ -665,21 +665,21 @@ class ProjectTest(GraphQLTestCase):
         self.assertEqual(
             {
                 "success": False,
-                "permission": None,
+                "member": None,
                 "errors": ["NOT_IMPLEMENTED"],
             },
-            r["data"]["createAccessmodProjectPermission"],
+            r["data"]["createAccessmodProjectMember"],
         )
 
-    def test_update_accessmod_project_permission(self):
+    def test_update_accessmod_project_member(self):
         self.client.force_login(self.USER_JIM)
 
         r = self.run_query(
             """
-                mutation updateAccessmodProjectPermission($input: UpdateAccessmodProjectPermissionInput!) {
-                  updateAccessmodProjectPermission(input: $input) {
+                mutation updateAccessmodProjectMember($input: UpdateAccessmodProjectMemberInput!) {
+                  updateAccessmodProjectMember(input: $input) {
                     success
-                    permission {
+                    member {
                         id
                     }
                     errors
@@ -690,21 +690,21 @@ class ProjectTest(GraphQLTestCase):
         )
 
         self.assertEqual(
-            r["data"]["updateAccessmodProjectPermission"],
+            r["data"]["updateAccessmodProjectMember"],
             {
                 "success": False,
-                "permission": None,
+                "member": None,
                 "errors": ["NOT_IMPLEMENTED"],
             },
         )
 
-    def test_delete_accessmod_project_permission(self):
+    def test_delete_accessmod_project_member(self):
         self.client.force_login(self.USER_JIM)
 
         r = self.run_query(
             """
-                mutation deleteAccessmodProjectPermission($input: DeleteAccessmodProjectPermissionInput!) {
-                  deleteAccessmodProjectPermission(input: $input) {
+                mutation deleteAccessmodProjectMember($input: DeleteAccessmodProjectMemberInput!) {
+                  deleteAccessmodProjectMember(input: $input) {
                     success
                     errors
                   }
@@ -718,7 +718,7 @@ class ProjectTest(GraphQLTestCase):
         )
 
         self.assertEqual(
-            r["data"]["deleteAccessmodProjectPermission"],
+            r["data"]["deleteAccessmodProjectMember"],
             {
                 "success": False,
                 "errors": ["NOT_IMPLEMENTED"],

--- a/hexa/user_management/graphql/schema.graphql
+++ b/hexa/user_management/graphql/schema.graphql
@@ -15,13 +15,16 @@ type Avatar {
 }
 type Me {
     user: User
-    authorizedActions: [MeAuthorizedActions!]!
     features: [FeatureFlag!]!
+    authorizedActions: [MeAuthorizedActions!]! @deprecated(reason: "authorizedActions is deprecated. Use permissions instead.")
+    permissions: MePermissions!
 }
+
 # This is our legacy approach : a simple enum that other modules can extend
 # it works fine, but implementing it in the API is complex - see resolve_me to get
 # a glimpse of the added complexity. We are now moving to an alternative approach -
-# see the "AuthorizedActions" type below
+# see the "MePermissions" type below
+#FIXME To remove once authorizedActions are completely deprecated
 enum MeAuthorizedActions {
     CREATE_TEAM
     ADMIN_PANEL
@@ -31,8 +34,10 @@ enum MeAuthorizedActions {
 # This is the preferred way of determining the global (not specific to a business object) actions that users can take
 # This type can be extended in other modules. It is the responsibility of each module to extend this type and provide a
 # resolver for the added fields.
-type AuthorizedActions {
+type MePermissions {
     createTeam: Boolean!
+    adminPanel: Boolean!
+    superUser: Boolean!
 }
 
 input LoginInput {
@@ -88,10 +93,18 @@ type Team {
     id: String!
     name: String!
     memberships(page: Int, perPage: Int): MembershipPage!
-    authorizedActions: [TeamAuthorizedActions!]!
+    authorizedActions: [TeamAuthorizedActions!]! @deprecated(reason: "authorizedActions is deprecated. Use permissions instead.")
+    permissions: TeamPermissions!
     createdAt: DateTime!
     updatedAt: DateTime!
 }
+
+type TeamPermissions {
+    update: Boolean!
+    createMembership: Boolean!
+    delete: Boolean!
+}
+
 type TeamPage {
     pageNumber: Int!
     totalPages: Int!

--- a/hexa/user_management/graphql/schema.graphql
+++ b/hexa/user_management/graphql/schema.graphql
@@ -175,11 +175,19 @@ type Membership {
     id: String!
     user: User!
     team: Team!
-    authorizedActions: [MembershipAuthorizedActions!]!
+    authorizedActions: [MembershipAuthorizedActions!]!  @deprecated(reason: "authorizedActions is deprecated. Use permissions instead.")
+    permissions: MembershipPermissions!
     role: MembershipRole!
     createdAt: DateTime!
     updatedAt: DateTime!
 }
+
+type MembershipPermissions {
+    update: Boolean!
+    delete: Boolean!
+}
+
+#FIXME To remove once authorizedActions are completely deprecated
 enum MembershipAuthorizedActions {
     UPDATE
     DELETE

--- a/hexa/user_management/schema.py
+++ b/hexa/user_management/schema.py
@@ -1,6 +1,7 @@
 import pathlib
 
 from ariadne import MutationType, ObjectType, QueryType, load_schema_from_path
+from django.conf import settings
 from django.contrib.auth import authenticate, login, logout, password_validation
 from django.contrib.auth.forms import PasswordResetForm
 from django.contrib.auth.tokens import default_token_generator
@@ -253,7 +254,7 @@ def resolve_reset_password(_, info, input, **kwargs):
     request: HttpRequest = info.context["request"]
     form = PasswordResetForm({"email": input["email"]})
     if form.is_valid():
-        form.save(request=request)
+        form.save(request=request, domain_override=settings.NEW_FRONTEND_DOMAIN)
         return {"success": True}
     else:
         return {"success": False}

--- a/hexa/user_management/schema.py
+++ b/hexa/user_management/schema.py
@@ -35,7 +35,7 @@ me_permissions_object = ObjectType("MePermissions")
 
 
 @me_permissions_object.field("createTeam")
-def resolve_can_create_team(obj, info, **kwargs):
+def resolve_me_permissions_create_team(obj, info, **kwargs):
     request: HttpRequest = info.context["request"]
     return request.user.is_authenticated  # TODO: Implement a real check of permissions
 
@@ -109,6 +109,11 @@ def resolve_me_features(_, info):
         return principal.featureflag_set.all()
     else:
         return []
+
+
+@me_object.field("permissions")
+def resolve_me_permissions(_, info):
+    return me_permissions_object
 
 
 @identity_query.field("me")

--- a/hexa/user_management/schema.py
+++ b/hexa/user_management/schema.py
@@ -204,6 +204,7 @@ def resolve_team_permissions_create_membership(team: Team, info):
 
 
 membership_object = ObjectType("Membership")
+membership_permissions_object = ObjectType("MembershipPermissions")
 
 
 # FIXME: To remove once authorizedActions are completely deprecated
@@ -223,6 +224,23 @@ def resolve_membership_authorized_actions(membership: Membership, info, **kwargs
             else None,
         ],
     )
+
+
+@membership_object.field("permissions")
+def resolve_membership_permissions(membership, info, **kwargs):
+    return membership
+
+
+@membership_permissions_object.field("update")
+def resolve_membership_permissions_update(membership: Membership, info, **kwargs):
+    request: HttpRequest = info.context["request"]
+    return request.user.has_perm("user_management.update_membership", membership)
+
+
+@membership_permissions_object.field("delete")
+def resolve_membership_permissions_delete(membership: Membership, info, **kwargs):
+    request: HttpRequest = info.context["request"]
+    return request.user.has_perm("user_management.delete_membership", membership)
 
 
 @identity_query.field("organizations")
@@ -453,6 +471,7 @@ identity_bindables = [
     membership_object,
     me_permissions_object,
     team_permissions_object,
+    membership_permissions_object,
     organization_object,
     identity_mutations,
 ]

--- a/hexa/user_management/tests/test_schema.py
+++ b/hexa/user_management/tests/test_schema.py
@@ -43,6 +43,9 @@ class SchemaTest(GraphQLTestCase):
         cls.SUPER_USER_ALF = User.objects.create_user(
             "alf@bluesquarehub.com", "alfdu96", is_superuser=True, is_staff=True
         )
+        cls.USER_ADMIN = User.objects.create_user(
+            "admin@blusqaurehub.com", "adminadmin2022", is_staff=True
+        )
         cls.TEAM_CORE = Team.objects.create(name="Core team")
         cls.MEMBERSHIP_JANE_CORE = Membership.objects.create(
             user=cls.USER_JANE, team=cls.TEAM_CORE, role=MembershipRole.ADMIN
@@ -82,7 +85,15 @@ class SchemaTest(GraphQLTestCase):
         )
 
         self.assertEqual(
-            {"user": None, "permissions": {"createTeam": False, "superUser": False, "adminPanel": False}, "features": []},
+            {
+                "user": None,
+                "permissions": {
+                    "createTeam": False,
+                    "superUser": False,
+                    "adminPanel": False,
+                },
+                "features": [],
+            },
             r["data"]["me"],
         )
 
@@ -105,6 +116,10 @@ class SchemaTest(GraphQLTestCase):
                     code
                     config
                   }
+                  permissions {
+                    createTeam
+                    adminPanel
+                  }
                 }
               }
             """,
@@ -124,6 +139,7 @@ class SchemaTest(GraphQLTestCase):
                     else None,
                 },
                 "features": [],
+                "permissions": {"createTeam": True, "adminPanel": False},
             },
             r["data"]["me"],
         )
@@ -138,6 +154,9 @@ class SchemaTest(GraphQLTestCase):
                     code
                     config
                   }
+                  user {
+                    id
+                  }
                 }
               }
             """,
@@ -151,6 +170,9 @@ class SchemaTest(GraphQLTestCase):
                         "config": self.TAYLOR_FEATURE_FLAG.config,
                     }
                 ],
+                "user": {
+                    "id": str(self.USER_TAYLOR.id),
+                },
             },
             r["data"]["me"],
         )

--- a/hexa/user_management/tests/test_schema.py
+++ b/hexa/user_management/tests/test_schema.py
@@ -68,9 +68,13 @@ class SchemaTest(GraphQLTestCase):
                   user {
                     id
                   }
-                  authorizedActions
                   features {
                     code
+                  }
+                  permissions {
+                    createTeam
+                    adminPanel
+                    superUser
                   }
                 }
               }
@@ -78,7 +82,7 @@ class SchemaTest(GraphQLTestCase):
         )
 
         self.assertEqual(
-            {"user": None, "authorizedActions": [], "features": []},
+            {"user": None, "permissions": {"createTeam": False, "superUser": False, "adminPanel": False}, "features": []},
             r["data"]["me"],
         )
 
@@ -97,7 +101,6 @@ class SchemaTest(GraphQLTestCase):
                     dateJoined
                     lastLogin
                   }
-                  authorizedActions
                   features {
                     code
                     config
@@ -121,7 +124,6 @@ class SchemaTest(GraphQLTestCase):
                     else None,
                 },
                 "features": [],
-                "authorizedActions": ["CREATE_TEAM", "CREATE_ACCESSMOD_PROJECT"],
             },
             r["data"]["me"],
         )

--- a/hexa/user_management/tests/test_schema.py
+++ b/hexa/user_management/tests/test_schema.py
@@ -440,7 +440,7 @@ class SchemaTest(GraphQLTestCase):
         )
 
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, "Password reset on app.openhexa.test")
+        self.assertEqual(mail.outbox[0].subject, "Password reset on localhost:3000")
 
     def test_reset_password_wrong_email(self):
         r = self.run_query(


### PR DESCRIPTION
This pull request refactors the permissions model exposed in the graphql.

`authorizedActions` is renamed to `permissions` and the new data structure is a type and not an enum anymore.

⚠️ This PR is not mergeable as-is. The changes made on `AccessmodProject.permissions` will break AccessMod. 