### PR TITLE
fix(DHIS2): Commit each models directly in DB and use a generator to …

### DIFF
--- a/hexa/plugins/connector_dhis2/api.py
+++ b/hexa/plugins/connector_dhis2/api.py
@@ -178,7 +178,6 @@ class Dhis2Client:
         return info
 
     def fetch_data_elements(self):
-        results = []
         for page in self._api.get_paged(
             "dataElements", params={"fields": ":all"}, page_size=100
         ):
@@ -188,11 +187,11 @@ class Dhis2Client:
                     self.name,
                     page.get("pager"),
                 )
-            results.extend([DataElementResult(data) for data in page["dataElements"]])
-        return results
+
+            for data in page["dataElements"]:
+                yield DataElementResult(data)
 
     def fetch_datasets(self):
-        results = []
         for page in self._api.get_paged(
             "dataSets", params={"fields": ":all"}, page_size=100
         ):
@@ -200,11 +199,10 @@ class Dhis2Client:
                 logger.info(
                     "sync_log %s: page from datasets %s", self.name, page.get("pager")
                 )
-            results.extend([DataSetResult(data) for data in page["dataSets"]])
-        return results
+            for data in page["dataSets"]:
+                yield DataSetResult(data)
 
     def fetch_indicator_types(self):
-        results = []
         for page in self._api.get_paged(
             "indicatorTypes", params={"fields": ":all"}, page_size=100
         ):
@@ -214,13 +212,10 @@ class Dhis2Client:
                     self.name,
                     page.get("pager"),
                 )
-            results.extend(
-                [IndicatorTypeResult(data) for data in page["indicatorTypes"]]
-            )
-        return results
+            for data in page["indicatorTypes"]:
+                yield IndicatorTypeResult(data)
 
     def fetch_indicators(self):
-        results = []
         for page in self._api.get_paged(
             "indicators", params={"fields": ":all"}, page_size=100
         ):
@@ -228,11 +223,10 @@ class Dhis2Client:
                 logger.info(
                     "sync_log %s: page from indicators %s", self.name, page.get("pager")
                 )
-            results.extend([IndicatorResult(data) for data in page["indicators"]])
-        return results
+            for data in page["indicators"]:
+                yield IndicatorResult(data)
 
     def fetch_organisation_units(self):
-        results = []
         for page in self._api.get_paged(
             "organisationUnits", params={"fields": ":all"}, page_size=100
         ):
@@ -244,11 +238,8 @@ class Dhis2Client:
                 )
             # rewrite path -> replace "/" by "." for correct ltree path
             # warning: in place edit, can side effect on tests
-            for element in page["organisationUnits"]:
-                if "path" in element:
-                    element["path"] = element["path"].replace("/", ".").strip(".")
+            for data in page["organisationUnits"]:
+                if "path" in data:
+                    data["path"] = data["path"].replace("/", ".").strip(".")
 
-            results.extend(
-                [OrganisationUnitResult(data) for data in page["organisationUnits"]]
-            )
-        return results
+                yield OrganisationUnitResult(data)

--- a/hexa/plugins/connector_dhis2/models.py
+++ b/hexa/plugins/connector_dhis2/models.py
@@ -135,45 +135,49 @@ class Instance(Datasource):
         self.sync_log("fetch info done: %s", info)
         self.name = info["systemName"]
 
-        self.sync_log("start fetch data_elements")
-
-        results += sync_from_dhis2_results(
-            model_class=DataElement,
-            instance=self,
-            results=client.fetch_data_elements(),
-        )
+        with transaction.atomic(savepoint=False, durable=True):
+            self.sync_log("start fetch data_elements")
+            results += sync_from_dhis2_results(
+                model_class=DataElement,
+                instance=self,
+                results=client.fetch_data_elements(),
+            )
 
         # Sync indicator types
-        self.sync_log("start fetch indicator_types")
-        results += sync_from_dhis2_results(
-            model_class=IndicatorType,
-            instance=self,
-            results=client.fetch_indicator_types(),
-        )
+        with transaction.atomic(savepoint=False, durable=True):
+            self.sync_log("start fetch indicator_types")
+            results += sync_from_dhis2_results(
+                model_class=IndicatorType,
+                instance=self,
+                results=client.fetch_indicator_types(),
+            )
 
         # Sync indicators
-        self.sync_log("start fetch indicators")
-        results += sync_from_dhis2_results(
-            model_class=Indicator,
-            instance=self,
-            results=client.fetch_indicators(),
-        )
+        with transaction.atomic(savepoint=False, durable=True):
+            self.sync_log("start fetch indicators")
+            results += sync_from_dhis2_results(
+                model_class=Indicator,
+                instance=self,
+                results=client.fetch_indicators(),
+            )
 
         # Sync datasets
-        self.sync_log("start fetch datasets")
-        results += sync_from_dhis2_results(
-            model_class=DataSet,
-            instance=self,
-            results=client.fetch_datasets(),
-        )
+        with transaction.atomic(savepoint=False, durable=True):
+            self.sync_log("start fetch datasets")
+            results += sync_from_dhis2_results(
+                model_class=DataSet,
+                instance=self,
+                results=client.fetch_datasets(),
+            )
 
         # Sync organisation units
-        self.sync_log("start fetch organisation_units")
-        results += sync_from_dhis2_results(
-            model_class=OrganisationUnit,
-            instance=self,
-            results=client.fetch_organisation_units(),
-        )
+        with transaction.atomic(savepoint=False, durable=True):
+            self.sync_log("start fetch organisation_units")
+            results += sync_from_dhis2_results(
+                model_class=OrganisationUnit,
+                instance=self,
+                results=client.fetch_organisation_units(),
+            )
 
         # Flag the datasource as synced
         self.sync_log("end of fetching resources")

--- a/hexa/plugins/connector_dhis2/sync.py
+++ b/hexa/plugins/connector_dhis2/sync.py
@@ -34,9 +34,7 @@ def sync_from_dhis2_results(*, model_class, instance, results):
     """Iterate over the DEs in the response and create, update or ignore depending on local data"""
 
     model_name = model_class._meta.model_name
-    instance.sync_log(
-        "start sync_from_dhis2_results model %s, results %s", model_name, len(results)
-    )
+    instance.sync_log("start sync_from_dhis2_results model %s", model_name)
 
     created = 0
     updated = 0

--- a/hexa/plugins/connector_dhis2/tests/test_api.py
+++ b/hexa/plugins/connector_dhis2/tests/test_api.py
@@ -37,8 +37,7 @@ class Dhis2Test(TestCase):
             json=mock_data_elements_response,
             status=200,
         )
-        results = self.dhis2_client.fetch_data_elements()
-        self.assertIsInstance(results, list)
+        results = list(self.dhis2_client.fetch_data_elements())
         self.assertGreater(len(results), 0)
         self.assertIsInstance(results[0], DataElementResult)
 
@@ -50,7 +49,7 @@ class Dhis2Test(TestCase):
             json=mock_indicator_types_response,
             status=200,
         )
-        results = self.dhis2_client.fetch_indicator_types()
+        results = list(self.dhis2_client.fetch_indicator_types())
         self.assertIsInstance(results, list)
         self.assertGreater(len(results), 0)
         self.assertIsInstance(results[0], IndicatorTypeResult)
@@ -63,7 +62,7 @@ class Dhis2Test(TestCase):
             json=mock_orgunits_response,
             status=200,
         )
-        results = self.dhis2_client.fetch_organisation_units()
+        results = list(self.dhis2_client.fetch_organisation_units())
         self.assertIsInstance(results, list)
         self.assertGreater(len(results), 0)
         self.assertIsInstance(results[0], OrganisationUnitResult)
@@ -76,7 +75,7 @@ class Dhis2Test(TestCase):
             json=mock_indicators_response,
             status=200,
         )
-        results = self.dhis2_client.fetch_indicators()
+        results = list(self.dhis2_client.fetch_indicators())
         self.assertIsInstance(results, list)
         self.assertGreater(len(results), 0)
         self.assertIsInstance(results[0], IndicatorResult)
@@ -89,7 +88,7 @@ class Dhis2Test(TestCase):
             json=mock_datasets_response,
             status=200,
         )
-        results = self.dhis2_client.fetch_datasets()
+        results = list(self.dhis2_client.fetch_datasets())
         self.assertIsInstance(results, list)
         self.assertGreater(len(results), 0)
         self.assertIsInstance(results[0], DataSetResult)


### PR DESCRIPTION
…fetch data from server

It should fix the sync of large DHIS2 instances on our infra. I didn't see a major surge of memory usage on the db or the command task.

## Changes

* Instead of fetching all pages of data and keeping it in memory, I replaced it by a page by page approach.
* Each type of data model is wrapped inside a db transaction
## How/what to test

Locally you can test it with a big instance

On prod we could try it with the one that fails
