### PR TITLE
fix(Workspaces): Add the 'workspaces' feature to legacy users invited in a workspace

### DIFF
--- a/hexa/workspaces/tests/test_schema/test_workspace.py
+++ b/hexa/workspaces/tests/test_schema/test_workspace.py
@@ -481,6 +481,7 @@ class WorkspaceTest(GraphQLTestCase):
 
     def test_invite_workspace_member(self):
         self.client.force_login(self.USER_WORKSPACE_ADMIN)
+        self.assertFalse(self.USER_SABRINA.has_feature_flag("workspaces"))
         r = self.run_query(
             """
             mutation inviteWorkspaceMember($input: InviteWorkspaceMemberInput!) {
@@ -518,6 +519,7 @@ class WorkspaceTest(GraphQLTestCase):
         )
 
         self.assertEqual(1, len(mail.outbox))
+        self.assertTrue(self.USER_SABRINA.has_feature_flag("workspaces"))
         self.assertEqual(
             f"You've been added to the workspace {self.WORKSPACE.name}",
             mail.outbox[0].subject,


### PR DESCRIPTION
If a legacy user was invited, the workspaces feature flag was not attached to the user and thus he cannot access the workspace anyway.

This case was handled when inviting external users

## Changes

We check if the feature has to be activated for the user
