### PR TITLE
feat(User): add openhexa_legacy and workspaces features to root

### DIFF
--- a/hexa/core/tests/test_fixtures.py
+++ b/hexa/core/tests/test_fixtures.py
@@ -3,8 +3,16 @@ from io import StringIO
 from django.core.management import call_command
 
 from hexa.core.test import TestCase
+from hexa.user_management.models import User
 
 
 class FixturesTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        User.objects.create_superuser(
+            "root@openhexa.org",
+            "root",
+        )
+
     def test_fixtures(self):
         call_command("loaddata", "demo.json", stdout=StringIO())

--- a/hexa/user_management/fixtures/demo.json
+++ b/hexa/user_management/fixtures/demo.json
@@ -79,7 +79,7 @@
         "fields": {
             "created_at": "2023-04-26T10:55:32.487Z",
             "updated_at": "2023-04-26T10:55:32.487Z",
-            "feature": ["workspaces"],
+            "feature": "9bc1ce72-1bc6-46a7-84f3-e9061cd04d37",
             "user": ["root@openhexa.org"],
             "config": {}
         }
@@ -90,7 +90,7 @@
         "fields": {
             "created_at": "2023-04-26T10:55:43.680Z",
             "updated_at": "2023-04-26T10:55:43.680Z",
-            "feature": ["openhexa_legacy"],
+            "feature": "da2feac3-9c69-4b8c-b6c1-b53a8000e57a",
             "user": ["root@openhexa.org"],
             "config": {}
         }

--- a/hexa/user_management/fixtures/demo.json
+++ b/hexa/user_management/fixtures/demo.json
@@ -52,5 +52,47 @@
       "updated_at": "2021-04-07T13:48:09.842Z",
       "name": "Bluesquare Users"
     }
-  }
+  },
+    {
+        "model": "user_management.feature",
+        "pk": "9bc1ce72-1bc6-46a7-84f3-e9061cd04d37",
+        "fields": {
+            "created_at": "2023-04-26T10:48:06.183Z",
+            "updated_at": "2023-04-26T10:55:32.486Z",
+            "code": "openhexa_legacy",
+            "force_activate": false
+        }
+    },
+    {
+        "model": "user_management.feature",
+        "pk": "da2feac3-9c69-4b8c-b6c1-b53a8000e57a",
+        "fields": {
+            "created_at": "2023-04-26T10:55:43.679Z",
+            "updated_at": "2023-04-26T10:55:43.679Z",
+            "code": "workspaces",
+            "force_activate": false
+        }
+    },
+    {
+        "model": "user_management.featureflag",
+        "pk": "8bcf45b6-d2c3-4eef-8b31-ec19c6c8613b",
+        "fields": {
+            "created_at": "2023-04-26T10:55:32.487Z",
+            "updated_at": "2023-04-26T10:55:32.487Z",
+            "feature": "9bc1ce72-1bc6-46a7-84f3-e9061cd04d37",
+            "user": ["root@openhexa.org"],
+            "config": {}
+        }
+    },
+    {
+        "model": "user_management.featureflag",
+        "pk": "17c137f0-8840-4358-b1d8-9b2c600a8186",
+        "fields": {
+            "created_at": "2023-04-26T10:55:43.680Z",
+            "updated_at": "2023-04-26T10:55:43.680Z",
+            "feature": "da2feac3-9c69-4b8c-b6c1-b53a8000e57a",
+            "user": ["root@openhexa.org"],
+            "config": {}
+        }
+    }
 ]

--- a/hexa/user_management/fixtures/demo.json
+++ b/hexa/user_management/fixtures/demo.json
@@ -79,7 +79,7 @@
         "fields": {
             "created_at": "2023-04-26T10:55:32.487Z",
             "updated_at": "2023-04-26T10:55:32.487Z",
-            "feature": "9bc1ce72-1bc6-46a7-84f3-e9061cd04d37",
+            "feature": ["workspaces"],
             "user": ["root@openhexa.org"],
             "config": {}
         }
@@ -90,7 +90,7 @@
         "fields": {
             "created_at": "2023-04-26T10:55:43.680Z",
             "updated_at": "2023-04-26T10:55:43.680Z",
-            "feature": "da2feac3-9c69-4b8c-b6c1-b53a8000e57a",
+            "feature": ["openhexa_legacy"],
             "user": ["root@openhexa.org"],
             "config": {}
         }

--- a/hexa/user_management/fixtures/demo.json
+++ b/hexa/user_management/fixtures/demo.json
@@ -55,7 +55,6 @@
   },
     {
         "model": "user_management.feature",
-        "pk": "9bc1ce72-1bc6-46a7-84f3-e9061cd04d37",
         "fields": {
             "created_at": "2023-04-26T10:48:06.183Z",
             "updated_at": "2023-04-26T10:55:32.486Z",
@@ -65,7 +64,6 @@
     },
     {
         "model": "user_management.feature",
-        "pk": "da2feac3-9c69-4b8c-b6c1-b53a8000e57a",
         "fields": {
             "created_at": "2023-04-26T10:55:43.679Z",
             "updated_at": "2023-04-26T10:55:43.679Z",
@@ -75,22 +73,20 @@
     },
     {
         "model": "user_management.featureflag",
-        "pk": "8bcf45b6-d2c3-4eef-8b31-ec19c6c8613b",
         "fields": {
             "created_at": "2023-04-26T10:55:32.487Z",
             "updated_at": "2023-04-26T10:55:32.487Z",
-            "feature": "9bc1ce72-1bc6-46a7-84f3-e9061cd04d37",
+            "feature": ["openhexa_legacy"],
             "user": ["root@openhexa.org"],
             "config": {}
         }
     },
     {
         "model": "user_management.featureflag",
-        "pk": "17c137f0-8840-4358-b1d8-9b2c600a8186",
         "fields": {
             "created_at": "2023-04-26T10:55:43.680Z",
             "updated_at": "2023-04-26T10:55:43.680Z",
-            "feature": "da2feac3-9c69-4b8c-b6c1-b53a8000e57a",
+            "feature": ["workspaces"],
             "user": ["root@openhexa.org"],
             "config": {}
         }

--- a/hexa/user_management/migrations/0016_auto_20230330_1506.py
+++ b/hexa/user_management/migrations/0016_auto_20230330_1506.py
@@ -11,10 +11,11 @@ def add_openhexa_legacy_flag(apps, schema_editor):
     feature = None
     try:
         feature = Feature.objects.get(code="openhexa_legacy")
-        for user in User.objects.all():
-            FeatureFlag.objects.create(feature=feature, user=user)
     except Feature.DoesNotExist:
-        pass
+        feature = Feature.objects.create(code="openhexa_legacy")
+
+    for user in User.objects.all():
+        FeatureFlag.objects.create(feature=feature, user=user)
 
 
 class Migration(migrations.Migration):

--- a/hexa/user_management/migrations/0016_auto_20230330_1506.py
+++ b/hexa/user_management/migrations/0016_auto_20230330_1506.py
@@ -11,11 +11,10 @@ def add_openhexa_legacy_flag(apps, schema_editor):
     feature = None
     try:
         feature = Feature.objects.get(code="openhexa_legacy")
+        for user in User.objects.all():
+            FeatureFlag.objects.create(feature=feature, user=user)
     except Feature.DoesNotExist:
-        feature = Feature.objects.create(code="openhexa_legacy")
-
-    for user in User.objects.all():
-        FeatureFlag.objects.create(feature=feature, user=user)
+        pass
 
 
 class Migration(migrations.Migration):

--- a/hexa/user_management/models.py
+++ b/hexa/user_management/models.py
@@ -283,12 +283,19 @@ class Membership(Base):
         return super().delete()
 
 
+class FeatureManager(models.Manager):
+    def get_by_natural_key(self, code: str):
+        return self.get(code=code)
+
+
 class Feature(Base):
     class Meta:
         db_table = "identity_feature"
 
     code = models.CharField(max_length=200)
     force_activate = models.BooleanField(default=False)
+
+    objects = FeatureManager()
 
     def __str__(self):
         return self.code

--- a/hexa/user_management/models.py
+++ b/hexa/user_management/models.py
@@ -53,6 +53,9 @@ class UserManager(BaseUserManager):
             raise ValueError(_("Superuser must have is_superuser=True."))
         return self.create_user(email, password, **extra_fields)
 
+    def get_by_natural_key(self, email: str):
+        return self.get(email=email)
+
 
 class UserInterface:
     is_staff = False

--- a/hexa/user_management/models.py
+++ b/hexa/user_management/models.py
@@ -53,9 +53,6 @@ class UserManager(BaseUserManager):
             raise ValueError(_("Superuser must have is_superuser=True."))
         return self.create_user(email, password, **extra_fields)
 
-    def get_by_natural_key(self, email: str):
-        return self.get(email=email)
-
 
 class UserInterface:
     is_staff = False
@@ -283,19 +280,12 @@ class Membership(Base):
         return super().delete()
 
 
-class FeatureManager(models.Manager):
-    def get_by_natural_key(self, code: str):
-        return self.get(code=code)
-
-
 class Feature(Base):
     class Meta:
         db_table = "identity_feature"
 
     code = models.CharField(max_length=200)
     force_activate = models.BooleanField(default=False)
-
-    objects = FeatureManager()
 
     def __str__(self):
         return self.code

--- a/hexa/user_management/models.py
+++ b/hexa/user_management/models.py
@@ -280,12 +280,22 @@ class Membership(Base):
         return super().delete()
 
 
+class FeatureManager(models.Manager):
+    def get_by_natural_key(self, code: str):
+        return self.get(code=code)
+
+
 class Feature(Base):
     class Meta:
         db_table = "identity_feature"
 
     code = models.CharField(max_length=200)
     force_activate = models.BooleanField(default=False)
+
+    def natural_key(self):
+        return (self.code,)
+
+    objects = FeatureManager()
 
     def __str__(self):
         return self.code


### PR DESCRIPTION
Add openhexa_legacy and workspaces feature flag to root user when installing fixtures.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- add features in fixtures
- use natural key in fixtures for user model 

## How/what to test

Have a fresh install of openhexa-app and check if root user have access to legacy and workspaces part.

## Screenshots / screencast

If relevant, please add some screenshots or a short video.