### PR TITLE
fix(Connections): Add a suffix to connection slug if it exists

### DIFF
--- a/hexa/workspaces/models.py
+++ b/hexa/workspaces/models.py
@@ -371,8 +371,13 @@ class ConnectionManager(models.Manager):
         if not principal.has_perm("workspaces.create_connection", workspace):
             raise PermissionDenied
 
+        # Check if the slug does not already exist
         if not slug:
             slug = slugify(name)[:40]
+
+        if self.filter(workspace=workspace, slug=slug).exists():
+            # If the slug already exists, we add a random string to it
+            slug = f"{slug}-{uuid.uuid4().hex[:4]}"
 
         connection = Connection(
             workspace=workspace, user=principal, name=name, slug=slug, **kwargs

--- a/hexa/workspaces/tests/test_models.py
+++ b/hexa/workspaces/tests/test_models.py
@@ -1,4 +1,5 @@
 import hashlib
+import uuid
 from unittest.mock import patch
 
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
@@ -218,6 +219,31 @@ class ConnectionTest(TestCase):
                 slug="conn",
                 connection_type=ConnectionType.CUSTOM,
             )
+
+    def test_create_connection_new_slug(self):
+        con = Connection.objects.create_if_has_perm(
+            self.USER_SERENA,
+            self.WORKSPACE,
+            name="Connection with a slug",
+            connection_type=ConnectionType.CUSTOM,
+        )
+
+        self.assertEqual(con.slug, "connection-with-a-slug")
+
+    def test_create_connection_existing_slug(self):
+        self.test_create_connection_new_slug()
+
+        slug_uuid = uuid.uuid4()
+
+        with patch("uuid.uuid4", return_value=slug_uuid):
+            con = Connection.objects.create_if_has_perm(
+                self.USER_SERENA,
+                self.WORKSPACE,
+                name="connection-with-a slug",
+                connection_type=ConnectionType.CUSTOM,
+            )
+
+        self.assertEqual(con.slug, f"connection-with-a-slug-{slug_uuid.hex[:4]}")
 
     def test_add_connection_field(self):
         connection = Connection.objects.create_if_has_perm(


### PR DESCRIPTION
Before creating a connection from the slug provided by the API of the name, we check for the existence of a workspace connection with this slug In case we find one, we add a random suffix to the slug of the new connection.