### PR TITLE
fix(files): Break when we have enough objects (and before loading the next page)

### DIFF
--- a/hexa/files/api.py
+++ b/hexa/files/api.py
@@ -173,7 +173,8 @@ def list_bucket_objects(
             res = _prefix_to_dict(bucket_name, prefix)
             if not ignore_hidden_files or not res["name"].startswith("."):
                 objects.append(res)
-        while len(objects) <= max_items:
+
+        while True:
             for obj in current_page:
                 if _is_dir(obj):
                     # We ignore objects that are directories (object with a size = 0 and ending with a /)
@@ -184,6 +185,11 @@ def list_bucket_objects(
                 if not ignore_hidden_files or not res["name"].startswith("."):
                     objects.append(res)
 
+            if len(objects) >= max_items:
+                # We have enough items, let's break
+                break
+
+            # Otherwise we load the next page and continue our loop
             current_page = next(pages)
 
         return ObjectsPage(


### PR DESCRIPTION
The pagination was broken when the user had a certain number of files in his buckets. It was displayed that no next page existed but it was a LIE.

The problem came from `current_page = next(page)` that was always called and could result in a `StopIteration` error.

## Changes

I check in the loop if we have enough objects and break the loop early
