### PR TITLE
Fix(Workspaces): don't test for access tokens in resolve_generate_workspace_token

### DIFF
--- a/hexa/workspaces/schema/mutations.py
+++ b/hexa/workspaces/schema/mutations.py
@@ -425,9 +425,6 @@ def resolve_generate_workspace_token(_, info, **kwargs):
     if membership.role == WorkspaceMembershipRole.VIEWER:
         return {"success": False, "errors": ["PERMISSION_DENIED"]}
 
-    if not membership.access_token:
-        membership.generate_access_token()
-
     token = Signer().sign_object(str(membership.access_token))
     return {"success": True, "errors": [], "token": token}
 


### PR DESCRIPTION
The check is not needed anymore, as every membership should always have an access token. Moreover, the `generate_access_token` method does not exist anymore.