### PR TITLE
feat(Workspaces): add admin entry for workspaces

### DIFF
--- a/hexa/workspaces/admin.py
+++ b/hexa/workspaces/admin.py
@@ -1,0 +1,13 @@
+from django.contrib import admin
+
+from .models import Workspace
+
+
+@admin.register(Workspace)
+class WorkspaceAdmin(admin.ModelAdmin):
+    list_display = (
+        "slug",
+        "name",
+        "created_at",
+        "updated_at",
+    )


### PR DESCRIPTION
Add entry in django admin for the Workspaces module

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Register Workspace model in django admin.

## How/what to test

Connect to the admin page and check if the Workspaces module is present.

## Screenshots / screencast

![image](https://user-images.githubusercontent.com/25453621/222113984-87b39c05-71e4-4bc8-94e8-c18ae43a6ed8.png)