### PR TITLE
Add a scheduler for airflow job

### DIFF
--- a/hexa/plugins/connector_airflow/api.py
+++ b/hexa/plugins/connector_airflow/api.py
@@ -42,14 +42,17 @@ class AirflowAPIClient:
         return response.text
 
     def trigger_dag_run(
-        self, dag_id: str, conf: typing.Mapping[str, typing.Any]
+        self, dag_id: str, run_type: str, conf: typing.Mapping[str, typing.Any]
     ) -> typing.Dict:
         url = urljoin(self._url, f"dags/{dag_id}/dagRuns")
+        formated_time = timezone.now().isoformat()
+        dag_run_id = f"{run_type.lower()}__{formated_time}"
         response = self._session.post(
             url,
             json={
-                "execution_date": timezone.now().isoformat(),
+                "execution_date": formated_time,
                 "conf": conf,
+                "dag_run_id": dag_run_id,
             },
             allow_redirects=False,
         )

--- a/hexa/plugins/connector_airflow/management/commands/dag_scheduler.py
+++ b/hexa/plugins/connector_airflow/management/commands/dag_scheduler.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+from logging import getLogger
+from time import sleep
+
+from croniter import croniter
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from hexa.plugins.connector_airflow.models import DAG, Cluster
+
+logger = getLogger(__name__)
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        # only run by sequence of 5min
+        cutoff = 5 * 60
+
+        while True:
+            sequence, start_time = [], timezone.now()
+            for cluster in Cluster.objects.all():
+                for pipeline in DAG.objects.filter(template__cluster=cluster).exclude(
+                    schedule=None
+                ):
+                    if not croniter.is_valid(pipeline.schedule):
+                        logger.warning("pipeline %s invalid schedule", pipeline.id)
+                        continue
+
+                    if pipeline.last_run:
+                        last_exec = pipeline.last_run.execution_date
+                    else:
+                        last_exec = timezone.now()
+
+                    cron = croniter(pipeline.schedule, last_exec)
+                    next_exec_time = cron.get_next(datetime)
+                    next_exec_delay = (next_exec_time - start_time).total_seconds()
+                    if next_exec_delay < cutoff:
+                        sequence.append((pipeline, next_exec_delay, next_exec_time))
+
+            logger.debug("exec seq %s", sequence)
+            for pipeline, delay, exec_time in sorted(sequence, key=lambda e: e[1]):
+                # to have a good quality sequence, correct the next delay with an
+                # offset based on the diff between NOW and START
+                real_delay = delay - (timezone.now() - start_time).total_seconds()
+                if real_delay > 0:
+                    logger.debug(f"sleep before run: {real_delay}")
+                    sleep(real_delay)
+
+                pipeline.run_scheduled()
+
+            empty_delay = cutoff - (timezone.now() - start_time).total_seconds()
+            if empty_delay > 0:
+                logger.debug("sleep end runs: %s", empty_delay)
+                sleep(empty_delay)

--- a/hexa/plugins/connector_airflow/tests/test_models.py
+++ b/hexa/plugins/connector_airflow/tests/test_models.py
@@ -190,7 +190,7 @@ class DagTemplateTest(TestCase):
                         "download_output_dir": "s3://invalid@/africa/chirps/rainfall/",
                     },
                     "report_email": "jim@bluesquarehub.com",
-                    "schedule": "0 12 * * 0",
+                    "schedule": None,  # Was '0 12 * * 0', but we have our own scheduer now
                 },
                 {
                     "dag_id": "chirps_extract_ct2",
@@ -205,7 +205,7 @@ class DagTemplateTest(TestCase):
                         "download_output_dir": "s3://invalid@/africa/chirps/rainfall/",
                     },
                     "report_email": "jim@bluesquarehub.com",
-                    "schedule": "0 12 * * 0",
+                    "schedule": None,  # We '0 12 * * 0', but we have our own scheduer now
                 },
             ],
         )
@@ -251,7 +251,7 @@ class DagTemplateTest(TestCase):
                         "out_notebook": "s3://invalid-bucket/code/output/prj1_{{ execution_date }}.ipynb",
                     },
                     "report_email": "jim@bluesquarehub.com",
-                    "schedule": "0 12 25 * *",
+                    "schedule": None,  # Was '0 12 25 * *', but we have our own scheduer now
                 },
                 {
                     "dag_id": "prj2_update",
@@ -263,7 +263,7 @@ class DagTemplateTest(TestCase):
                         "out_notebook": "s3://invalid-bucket/code/output/ct1_dqa_{{ execution_date }}.ipynb",
                     },
                     "report_email": "jim@bluesquarehub.com",
-                    "schedule": "0 12 20 * *",
+                    "schedule": None,  # Was '0 12 20 * *' , but we have our own scheduer now
                 },
             ],
         )

--- a/requirements.in
+++ b/requirements.in
@@ -22,6 +22,7 @@ tblib
 whitenoise
 sentry-sdk
 tqdm
+croniter
 
 # production
 google-cloud-logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,6 +82,8 @@ colorhash==1.2.1
     # via -r requirements.in
 coverage[toml]==6.5.0
     # via -r requirements.in
+croniter==1.3.7
+    # via -r requirements.in
 cryptography==38.0.3
     # via
     #   -r requirements.in
@@ -288,6 +290,7 @@ pyproj==3.4.0
 python-dateutil==2.8.2
     # via
     #   botocore
+    #   croniter
     #   moto
     #   pandas
 python-slugify==6.1.2


### PR DESCRIPTION
This PR add a background worker in the connector_airflow, which will trigger the start of a dag based on the schedule set by an openhexa admin. Previously, the schedule was forwarded by the sync to airflow, and airflow started a DAG based on its own rules. Unfortunately, this method was challenging from an architectural point of view because it means a DagRun can be 2 types: manual and scheduled. Now, every run are manual (from an airflow point of view), only some are triggered by users and others are called by the background worker.

## Changes

- Add a background worker
- Update cluster sync

## How/what to test

Schedule pipelines, check if they are launched