### PR TITLE
fix(Pipelines): generate random string to avoid pod names collision

### DIFF
--- a/hexa/pipelines/management/commands/pipelines_runner.py
+++ b/hexa/pipelines/management/commands/pipelines_runner.py
@@ -12,11 +12,9 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.core.signing import Signer
 from django.utils import timezone
-from django.utils.crypto import get_random_string
-from slugify import slugify
 
 from hexa.pipelines.models import PipelineRun, PipelineRunState
-from hexa.pipelines.utils import mail_run_recipients
+from hexa.pipelines.utils import generate_pipeline_container_name, mail_run_recipients
 
 logger = getLogger(__name__)
 
@@ -33,10 +31,7 @@ def run_pipeline_kube(run: PipelineRun, env_var: dict):
 
     exec_time_str = timezone.now().replace(tzinfo=None, microsecond=0).isoformat()
     logger.debug("K8S RUN %s: %s for %s", os.getpid(), run.pipeline.name, exec_time_str)
-    suffix = f"-{exec_time_str}-{get_random_string(8)}"
-    container_name = slugify(
-        f"pipeline-{run.pipeline.code}"[: 63 - len(suffix)] + suffix
-    )
+    container_name = generate_pipeline_container_name(run)
 
     pipeline_timeout = (
         run.pipeline_version.timeout

--- a/hexa/pipelines/tests/test_utils.py
+++ b/hexa/pipelines/tests/test_utils.py
@@ -1,0 +1,20 @@
+from unittest.mock import MagicMock
+
+from django.utils.crypto import get_random_string
+
+from hexa.core.test import TestCase
+from hexa.pipelines.utils import generate_pipeline_container_name
+
+
+class PipelineUtilsTest(TestCase):
+    def test_generate_pipeline_container_name(self):
+        run = MagicMock()
+        run.code = get_random_string(50)
+
+        container_name = generate_pipeline_container_name(run)
+        self.assertTrue(len(container_name) <= 63)
+
+        run.code = get_random_string(100)
+
+        container_name = generate_pipeline_container_name(run)
+        self.assertTrue(len(container_name) <= 63)

--- a/hexa/pipelines/utils.py
+++ b/hexa/pipelines/utils.py
@@ -1,6 +1,9 @@
 import datetime
 
+from django.utils import timezone
+from django.utils.crypto import get_random_string
 from django.utils.translation import gettext_lazy
+from slugify import slugify
 
 from config import settings
 from hexa.core.utils import send_mail
@@ -32,3 +35,9 @@ def mail_run_recipients(run: PipelineRun):
         },
         recipient_list=recipient_list,
     )
+
+
+def generate_pipeline_container_name(run: PipelineRun) -> str:
+    exec_time_str = timezone.now().replace(tzinfo=None, microsecond=0).isoformat()
+    suffix = f"-{exec_time_str}-{get_random_string(8)}"
+    return slugify(f"pipeline-{run.pipeline.code}"[: 63 - len(suffix)] + suffix)


### PR DESCRIPTION
Fix for issue about[ pipeline pod names](https://github.com/BLSQ/openhexa-team/issues/530).

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Append random string to pipeline pod name.