### PR TITLE
Fix KeyError, two factor auth checking and metrics saving for pipelines-v2 runner

### DIFF
--- a/hexa/metrics/middlewares.py
+++ b/hexa/metrics/middlewares.py
@@ -19,6 +19,7 @@ def track_request_event(
         if (
             settings.SAVE_REQUESTS
             and request.user.is_authenticated
+            and hasattr(request.user, "id")
             and request.method in ("GET", "POST")
             and not request.META.get("PATH_INFO", "").startswith("/admin")
             and not request.META.get("HEXA_DO_NOT_TRACK", "false") == "true"

--- a/hexa/pipelines/graphql/schema.graphql
+++ b/hexa/pipelines/graphql/schema.graphql
@@ -188,7 +188,7 @@ extend type Mutation {
   runPipeline(input: RunPipelineInput): RunPipelineResult! @login_required
   pipelineToken(input: PipelineTokenInput): PipelineTokenResult! @login_required
   uploadPipeline(input: UploadPipelineInput): UploadPipelineResult! @login_required
-  logPipelineMessage(input: LogPipelineMessageInput): LogPipelineMessageResult! @login_required
-  updatePipelineProgress(input: UpdatePipelineProgressInput): UpdatePipelineProgressResult! @login_required
-  addPipelineOutput(input: AddPipelineOutputInput): AddPipelineOutputResult! @login_required
+  logPipelineMessage(input: LogPipelineMessageInput): LogPipelineMessageResult!
+  updatePipelineProgress(input: UpdatePipelineProgressInput): UpdatePipelineProgressResult!
+  addPipelineOutput(input: AddPipelineOutputInput): AddPipelineOutputResult!
 }

--- a/hexa/pipelines/management/commands/pipelines_runner.py
+++ b/hexa/pipelines/management/commands/pipelines_runner.py
@@ -148,7 +148,7 @@ def run_pipeline_kube(run: PipelineRun, env_var: dict):
     # download termination message and logs
     try:
         containers = {c.name: c.state for c in remote_pod.status.container_statuses}
-        termination_message = containers["papermill"].terminated.message
+        termination_message = containers[container_name].terminated.message
     except (KeyError, AttributeError, TypeError):
         logger.exception("get termination_message")
         termination_message = ""
@@ -157,7 +157,7 @@ def run_pipeline_kube(run: PipelineRun, env_var: dict):
         stdout = v1.read_namespaced_pod_log(
             name=pod.metadata.name,
             namespace=pod.metadata.namespace,
-            container="papermill",
+            container=container_name,
         )
     except Exception:
         logger.exception("get logs")


### PR DESCRIPTION
- Fix KeyError for container name in pipelines-v2 runner
- Fix two factors authentication in API endpoint for pipeline runs
- Don't save the pipeline runs API calls because it doesn't have a valid user