### PR TITLE
feat(Workspaces): remove public role privileges on created database

### DIFF
--- a/hexa/databases/api.py
+++ b/hexa/databases/api.py
@@ -67,6 +67,11 @@ def create_database(db_name: str, pwd: str):
                 )
             )
             cursor.execute(
+                sql.SQL("REVOKE ALL ON DATABASE {db_name} FROM PUBLIC;").format(
+                    db_name=sql.Identifier(db_name),
+                )
+            )
+            cursor.execute(
                 sql.SQL("CREATE ROLE {role_name} LOGIN PASSWORD {password};").format(
                     role_name=sql.Identifier(db_name), password=sql.Literal(pwd)
                 )


### PR DESCRIPTION
This PR intends to remove public role privileges on created database. It allows to restrict the created role to have access to  only his workspace databases. 

## Changes

- Add query to revoke all privileges on database to the public role.

## How/what to test

By using a Posgres client, open a connection to the database server and try to access to another database.

## Screenshots / screencast

If relevant, please add some screenshots or a short video.