### PR TITLE
fix: replace display_name by name in search_fields for dhis2 admin

### DIFF
--- a/hexa/plugins/connector_dhis2/admin.py
+++ b/hexa/plugins/connector_dhis2/admin.py
@@ -26,7 +26,7 @@ class PermissionInline(admin.TabularInline):
 class InstanceAdmin(admin.ModelAdmin):
     list_display = ("url", "display_name", "slug", "last_synced_at", "auto_sync")
     list_filter = ("url",)
-    search_fields = ("url", "display_name")
+    search_fields = ("url", "name")
     prepopulated_fields = {"slug": ("name",)}
 
     inlines = [


### PR DESCRIPTION
Fix error happening when searching for a dhis2 instance

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Replace display_name by name in search_fields

## How/what to test

Go to the list of dhis2 instance on admin page and try search.