### PR TITLE
WIP Logout

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -16,11 +16,11 @@ Including another URLconf
 from ariadne_django.views import GraphQLView
 from django.conf import settings
 from django.contrib import admin
-from django.contrib.auth import views as auth_views
 from django.urls import include, path, re_path
 
 from hexa.app import get_hexa_app_configs
 
+from . import views
 from .schema import schema
 
 admin.site.site_header = "OpenHexa Admin"
@@ -51,7 +51,7 @@ urlpatterns = [
     # TODO: use API (https://github.com/jupyterhub/jupyterhub/issues/3688)
     path(
         "auth/logout/",
-        auth_views.LogoutView.as_view(next_page=f"{settings.NOTEBOOKS_URL}/hub/logout"),
+        views.LogoutView.as_view(),
         name="logout",
     ),
     path("auth/", include("django.contrib.auth.urls")),

--- a/config/views.py
+++ b/config/views.py
@@ -1,0 +1,17 @@
+from django.contrib.auth import views as auth_views
+from django.conf import settings
+import requests
+
+
+class LogoutView(auth_views.LogoutView):
+    def get(self, request, *args, **kwargs):
+        # Log out the user from jupyterhub
+        requests.get(
+            f"{settings.NOTEBOOKS_URL}/hub/logout",
+            cookies=request.COOKIES,
+        )
+        response = super().get(request, *args, **kwargs)
+        response.delete_cookie("jupyterhub-session-id")
+        response.delete_cookie("jupyterhub-hub-login")
+
+        return response


### PR DESCRIPTION
The goal is to logout the user also from jupyterhub when he logout of OpenHexa.

The solution implemented here is not working as-is because the two services run on different domains in development (so they do not share their cookies)

It's not possible to use the logout mutation in graphql since we need to return a custom response with the jupyterhub cookies deleted (`jupyter-session-id` & ~`jupyter-hub-login`).


