### PR TITLE
fix(Workspaces): filter invitations by user and workspace

### DIFF
--- a/hexa/workspaces/schema/types.py
+++ b/hexa/workspaces/schema/types.py
@@ -100,8 +100,10 @@ def resolve_workspace_members(workspace: Workspace, info, **kwargs):
 def resolve_workspace_invitations(workspace: Workspace, info, **kwargs):
     request: HttpRequest = info.context["request"]
 
-    qs = WorkspaceInvitation.objects.filter_for_user(request.user).order_by(
-        "-updated_at"
+    qs = (
+        WorkspaceInvitation.objects.filter_for_user(request.user)
+        .filter(workspace=workspace)
+        .order_by("-updated_at")
     )
     if kwargs.get("status"):
         qs = qs.filter(status=kwargs["status"])

--- a/hexa/workspaces/tests/test_schema/test_workspace.py
+++ b/hexa/workspaces/tests/test_schema/test_workspace.py
@@ -97,6 +97,13 @@ class WorkspaceTest(GraphQLTestCase):
             role=WorkspaceMembershipRole.VIEWER,
             status=WorkspaceInvitationStatus.ACCEPTED,
         )
+        cls.INVITATION_BAZ = WorkspaceInvitation.objects.create(
+            invited_by=cls.USER_WORKSPACE_ADMIN,
+            workspace=cls.WORKSPACE_2,
+            email=cls.USER_REBECCA.email,
+            role=WorkspaceMembershipRole.VIEWER,
+            status=WorkspaceInvitationStatus.ACCEPTED,
+        )
 
     @mock_gcp_storage
     def test_create_workspace_denied(self):
@@ -1207,7 +1214,7 @@ class WorkspaceTest(GraphQLTestCase):
         user = auth.get_user(self.client)
         self.assertTrue(user.is_authenticated)
 
-    def test_get_all_workspace_invitations(self):
+    def test_get_workspace_invitations(self):
         self.client.force_login(self.USER_WORKSPACE_ADMIN)
         r = self.run_query(
             """


### PR DESCRIPTION
Fix bug that allowed user from one workspace to be able to see invitations for others workspaces.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Add filter by workspace and Queryset result.