### PR TITLE
fix(Workspaces): fix psycopg2 connection error

### DIFF
--- a/hexa/databases/tests/test_api.py
+++ b/hexa/databases/tests/test_api.py
@@ -1,12 +1,13 @@
 import psycopg2
 from django.core.exceptions import ValidationError
-from psycopg2 import OperationalError, sql
-from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+from psycopg2 import sql
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT, STATUS_READY
 
 from hexa.core.test import TestCase
 from hexa.databases.api import (
     create_database,
     format_db_name,
+    get_database_connection,
     get_db_server_credentials,
 )
 from hexa.user_management.models import User
@@ -21,16 +22,15 @@ class DatabaseAPITest(TestCase):
 
     def setUp(self):
         self.DB1_NAME = "rdcproject"
-        self.DB2_NAME = "rwandaproject"
+        self.PWD_1 = "p%ygy+_'#wd@"
+        create_database(self.DB1_NAME, self.PWD_1)
 
     def tearDown(self):
         credentials = get_db_server_credentials()
-
         role = credentials["role"]
         password = credentials["password"]
         host = credentials["host"]
         port = credentials["port"]
-
         url = f"postgresql://{role}:{password}@{host}:{port}"
         conn = None
         try:
@@ -43,24 +43,22 @@ class DatabaseAPITest(TestCase):
                     )
                 )
                 cursor.execute(
-                    sql.SQL("DROP DATABASE {db_name};").format(
-                        db_name=sql.Identifier(self.DB2_NAME),
-                    )
-                )
-                cursor.execute(
                     sql.SQL("DROP ROLE {role_name};").format(
                         role_name=sql.Identifier(self.DB1_NAME)
                     )
                 )
-                cursor.execute(
-                    sql.SQL("DROP ROLE {role_name};").format(
-                        role_name=sql.Identifier(self.DB2_NAME)
-                    )
-                )
-
         finally:
             if conn:
                 conn.close()
+
+    def test_get_connection_with_special_chars(self):
+        with self.settings(
+            WORKSPACES_DATABASE_ROLE=self.DB1_NAME,
+            WORKSPACES_DATABASE_PASSWORD=self.PWD_1,
+        ):
+            con = get_database_connection(self.DB1_NAME)
+            self.assertEqual(con.status, STATUS_READY)
+            con.close()
 
     def test_format_db_name(self):
         db_name = "RDC_POLIO_PROJECT"
@@ -79,20 +77,3 @@ class DatabaseAPITest(TestCase):
         password = "password"
         with self.assertRaises(ValidationError):
             create_database(bad_input, password)
-
-    def test_create_database_not_access(self):
-        password_1 = "password_1"
-        password_2 = "password_2"
-        create_database(self.DB1_NAME, password_1)
-        create_database(self.DB2_NAME, password_2)
-
-        credentials = get_db_server_credentials()
-
-        host = credentials["host"]
-        port = credentials["port"]
-
-        # check that role db2 doesn't have access to db1
-        url = f"postgresql://{self.DB2_NAME}:{password_2}@{host}:{port}/{self.DB1_NAME}"
-
-        with self.assertRaises(OperationalError):
-            conn = psycopg2.connect(url)

--- a/hexa/databases/utils.py
+++ b/hexa/databases/utils.py
@@ -3,24 +3,13 @@ from psycopg2 import sql
 
 from hexa.workspaces.models import Workspace
 
-from .api import get_db_server_credentials
-
-
-def get_database_url(database: str):
-    credentials = get_db_server_credentials()
-    role = credentials["role"]
-    password = credentials["password"]
-    host = credentials["host"]
-    port = credentials["port"]
-
-    return f"postgresql://{role}:{password}@{host}:{port}/{database}"
+from .api import get_database_connection
 
 
 def get_database_definition(workspace: Workspace):
-    url = get_database_url(workspace.db_name)
     conn = None
     try:
-        conn = psycopg2.connect(url)
+        conn = get_database_connection(workspace.db_name)
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
             cursor.execute(
                 """
@@ -43,11 +32,10 @@ def get_database_definition(workspace: Workspace):
 
 
 def get_table_definition(workspace: Workspace, table_name: str):
-    url = get_database_url(workspace.db_name)
     columns = []
     conn = None
     try:
-        conn = psycopg2.connect(url)
+        conn = get_database_connection(workspace.db_name)
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
             cursor.execute(
                 """
@@ -85,10 +73,9 @@ def get_table_definition(workspace: Workspace, table_name: str):
 
 
 def get_table_sample_data(workspace: Workspace, table_name: str, n_rows: int = 4):
-    url = get_database_url(workspace.db_name)
     conn = None
     try:
-        conn = psycopg2.connect(url)
+        conn = get_database_connection(workspace.db_name)
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cursor:
             cursor.execute(
                 sql.SQL("SELECT * FROM {table} LIMIT %s;").format(


### PR DESCRIPTION
A connection error may occur using credentials that contain special characters like "@,%". 

## Changes

- Use keyword arguments for opening connection instead of URI string.
- Add function to return the database connection object.

## How/what to test

Generate new credentials with special characters and check if the connection is established without error(s).