### PR TITLE
chore(Workspaces): add workspace bucket name env variable

### DIFF
--- a/hexa/files/credentials.py
+++ b/hexa/files/credentials.py
@@ -20,6 +20,7 @@ def notebooks_credentials(user: User, workspace: Workspace):
     )
     token, expires_in = get_short_lived_downscoped_access_token(workspace.bucket_name)
     return {
+        "WORKSPACE_BUCKET_NAME": workspace.bucket_name,
         "GCS_TOKEN": token,
         "GCS_BUCKETS": base64.b64encode(
             json.dumps(

--- a/hexa/pipelines/views.py
+++ b/hexa/pipelines/views.py
@@ -141,7 +141,7 @@ def credentials2(request: HttpRequest) -> HttpResponse:
             "mount": "/workspace",
         }
     )
-    env["WORKSPACE_BUCKET"] = run.pipeline.workspace.bucket_name
+    env["WORKSPACE_BUCKET_NAME"] = run.pipeline.workspace.bucket_name
     env["GCS_TOKEN"] = build_app_short_lived_credentials().access_token
     env["GCS_BUCKETS"] = base64.b64encode(
         json.dumps({"buckets": gcs_buckets}).encode()

--- a/hexa/workspaces/tests/test_views.py
+++ b/hexa/workspaces/tests/test_views.py
@@ -118,6 +118,7 @@ class ViewsTest(TestCase):
                 "DB_DATABASE": "hexa-app",  # Kept for backward-compat
                 "DB_DB_NAME": "hexa-app",
                 "DB_URL": "postgresql+psycopg2://hexa-app:hexa-app@127.0.0.1:5432/hexa-app",
+                "WORKSPACE_BUCKET_NAME": self.WORKSPACE.bucket_name,
                 "WORKSPACE_DATABASE_DB_NAME": self.WORKSPACE.db_name,
                 "WORKSPACE_DATABASE_HOST": db_credentials["host"],
                 "WORKSPACE_DATABASE_PORT": db_credentials["port"],


### PR DESCRIPTION
We need this env variable, ideally for both notebooks and pipelines, in order to be able to generate absolute GCS URIs.