### PR TITLE
Remove ENABLE_GRAPHQL setting

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -183,9 +183,6 @@ SESSION_COOKIE_AGE = 365 * 24 * 3600
 if "TRUST_FORWARDED_PROTO" in os.environ:
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-# GraphQL
-ENABLE_GRAPHQL = os.environ.get("ENABLE_GRAPHQL", "false") == "true"
-
 # CORS (For GraphQL)
 # https://github.com/adamchainz/django-cors-headers
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -61,9 +61,6 @@ urlpatterns = [
         GraphQLView.as_view(
             schema=schema, playground_options={"request.credentials": "include"}
         )
-        if settings.ENABLE_GRAPHQL is True
-        else TemplateView.as_view(template_name="404.html"),
-        name="graphql",
     ),
 ]
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -18,7 +18,6 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.urls import include, path, re_path
-from django.views.generic import TemplateView
 
 from hexa.app import get_hexa_app_configs
 
@@ -60,7 +59,8 @@ urlpatterns = [
         r"^graphql/([\w+\/]*?)?$",
         GraphQLView.as_view(
             schema=schema, playground_options={"request.credentials": "include"}
-        )
+        ),
+        name="graphql",
     ),
 ]
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,6 @@ x-app: &common
     build: .
     environment:
       - DEBUG=true
-      - ENABLE_GRAPHQL=true
       - SESSION_COOKIE_SECURE=false
       - CSRF_COOKIE_SECURE=false
       - SECURE_SSL_REDIRECT=false


### PR DESCRIPTION
GraphQL is not optional / experimental anymore.

## Changes

 - Remove ENABLE_GRAPHQLsetting  from `config/settings.py`
 - Remove ENABLE_GRAPHQL env variable from `docker-compose.yaml`

## How/what to test

- Build a new image
- Test on localhosting
- Deploy in demo and prod
