### PR TITLE
feat(Datasets): add fileByName on dataset's version, datasets improvements

### DIFF
--- a/hexa/datasets/graphql/schema.graphql
+++ b/hexa/datasets/graphql/schema.graphql
@@ -185,9 +185,11 @@ input CreateDatasetVersionFileInput {
 
 enum CreateDatasetVersionFileError {
   VERSION_NOT_FOUND
+  LOCKED_VERSION
   ALREADY_EXISTS
   INVALID_URI
   PERMISSION_DENIED
+
 }
 
 type CreateDatasetVersionFileResult {

--- a/hexa/datasets/schema/mutations.py
+++ b/hexa/datasets/schema/mutations.py
@@ -188,6 +188,9 @@ def resolve_create_version_file(_, info, **kwargs):
         ):
             raise PermissionDenied
 
+        if version.id != version.dataset.latest_version.id:
+            return {"success": False, "errors": ["LOCKED_VERSION"]}
+
         with transaction.atomic():
             file = None
             try:


### PR DESCRIPTION
- Users can now get files by name from the version
- Only the latest version of a dataset accepts new uploads of files
