### PR TITLE
fix(Workspaces): fix workspace member role update

### DIFF
--- a/hexa/workspaces/tests/test_schema/test_workspace.py
+++ b/hexa/workspaces/tests/test_schema/test_workspace.py
@@ -744,7 +744,7 @@ class WorkspaceTest(GraphQLTestCase):
             """,
             {
                 "input": {
-                    "membershipId": str(self.WORKSPACE_MEMBERSHIP_2.id),
+                    "membershipId": str(self.WORKSPACE_MEMBERSHIP.id),
                     "role": WorkspaceMembershipRole.EDITOR,
                 }
             },
@@ -754,7 +754,7 @@ class WorkspaceTest(GraphQLTestCase):
                 "success": True,
                 "errors": [],
                 "workspaceMembership": {
-                    "id": str(self.WORKSPACE_MEMBERSHIP_2.id),
+                    "id": str(self.WORKSPACE_MEMBERSHIP.id),
                     "role": WorkspaceMembershipRole.EDITOR,
                 },
             },


### PR DESCRIPTION
Fix broken update on workspace's member role update.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Change filter_for_user query
- Ensure that a user cannot update/delete his own membership

## How/what to test

- Test update of another user's role.
- Check if you can delete/update your own role
