### PR TITLE
feat(Workspaces): delete database when deleting workspace

### DIFF
--- a/hexa/databases/api.py
+++ b/hexa/databases/api.py
@@ -119,3 +119,28 @@ def update_database_password(db_role: str, new_password: str):
     finally:
         if conn:
             conn.close()
+
+
+def delete_database(db_name: str):
+    """
+    Delete database, role and all objects associated with the role.
+    """
+    conn = None
+    try:
+        conn = get_database_connection(settings.WORKSPACES_DATABASE_DEFAULT_DB)
+        conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        with conn.cursor() as cursor:
+            cursor.execute(
+                sql.SQL("DROP DATABASE {db_name};").format(
+                    db_name=sql.Identifier(db_name),
+                )
+            )
+            cursor.execute(
+                sql.SQL("DROP OWNED BY {role};").format(role=sql.Identifier(db_name))
+            )
+            cursor.execute(
+                sql.SQL("DROP ROLE {role};").format(role=sql.Identifier(db_name))
+            )
+    finally:
+        if conn:
+            conn.close()

--- a/hexa/workspaces/models.py
+++ b/hexa/workspaces/models.py
@@ -18,7 +18,12 @@ from slugify import slugify
 from hexa.core.models import Base
 from hexa.core.models.base import BaseQuerySet
 from hexa.core.models.cryptography import EncryptedTextField
-from hexa.databases.api import create_database, format_db_name, update_database_password
+from hexa.databases.api import (
+    create_database,
+    delete_database,
+    format_db_name,
+    update_database_password,
+)
 from hexa.files.api import create_bucket
 from hexa.user_management.models import User
 
@@ -132,7 +137,7 @@ class Workspace(Base):
     def delete_if_has_perm(self, *, principal: User):
         if not principal.has_perm("workspaces.delete_workspace", self):
             raise PermissionDenied
-
+        delete_database(self.db_name)
         self.delete()
 
     def generate_new_database_password(self, *, principal: User):

--- a/hexa/workspaces/tests/test_schema/test_workspace.py
+++ b/hexa/workspaces/tests/test_schema/test_workspace.py
@@ -320,7 +320,8 @@ class WorkspaceTest(GraphQLTestCase):
             r["data"]["deleteWorkspace"],
         )
 
-    def test_delete_workspace(self):
+    @patch("hexa.workspaces.models.delete_database")
+    def test_delete_workspace(self, mock_delete_database):
         self.client.force_login(self.USER_WORKSPACE_ADMIN)
         r = self.run_query(
             """
@@ -337,6 +338,7 @@ class WorkspaceTest(GraphQLTestCase):
                 }
             },
         )
+        self.assertTrue(mock_delete_database.called)
         self.assertEqual(
             {
                 "success": True,


### PR DESCRIPTION
Delete associated database when deleting a workspace.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- add method for deleting a database (the role and associated objects will be dropped)
- delete database when deleting workspace

## How/what to test

Create/Use a workspace, go to settings page and click on delete. The workspace database should be deleted alongside the workspace