### PR TITLE
fix(Search): adapt collection id to be a uuid instead of a string

### DIFF
--- a/hexa/data_collections/graphql/schema.graphql
+++ b/hexa/data_collections/graphql/schema.graphql
@@ -1,6 +1,6 @@
 # Collections
 type Collection {
-    id: String!
+    id: UUID!
     name: String!
     author: User
     countries: [Country!]!
@@ -48,7 +48,7 @@ enum CreateCollectionError {
     INVALID
 }
 input UpdateCollectionInput {
-    id: String!
+    id: UUID!
     name: String
     summary: String
     authorId: String
@@ -66,7 +66,7 @@ enum UpdateCollectionError {
     INVALID
 }
 input DeleteCollectionInput {
-    id: String!
+    id: UUID!
 }
 type DeleteCollectionResult {
     success: Boolean!
@@ -76,7 +76,7 @@ enum DeleteCollectionError {
     INVALID
 }
 extend type Query {
-    collection(id: String!): Collection @loginRequired
+    collection(id: UUID!): Collection @loginRequired
     collections(page: Int, perPage: Int): CollectionPage! @loginRequired
 }
 
@@ -91,7 +91,7 @@ extend type Mutation {
 }
 
 input CreateCollectionElementInput {
-    collectionId: String!
+    collectionId: UUID!
     app: String!
     model: String!
     objectId: String!
@@ -108,7 +108,7 @@ enum CreateCollectionElementError {
 }
 
 input DeleteCollectionElementInput {
-    id: String!
+    id: UUID!
 }
 type DeleteCollectionElementResult {
     success: Boolean!
@@ -123,7 +123,7 @@ enum DeleteCollectionElementError {
 
 # Collection items
 type CollectionElement {
-    id: String!
+    id: UUID!
     app: String!
     model: String!
     type: String!


### PR DESCRIPTION
OPENHEXA-M5

Reason: 
```
Fields 'id' conflict because they return conflicting types 'String!' and 'UUID!'. Use different aliases on the fields to fetch both if this was intentional.

GraphQL request:27:7
    ... on Collection {
       id
       ^
       name

GraphQL request:32:7
     ... on CatalogEntry {
       id
       ^
       name
```