### PR TITLE
fix: Use blsq/openhexa-base-notebook:latest by default for pipelines

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -403,7 +403,7 @@ BASE_URL = os.environ.get("BASE_URL", "http://localhost:8000")
 # Pipeline settings
 PIPELINE_SCHEDULER_SPAWNER = os.environ.get("PIPELINE_SCHEDULER_SPAWNER", "kubernetes")
 PIPELINE_API_URL = os.environ.get("PIPELINE_API_URL", BASE_URL)
-PIPELINE_IMAGE = os.environ.get("PIPELINE_IMAGE", "blsq/openhexa-pipelines:latest")
+PIPELINE_IMAGE = os.environ.get("PIPELINE_IMAGE", "blsq/openhexa-base-notebook:latest")
 PIPELINE_DEFAULT_CONTAINER_CPU_LIMIT = os.environ.get(
     "PIPELINE_DEFAULT_CONTAINER_CPU_LIMIT", "2"
 )


### PR DESCRIPTION
We no longer use openhexa-pipelines