### PR TITLE
Fix pipeline runner: missing lib, default namespace

### DIFF
--- a/hexa/pipelines/management/commands/pipelines_runner.py
+++ b/hexa/pipelines/management/commands/pipelines_runner.py
@@ -31,7 +31,7 @@ def run_pipeline_kube(run: PipelineRun, env_var: dict):
         api_version="v1",
         kind="Pod",
         metadata=k8s.V1ObjectMeta(
-            namespace="default",
+            namespace=os.environ.get("PIPELINE_NAMESPACE", "default"),
             name=slugify("pipeline-" + run.pipeline.name + "-" + exec_time_str),
             annotations={
                 # Unfortunately, it also seems that GKE (at least) uses app armor to restrict
@@ -100,7 +100,7 @@ def run_pipeline_kube(run: PipelineRun, env_var: dict):
             ],
         ),
     )
-    v1.create_namespaced_pod(namespace="default", body=pod)
+    v1.create_namespaced_pod(namespace=pod.metadata.namespace, body=pod)
 
     # monitore the pod
     while True:

--- a/requirements.in
+++ b/requirements.in
@@ -24,6 +24,7 @@ whitenoise
 sentry-sdk
 tqdm
 croniter
+kubernetes
 
 # production
 google-cloud-logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ cachetools==5.2.0
 certifi==2022.9.24
     # via
     #   fiona
+    #   kubernetes
     #   pyproj
     #   rasterio
     #   requests
@@ -157,6 +158,7 @@ google-auth==2.14.0
     #   google-auth-oauthlib
     #   google-cloud-core
     #   google-cloud-storage
+    #   kubernetes
 google-auth-oauthlib==0.7.0
     # via gcsfs
 google-cloud-appengine-logging==1.1.6
@@ -212,6 +214,8 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
+kubernetes==25.3.0
+    # via -r requirements.in
 logzero==1.7.0
     # via dhis2-py
 markdown==3.4.1
@@ -294,6 +298,7 @@ python-dateutil==2.8.2
     # via
     #   botocore
     #   croniter
+    #   kubernetes
     #   moto
     #   pandas
 python-slugify==6.1.2
@@ -303,7 +308,9 @@ pytz==2022.6
     #   moto
     #   pandas
 pyyaml==6.0
-    # via moto
+    # via
+    #   kubernetes
+    #   moto
 rasterio==1.2.10
     # via
     #   -r requirements.in
@@ -314,11 +321,14 @@ requests==2.28.1
     #   gcsfs
     #   google-api-core
     #   google-cloud-storage
+    #   kubernetes
     #   moto
     #   requests-oauthlib
     #   responses
 requests-oauthlib==1.3.1
-    # via google-auth-oauthlib
+    # via
+    #   google-auth-oauthlib
+    #   kubernetes
 responses==0.22.0
     # via
     #   -r requirements.in
@@ -341,6 +351,7 @@ six==1.16.0
     #   fiona
     #   google-auth
     #   grpcio
+    #   kubernetes
     #   munch
     #   python-dateutil
 sniffio==1.3.0
@@ -380,9 +391,12 @@ typing-extensions==4.4.0
 urllib3==1.26.12
     # via
     #   botocore
+    #   kubernetes
     #   requests
     #   responses
     #   sentry-sdk
+websocket-client==1.4.2
+    # via kubernetes
 werkzeug==2.2.2
     # via moto
 wheel==0.37.1


### PR DESCRIPTION
- The runner needs kubernetes lib, it was added to the requirements.in/txt
- The runner try to add pipeline pod in the default namespace, now using an env var