### PR TITLE
Allow workspace creation if user has workspaces feature flag

### DIFF
--- a/hexa/workspaces/permissions.py
+++ b/hexa/workspaces/permissions.py
@@ -5,7 +5,7 @@ from .models import Workspace, WorkspaceMembershipRole
 
 def create_workspace(principal: User):
     """Only superusers can create a workspace"""
-    return principal.is_superuser
+    return principal.has_feature_flag("workspaces")
 
 
 def update_workspace(principal: User, workspace: Workspace):

--- a/hexa/workspaces/tests/test_models.py
+++ b/hexa/workspaces/tests/test_models.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 
 from hexa.core.test import TestCase
-from hexa.user_management.models import User
+from hexa.user_management.models import Feature, FeatureFlag, User
 from hexa.workspaces.models import (
     Workspace,
     WorkspaceMembership,
@@ -11,7 +11,7 @@ from hexa.workspaces.models import (
 
 class WorkspaceTest(TestCase):
     USER_SERENA = None
-    USER_ADMIN = None
+    USER_JULIA = None
 
     @classmethod
     def setUpTestData(cls):
@@ -20,8 +20,11 @@ class WorkspaceTest(TestCase):
             "serena's password",
         )
 
-        cls.USER_ADMIN = User.objects.create_user(
-            "admin@bluesquarehub.com", "admin", is_superuser=True
+        cls.USER_JULIA = User.objects.create_user(
+            "julia@bluesquarehub.com", "juliaspassword"
+        )
+        FeatureFlag.objects.create(
+            feature=Feature.objects.create(code="workspaces"), user=cls.USER_JULIA
         )
 
     def test_create_workspace_regular_user(self):
@@ -35,7 +38,7 @@ class WorkspaceTest(TestCase):
 
     def test_create_workspace_admin_user(self):
         workspace = Workspace.objects.create_if_has_perm(
-            self.USER_ADMIN,
+            self.USER_JULIA,
             name="Senegal Workspace",
             description="This is test for creating workspace",
         )
@@ -44,7 +47,7 @@ class WorkspaceTest(TestCase):
 
     def test_get_workspace_by_id(self):
         workspace = Workspace.objects.create_if_has_perm(
-            self.USER_ADMIN,
+            self.USER_JULIA,
             name="Senegal Workspace",
             description="This is test for creating workspace",
         )
@@ -57,14 +60,14 @@ class WorkspaceTest(TestCase):
 
     def test_add_member(self):
         workspace = Workspace.objects.create_if_has_perm(
-            self.USER_ADMIN,
+            self.USER_JULIA,
             name="Senegal Workspace",
             description="This is test for creating workspace",
         )
         workspace.save()
         self.assertTrue(
             WorkspaceMembership.objects.filter(
-                user=self.USER_ADMIN,
+                user=self.USER_JULIA,
                 workspace=workspace,
                 role=WorkspaceMembershipRole.ADMIN,
             ).exists()

--- a/hexa/workspaces/tests/test_schema.py
+++ b/hexa/workspaces/tests/test_schema.py
@@ -1,7 +1,7 @@
 import uuid
 
 from hexa.core.test import GraphQLTestCase
-from hexa.user_management.models import User
+from hexa.user_management.models import Feature, FeatureFlag, User
 from hexa.workspaces.models import (
     Workspace,
     WorkspaceMembership,
@@ -12,8 +12,9 @@ from hexa.workspaces.models import (
 class WorkspaceTest(GraphQLTestCase):
     USER_SABRINA = None
     USER_REBECCA = None
+    USER_JULIA = None
     USER_WORKSPACE_ADMIN = None
-    USER_ADMIN = None
+    WORKSPACE = None
 
     @classmethod
     def setUpTestData(cls):
@@ -21,13 +22,16 @@ class WorkspaceTest(GraphQLTestCase):
             "sabrina@bluesquarehub.com",
             "standardpassword",
         )
-        cls.USER_ADMIN = User.objects.create_user(
-            "root@openhexa.org", "root", is_superuser=True
-        )
 
         cls.USER_REBECCA = User.objects.create_user(
             "rebecca@bluesquarehub.com",
             "standardpassword",
+        )
+        cls.USER_JULIA = User.objects.create_user(
+            "julia@bluesquarehub.com", "juliaspassword"
+        )
+        FeatureFlag.objects.create(
+            feature=Feature.objects.create(code="workspaces"), user=cls.USER_JULIA
         )
 
         cls.USER_WORKSPACE_ADMIN = User.objects.create_user(
@@ -36,14 +40,14 @@ class WorkspaceTest(GraphQLTestCase):
         )
 
         cls.WORKSPACE = Workspace.objects.create_if_has_perm(
-            cls.USER_ADMIN,
+            cls.USER_JULIA,
             name="Senegal Workspace",
             description="This is a workspace for Senegal",
             countries=[{"code": "AL"}],
         )
 
         cls.WORKSPACE_2 = Workspace.objects.create_if_has_perm(
-            cls.USER_ADMIN,
+            cls.USER_JULIA,
             name="Burundi Workspace",
             description="This is a workspace for Burundi",
             countries=[{"code": "AD"}],
@@ -90,7 +94,7 @@ class WorkspaceTest(GraphQLTestCase):
         )
 
     def test_create_workspace(self):
-        self.client.force_login(self.USER_ADMIN)
+        self.client.force_login(self.USER_JULIA)
         r = self.run_query(
             """
             mutation createWorkspace($input:CreateWorkspaceInput!) {
@@ -124,7 +128,7 @@ class WorkspaceTest(GraphQLTestCase):
         )
 
     def test_create_workspace_with_country(self):
-        self.client.force_login(self.USER_ADMIN)
+        self.client.force_login(self.USER_JULIA)
         r = self.run_query(
             """
             mutation createWorkspace($input:CreateWorkspaceInput!) {
@@ -457,7 +461,7 @@ class WorkspaceTest(GraphQLTestCase):
                 "items": [
                     {"user": {"id": str(self.USER_WORKSPACE_ADMIN.id)}},
                     {"user": {"id": str(self.USER_REBECCA.id)}},
-                    {"user": {"id": str(self.USER_ADMIN.id)}},
+                    {"user": {"id": str(self.USER_JULIA.id)}},
                 ],
             },
             r["data"]["workspace"]["members"],


### PR DESCRIPTION
Allow any user with the `workspaces` feature flag to create a workspace - this will make testing easier.

## Changes

- Replaced the check for superuser status in workspaces permissions by a check on the feature fag

## How/what to test

If you have the workspace feature flag, you should be able to create a workspace.