### PR TITLE
fix(Databases): get_table_rows has to take the page_size from the db return

### DIFF
--- a/hexa/databases/utils.py
+++ b/hexa/databases/utils.py
@@ -155,7 +155,7 @@ def get_table_rows(
             page=page,
             has_previous=page > 1,
             has_next=len(data) > per_page,
-            items=data[:-1],
+            items=data[:per_page],
         )
     finally:
         if conn:


### PR DESCRIPTION
`get_table_rows` always removed the last item of the items returned by the DB. In case we have the exact number of items, we should not remove the last one and just take the page size requested by the user instead.