### PR TITLE
fix(GCS): Add a content-disposition:download on object download url

### DIFF
--- a/hexa/files/api.py
+++ b/hexa/files/api.py
@@ -205,11 +205,17 @@ def delete_object(bucket_name, name):
     return
 
 
-def generate_download_url(bucket_name: str, target_key: str):
+def generate_download_url(bucket_name: str, target_key: str, force_attachment=False):
     client = get_storage_client()
     gcs_bucket = client.get_bucket(bucket_name)
     blob: Blob = gcs_bucket.get_blob(target_key)
-    return blob.generate_signed_url(expiration=600, version="v4")
+    response_disposition = (
+        f"attachment;filename={blob.name}" if force_attachment else None
+    )
+
+    return blob.generate_signed_url(
+        expiration=600, version="v4", response_disposition=response_disposition
+    )
 
 
 def generate_upload_url(bucket_name: str, target_key: str, content_type: str):

--- a/hexa/files/schema/mutations.py
+++ b/hexa/files/schema/mutations.py
@@ -41,7 +41,9 @@ def resolve_prepare_download_object(_, info, **kwargs):
         if not request.user.has_perm("files.download_object", workspace):
             return {"success": False, "errors": ["PERMISSION_DENIED"]}
         object_key = mutation_input["objectKey"]
-        download_url = generate_download_url(workspace.bucket_name, object_key)
+        download_url = generate_download_url(
+            workspace.bucket_name, object_key, force_attachment=True
+        )
 
         return {"success": True, "download_url": download_url, "errors": []}
     except (NotFound, Workspace.DoesNotExist):


### PR DESCRIPTION
When users wanted to download files, some triggered a the browser to download the object directly while other opened a new windows with the content of the file. 

We now ask to have a "download" content disposition set on the generated download url created by google.