### PR TITLE
fix(Connections): Returns the secret value for members that can edit them

### DIFF
--- a/hexa/workspaces/schema/types.py
+++ b/hexa/workspaces/schema/types.py
@@ -108,10 +108,13 @@ def resolve_workspace_connection_fields(obj, info, **kwargs):
 
 @connection_field_object.field("value")
 def resolve_connection_field_value(obj: ConnectionField, info, **kwargs):
-    if obj.secret:
-        return None
-    else:
+    request: HttpRequest = info.context["request"]
+    if obj.secret is False:
         return obj.value
+    elif request.user.has_perm("workspaces.update_connection", obj.connection):
+        return obj.value
+    else:
+        return None
 
 
 connection_object.set_alias("type", "connection_type")


### PR DESCRIPTION
When a user edited any field of a connection that had secret fields, those secret fields were reset to an empty value

## Changes

We now return the value of the secret fields when the user is at least an member with the editor role

## How/what to test

- Create a connection with at least 2 fields (one secret and one non secret).
- Edit the non secret field
- The secret field value should not have changed
