### PR TITLE
Add link to main OpenHexa repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ OpenHexa is an **open-source data integration platform** that allows users to:
 OpenHexa architecture
 =====================
 
+You will find an overview of OpenHexa in the [main OpenHexa repository](https://github.com/blsq/openhexa).
+
 The OpenHexa platform is composed of **three main components**:
 
 - The **App component**, a Django application that acts as the user-facing part of the OpenHexa platform


### PR DESCRIPTION
Now that we have a global OpenHexa repo, let's link to it.

## Changes

- Added link in README