### PR TITLE
Add download mutation + run auth

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -84,6 +84,7 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "hexa.plugins.connector_airflow.middlewares.dag_run_authentication_middleware",
+    "hexa.pipelines.middlewares.pipeline_run_authentication_middleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "hexa.user_management.middlewares.login_required_middleware",

--- a/hexa/pipelines/authentication.py
+++ b/hexa/pipelines/authentication.py
@@ -1,0 +1,20 @@
+from hexa.pipelines.models import PipelineRun
+from hexa.user_management.models import UserInterface
+
+
+class PipelineRunUser(UserInterface):
+    def __init__(self, pipeline_run: PipelineRun):
+        super().__init__()
+        self.pipeline_run: PipelineRun = pipeline_run
+
+    is_active = True
+    is_authenticated = True
+
+    def get_username(self):
+        return f"pipeline_{self.pipeline_run.id}"
+
+    def natural_key(self):
+        return self.pipeline_run.id
+
+    def has_perm(self, perm, obj=None):
+        return False

--- a/hexa/pipelines/graphql/schema.graphql
+++ b/hexa/pipelines/graphql/schema.graphql
@@ -29,9 +29,20 @@ enum PipelineRunStatus {
   queued
 }
 
-type PipelineRun {
+type PipelineVersion {
   id: String!
   user: User
+  pipeline: Pipeline!
+  number: Int!
+  zipfile: String!
+}
+
+type PipelineRun {
+  id: String!
+  run_id: String!
+  user: User
+  pipeline: Pipeline!
+  version: PipelineVersion!
   config: String!
   status: PipelineRunStatus!
   executionDate: DateTime
@@ -41,6 +52,7 @@ type PipelineRun {
   messages: [PipelineRunMessage!]!
   logs: String
   outputs: [PipelineRunOutput!]!
+  code: String!
 }
 
 enum PipelineRunOrderBy {
@@ -141,21 +153,21 @@ type UploadPipelineResult {
   errors: [PipelineError!]!
 }
 
-input PipelineLogMessageInput {
+input LogPipelineMessageInput {
   priority: MessagePriority!
   message: String!
 }
 
-type PipelineLogMessageResult {
+type LogPipelineMessageResult {
   success: Boolean!
   errors: [PipelineError!]!
 }
 
-input PipelineProgressInput {
+input UpdatePipelineProgressInput {
   percent: Int!
 }
 
-type PipelineProgressResult {
+type UpdatePipelineProgressResult {
   success: Boolean!
   errors: [PipelineError!]!
 }
@@ -166,6 +178,6 @@ extend type Mutation {
   runPipeline(input: RunPipelineInput): RunPipelineResult!
   pipelineToken(input: PipelineTokenInput): PipelineTokenResult!
   uploadPipeline(input: UploadPipelineInput): UploadPipelineResult!
-  pipelineLogMessage(input: PipelineLogMessageInput): PipelineLogMessageResult!
-  pipelineProgress(input: PipelineProgressInput): PipelineProgressResult!
+  logPipelineMessage(input: LogPipelineMessageInput): LogPipelineMessageResult!
+  updatePipelineProgress(input: UpdatePipelineProgressInput): UpdatePipelineProgressResult!
 }

--- a/hexa/pipelines/graphql/schema.graphql
+++ b/hexa/pipelines/graphql/schema.graphql
@@ -77,12 +77,14 @@ enum PipelineError {
   PIPELINE_NOT_FOUND
   PIPELINE_VERSION_NOT_FOUND
   INVALID_CONFIG
+  PIPELINE_ALREADY_COMPLETED
 }
 
 extend type Query {
   pipelines(page: Int, perPage: Int): PipelinesPage!
   pipeline(id: String, name: String): Pipeline
   pipelineRun(id: String!): PipelineRun
+  pipelineRunCode(id: String): String
 }
 
 input CreatePipelineInput {
@@ -139,10 +141,31 @@ type UploadPipelineResult {
   errors: [PipelineError!]!
 }
 
+input PipelineLogMessageInput {
+  priority: MessagePriority!
+  message: String!
+}
+
+type PipelineLogMessageResult {
+  success: Boolean!
+  errors: [PipelineError!]!
+}
+
+input PipelineProgressInput {
+  percent: Int!
+}
+
+type PipelineProgressResult {
+  success: Boolean!
+  errors: [PipelineError!]!
+}
+
 extend type Mutation {
   createPipeline(input: CreatePipelineInput): CreatePipelineResult!
   deletePipeline(input: DeletePipelineInput): DeletePipelineResult!
   runPipeline(input: RunPipelineInput): RunPipelineResult!
   pipelineToken(input: PipelineTokenInput): PipelineTokenResult!
   uploadPipeline(input: UploadPipelineInput): UploadPipelineResult!
+  pipelineLogMessage(input: PipelineLogMessageInput): PipelineLogMessageResult!
+  pipelineProgress(input: PipelineProgressInput): PipelineProgressResult!
 }

--- a/hexa/pipelines/middlewares.py
+++ b/hexa/pipelines/middlewares.py
@@ -1,0 +1,36 @@
+import binascii
+from logging import getLogger
+
+from django.core.signing import BadSignature, Signer
+from django.http import HttpRequest
+
+from hexa.pipelines.models import PipelineRun
+
+from .authentication import PipelineRunUser
+
+logger = getLogger(__name__)
+
+
+def pipeline_run_authentication_middleware(get_response):
+    """This middleware allows an Pipeline v2 run to authenticate through a simple token"""
+
+    def middleware(request: HttpRequest):
+        try:
+            auth_type, token = request.headers["Authorization"].split(" ")
+            if auth_type.lower() == "bearer":
+                token = Signer().unsign_object(token)
+                pipeline_run = PipelineRun.objects.get(webhook_token=token)
+                request.user = PipelineRunUser(pipeline_run=pipeline_run)
+        except KeyError:
+            pass  # No Authorization header
+        except ValueError as e:
+            logger.exception(
+                "pipeline_run_authentication_middleware error",
+            )
+        except (UnicodeDecodeError, binascii.Error, BadSignature):
+            pass
+        except PipelineRun.DoesNotExist:
+            pass
+        return get_response(request)
+
+    return middleware

--- a/hexa/pipelines/models.py
+++ b/hexa/pipelines/models.py
@@ -165,8 +165,8 @@ class Pipeline(models.Model):
         )
 
         # TODO: Object in DB is created, now we need to really launch k8s/docker
-        # need to export "signed_token" as HEXA_WEBHOOK_TOKEN
-        # need to export f"{settings.BASE_URL}{webhook_path}" as HEXA_WEBHOOK_URL
+        # need to export "signed_token" as HEXA_PIPELINERUN_TOKEN
+        # need to export f"{settings.BASE_URL}{webhook_path}" as HEXA_PIPELINERUN_URL
 
         return run
 
@@ -276,6 +276,9 @@ class PipelineRun(Base, WithStatus):
             args=(self.pipeline.id, self.id),
         )
 
+    def get_code(self):
+        return self.pipeline_version.zipfile
+
     def log_message(self, priority: str, message: str):
         self.messages.append(
             {
@@ -284,10 +287,6 @@ class PipelineRun(Base, WithStatus):
                 "timestamp": datetime.utcnow().isoformat(),
             }
         )
-        self.save()
-
-    def set_output(self, title: str, uri: str):
-        self.outputs.append({"title": title, "uri": uri})
         self.save()
 
     def progress_update(self, percent: int):


### PR DESCRIPTION
Add download pipeline-v2 code for the cloud runner. The pipeline run has no cookie, so no auhentication access; to make this work the backend needed a way to authenticate the pipelineRun: as in connector_airflow, it's done with a custom auth middleware.

## Changes

- Add pipeline code download mutation
- Add pipeline run authentication

## How/what to test

Run a pipeline in docker, whatch it download itself.
