### PR TITLE
Fix(Databases): always use db_url

### DIFF
--- a/hexa/databases/tests/test_schema.py
+++ b/hexa/databases/tests/test_schema.py
@@ -107,7 +107,7 @@ class DatabaseTest(GraphQLTestCase):
                     "username": self.WORKSPACE.db_name,
                     "port": port,
                     "host": f"{self.WORKSPACE.slug}.{settings.WORKSPACES_DATABASE_PROXY_HOST}",
-                    "url": f"postgresql+psycopg2://{self.WORKSPACE.db_name}:{self.WORKSPACE.db_password}@{host}:{port}/{self.WORKSPACE.db_name}",
+                    "url": f"postgresql://{self.WORKSPACE.db_name}:{self.WORKSPACE.db_password}@{host}:{port}/{self.WORKSPACE.db_name}",
                     "password": self.WORKSPACE.db_password,
                 },
                 r["data"]["workspace"]["database"]["credentials"],

--- a/hexa/pipelines/views.py
+++ b/hexa/pipelines/views.py
@@ -130,7 +130,7 @@ def credentials2(request: HttpRequest) -> HttpResponse:
             "WORKSPACE_DATABASE_PORT": db_credentials["port"],
             "WORKSPACE_DATABASE_USERNAME": workspace.db_name,
             "WORKSPACE_DATABASE_PASSWORD": workspace.db_password,
-            "WORKSPACE_DATABASE_URL": f"postgresql://{workspace.db_name}:{workspace.db_password}@{db_credentials['host']}:{db_credentials['port']}/{workspace.db_name}",
+            "WORKSPACE_DATABASE_URL": workspace.db_url,
         }
     )
 

--- a/hexa/workspaces/models.py
+++ b/hexa/workspaces/models.py
@@ -150,7 +150,7 @@ class Workspace(Base):
     @property
     def db_url(self):
         host = get_db_server_credentials()["host"]
-        return f"postgresql+psycopg2://{self.db_name}:{self.db_password}@{host}:{self.db_port}/{self.db_name}"
+        return f"postgresql://{self.db_name}:{self.db_password}@{host}:{self.db_port}/{self.db_name}"
 
     def update_if_has_perm(self, *, principal: User, **kwargs):
         if not principal.has_perm("workspaces.update_workspace", self):
@@ -412,7 +412,7 @@ class Connection(models.Model):
                     # Add compound database URL for SQLALchemy and the like
                     stringcase.constcase(
                         f"{self.slug}_url".lower()
-                    ): f"postgresql+psycopg2://{fields['username']}:{fields['password']}@{fields['host']}:{fields['port']}/{fields['db_name']}",
+                    ): f"postgresql://{fields['username']}:{fields['password']}@{fields['host']}:{fields['port']}/{fields['db_name']}",
                     # Add "_DATABASE" for backward-compatibility (we now use "_DB_NAME" but it used to be _DATABASE")
                     stringcase.constcase(f"{self.slug}_database".lower()): fields[
                         "db_name"

--- a/hexa/workspaces/tests/test_views.py
+++ b/hexa/workspaces/tests/test_views.py
@@ -117,7 +117,7 @@ class ViewsTest(TestCase):
                 "DB_PASSWORD": "hexa-app",
                 "DB_DATABASE": "hexa-app",  # Kept for backward-compat
                 "DB_DB_NAME": "hexa-app",
-                "DB_URL": "postgresql+psycopg2://hexa-app:hexa-app@127.0.0.1:5432/hexa-app",
+                "DB_URL": "postgresql://hexa-app:hexa-app@127.0.0.1:5432/hexa-app",
                 "WORKSPACE_BUCKET_NAME": self.WORKSPACE.bucket_name,
                 "WORKSPACE_DATABASE_DB_NAME": self.WORKSPACE.db_name,
                 "WORKSPACE_DATABASE_HOST": db_credentials["host"],

--- a/hexa/workspaces/views.py
+++ b/hexa/workspaces/views.py
@@ -45,7 +45,7 @@ def credentials(request: HttpRequest, workspace_slug: str) -> HttpResponse:
             "WORKSPACE_DATABASE_PORT": db_credentials["port"],
             "WORKSPACE_DATABASE_USERNAME": workspace.db_name,
             "WORKSPACE_DATABASE_PASSWORD": workspace.db_password,
-            "WORKSPACE_DATABASE_URL": f"postgresql://{workspace.db_name}:{workspace.db_password}@{db_credentials['host']}:{db_credentials['port']}/{workspace.db_name}",
+            "WORKSPACE_DATABASE_URL": workspace.db_url,
         }
     )
 


### PR DESCRIPTION
This PR simplifies how we generate workspaces database URL.

## Changes

- Always use `db_url()` to generate the database URL
- Don't use `psycopg2` in the scheme