### PR TITLE
Better pipeline outputs

### DIFF
--- a/hexa/pipelines/graphql/schema.graphql
+++ b/hexa/pipelines/graphql/schema.graphql
@@ -17,11 +17,14 @@ enum PipelineRunTrigger {
   manual
 }
 
-type PipelineRunOutput {
+type GenericOutput {
   name: String
   type: String!
   uri: String!
 }
+
+
+union PipelineRunOutput = BucketObject | GenericOutput | DatabaseTable
 
 enum PipelineRunStatus {
   success


### PR DESCRIPTION
In pipelines, users can call `current_run.add_file_output` & `current_run.add_database_output`. We transform those two types of output to their correct representation of `BucketObject` & `DatabaseTable`.

Example of return when querying a pipeline run
```json
{
  "data": {
    "workspace": {
      "bucket": {
        "objects": {
          "hasNextPage": false,
          "hasPreviousPage": false,
          "items": [
            {
              "name": ".hidden_files",
              "key": ".hidden_files/"
            },
            {
              "name": "all",
              "key": "all/"
            },
            {
              "name": "README.MD",
              "key": "README.MD"
            },
            {
              "name": "covid_data.csv",
              "key": "covid_data.csv"
            },
            {
              "name": "demo.ipynb",
              "key": "demo.ipynb"
            }
          ]
        }
      }
    },
    "pipelineRun": {
      "id": "91efe9c7-277d-45e2-9d7a-3b9dbadf49fc",
      "outputs": [
        {
          "__typename": "GenericOutput",
          "name": "dhis2_extract.csv",
          "uri": "httsp://google.com"
        },
        {
          "__typename": "BucketObject",
          "key": "all/ChatGPT.log",
          "objectName": "ChatGPT.log",
          "path": "hexa-test-quentin-s-workspace-823946/all/ChatGPT.log",
          "size": 5319,
          "type": "FILE"
        }
      ]
    }
  }
}

```