### PR TITLE
Restrict allowed S3 actions in S3 policy generation

### DIFF
--- a/hexa/plugins/connector_s3/api.py
+++ b/hexa/plugins/connector_s3/api.py
@@ -235,7 +235,7 @@ def generate_s3_policy(
             {
                 "Sid": "S3RO",
                 "Effect": "Allow",
-                "Action": ["s3:ListBucket", "s3:GetObject*"],
+                "Action": ["s3:ListBucket", "s3:GetObject"],
                 "Resource": [
                     *[f"arn:aws:s3:::{bucket.name}" for bucket in read_only_buckets],
                     *[f"arn:aws:s3:::{bucket.name}/*" for bucket in read_only_buckets],
@@ -246,7 +246,7 @@ def generate_s3_policy(
             {
                 "Sid": "S3RWK",
                 "Effect": "Allow",
-                "Action": "s3:*",
+                "Action": "s3:*Object",
                 "Resource": [
                     f"arn:aws:s3:::{bucket.name}/.s3keep"
                     for bucket in read_only_buckets
@@ -258,7 +258,7 @@ def generate_s3_policy(
             {
                 "Sid": "S3AllActions",
                 "Effect": "Allow",
-                "Action": "s3:*",
+                "Action": ["s3:ListBucket", "s3:*Object"],
                 "Resource": [
                     *[f"arn:aws:s3:::{bucket.name}" for bucket in read_write_buckets],
                     *[f"arn:aws:s3:::{bucket.name}/*" for bucket in read_write_buckets],

--- a/hexa/plugins/connector_s3/tests/test_credentials.py
+++ b/hexa/plugins/connector_s3/tests/test_credentials.py
@@ -226,7 +226,7 @@ class PipelinesCredentialsTest(BaseCredentialsTestCase):
             {
                 "Statement": [
                     {
-                        "Action": "s3:*",
+                        "Action": ["s3:ListBucket", "s3:*Object"],
                         "Effect": "Allow",
                         "Resource": [
                             "arn:aws:s3:::hexa-test-bucket-1",
@@ -322,7 +322,7 @@ class PipelinesCredentialsTest(BaseCredentialsTestCase):
             {
                 "Statement": [
                     {
-                        "Action": "s3:*",
+                        "Action": ["s3:ListBucket", "s3:*Object"],
                         "Effect": "Allow",
                         "Resource": [
                             "arn:aws:s3:::hexa-test-bucket-1",


### PR DESCRIPTION
The idea behind the PR is to be much more explicit regarding the actions that can be performed in notebooks and pipelines.

This is mostly for safety reasons (prevent unwanted operations such as a bucket deletion).