### PR TITLE
fix: Do not allow slugs for workspace, datasets & connection to have double dash

### DIFF
--- a/hexa/datasets/models.py
+++ b/hexa/datasets/models.py
@@ -13,7 +13,7 @@ from hexa.user_management.models import User
 def create_dataset_slug(name: str):
     suffix = secrets.token_hex(3)
     prefix = slugify(name[: 64 - 3])
-    return prefix[:23] + "-" + suffix
+    return prefix[:23].rstrip("-") + "-" + suffix
 
 
 class DatasetQuerySet(BaseQuerySet):

--- a/hexa/datasets/tests/test_models.py
+++ b/hexa/datasets/tests/test_models.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.test import override_settings
@@ -85,6 +87,11 @@ class DatasetTest(BaseTestMixin, TestCase):
         self.assertEqual(dataset.created_by, self.USER_EDITOR)
 
         return dataset
+
+    def test_create_dataset_with_double_dash(self):
+        with patch("secrets.token_hex", return_value="123"):
+            dataset = self.test_create_dataset(name="My dataset -- test-")
+        self.assertEqual(dataset.slug, "my-dataset-test-123")
 
     def test_workspace_datasets(self):
         self.test_create_dataset(name="dataset_1", description="description_1")

--- a/hexa/workspaces/models.py
+++ b/hexa/workspaces/models.py
@@ -41,7 +41,7 @@ class AlreadyExists(Exception):
 def create_workspace_slug(name):
     suffix = secrets.token_hex(3)
     prefix = slugify(name[:23])
-    return prefix[:23] + "-" + suffix
+    return prefix[:23].rstrip("-") + "-" + suffix
 
 
 def generate_database_name():
@@ -413,7 +413,7 @@ class ConnectionManager(models.Manager):
 
         # Check if the slug does not already exist
         if not slug:
-            slug = slugify(name)[:40]
+            slug = slugify(name)[:40].rstrip("-")
 
         if self.filter(workspace=workspace, slug=slug).exists():
             # If the slug already exists, we add a random string to it


### PR DESCRIPTION
This is to prevent the creation of slugs like `my-dataset--za21`