### PR TITLE
Fix regression over user permission on dag list

### DIFF
--- a/hexa/plugins/connector_airflow/schema.py
+++ b/hexa/plugins/connector_airflow/schema.py
@@ -146,7 +146,8 @@ dags_query = QueryType()
 def resolve_dags(_, info, **kwargs):
     request: HttpRequest = info.context["request"]
     qs = (
-        DAG.objects.prefetch_related(
+        DAG.objects.filter_for_user(request.user)
+        .prefetch_related(
             Prefetch(
                 "indexes",
                 queryset=Index.objects.filter_for_user(request.user),


### PR DESCRIPTION
Fix regression on resolve_dags: if the user doesnt have the perm to list all DAG, restrict the DAG list instead of crashing the backend over non existant index

## How/what to test

- Go to index pipelines. if it doesnt crash as a non admin user, this fix works