### PR TITLE
feat(Workspaces): set demo data optional

### DIFF
--- a/hexa/workspaces/graphql/schema.graphql
+++ b/hexa/workspaces/graphql/schema.graphql
@@ -160,6 +160,7 @@ input CreateWorkspaceInput {
   slug: String
   description: String
   countries: [CountryInput!]
+  loadSampleData: Boolean
 }
 
 input UpdateWorkspaceInput {

--- a/hexa/workspaces/models.py
+++ b/hexa/workspaces/models.py
@@ -66,6 +66,7 @@ class WorkspaceManager(models.Manager):
         name: str,
         description: str = None,
         countries: typing.Sequence[Country] = None,
+        load_sample_data: bool = False,
     ):
         if not principal.has_perm("workspaces.create_workspace"):
             raise PermissionDenied
@@ -83,13 +84,14 @@ class WorkspaceManager(models.Manager):
         db_name = generate_database_name()
         create_kwargs["db_password"] = db_password
         create_kwargs["db_name"] = db_name
-
         create_database(db_name, db_password)
-        load_database_sample_data(db_name)
 
         bucket = create_bucket(settings.WORKSPACE_BUCKET_PREFIX + slug)
-        load_bucket_sample_data(bucket.name)
         create_kwargs["bucket_name"] = bucket.name
+
+        if load_sample_data:
+            load_database_sample_data(db_name)
+            load_bucket_sample_data(bucket.name)
 
         workspace = self.create(**create_kwargs)
 

--- a/hexa/workspaces/schema/mutations.py
+++ b/hexa/workspaces/schema/mutations.py
@@ -42,6 +42,7 @@ def resolve_create_workspace(_, info, **kwargs):
             ]
             if "countries" in create_input
             else None,
+            load_sample_data=create_input.get("loadSampleData"),
         )
 
         return {"success": True, "workspace": workspace, "errors": []}


### PR DESCRIPTION
Makes optional demo data loaded when creating a workspace.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- update schema, mutation and model to handle to make demo data optional.

## How/what to test

A few words about what needs to be tested, along with specific testing instructions if needed.

## Screenshots / screencast

If relevant, please add some screenshots or a short video.