### PR TITLE
fix: Fix permission check for dataset download

### DIFF
--- a/hexa/datasets/schema/mutations.py
+++ b/hexa/datasets/schema/mutations.py
@@ -236,7 +236,7 @@ def resolve_version_file_download(_, info, **kwargs):
             ):
                 raise PermissionDenied
         elif not request.user.has_perm(
-            "datasets.download_dataset", file.dataset_version.dataset
+            "datasets.download_dataset_version", file.dataset_version
         ):
             raise PermissionDenied
 

--- a/hexa/datasets/tests/test_schema.py
+++ b/hexa/datasets/tests/test_schema.py
@@ -1,6 +1,9 @@
+from django.conf import settings
 from django.db import IntegrityError
 
 from hexa.core.test import GraphQLTestCase
+from hexa.files.api import create_bucket
+from hexa.files.tests.mocks.mockgcp import mock_gcp_storage
 from hexa.user_management.models import User
 from hexa.workspaces.models import WorkspaceMembershipRole
 
@@ -320,6 +323,11 @@ class DatasetTest(GraphQLTestCase, DatasetTestMixin):
 
 
 class DatasetVersionTest(GraphQLTestCase, DatasetTestMixin):
+    @classmethod
+    @mock_gcp_storage
+    def setUpTestData(cls):
+        create_bucket(settings.WORKSPACE_DATASETS_BUCKET)
+
     def test_create_dataset_version(self):
         superuser = self.create_user("superuser@blsq.com", is_superuser=True)
 
@@ -411,4 +419,56 @@ class DatasetVersionTest(GraphQLTestCase, DatasetTestMixin):
 
         self.assertEqual(
             {"datasetVersion": {"fileByName": {"filename": file.filename}}}, r["data"]
+        )
+
+    @mock_gcp_storage
+    def test_prepare_version_file_download(self):
+        serena = self.create_user("sereba@blsq.org", is_superuser=True)
+        workspace = self.create_workspace(
+            serena,
+            name="My Workspace",
+            description="Test workspace",
+        )
+
+        olivia = self.create_user(
+            "olivia@blsq.org",
+        )
+        self.create_feature_flag(code="datasets", user=olivia)
+        self.join_workspace(
+            olivia, workspace=workspace, role=WorkspaceMembershipRole.ADMIN
+        )
+
+        dataset = self.create_dataset(
+            olivia, workspace, "Dataset", "Dataset description"
+        )
+        dataset_version = self.create_dataset_version(olivia, dataset=dataset)
+        version_file = self.create_dataset_version_file(
+            olivia, dataset_version=dataset_version
+        )
+
+        self.client.force_login(olivia)
+        r = self.run_query(
+            """
+            mutation PrepareVersionFileDownload ($input: PrepareVersionFileDownloadInput!) {
+                prepareVersionFileDownload(input: $input) {
+                    downloadUrl
+                    success
+                    errors
+                }
+            }
+            """,
+            {
+                "input": {
+                    "fileId": str(version_file.id),
+                }
+            },
+        )
+
+        self.assertEqual(
+            {
+                "success": True,
+                "errors": [],
+                "downloadUrl": "http://signed-url/some-uri.csv",
+            },
+            r["data"]["prepareVersionFileDownload"],
         )

--- a/hexa/datasets/tests/testutils.py
+++ b/hexa/datasets/tests/testutils.py
@@ -6,7 +6,7 @@ from hexa.workspaces.models import (
     WorkspaceMembershipRole,
 )
 
-from ..models import Dataset
+from ..models import Dataset, DatasetVersion, DatasetVersionFile
 
 
 class DatasetTestMixin:
@@ -16,6 +16,11 @@ class DatasetTestMixin:
         feature, _ = Feature.objects.get_or_create(code="workspaces")
         FeatureFlag.objects.create(feature=feature, user=user)
         return user
+
+    @staticmethod
+    def create_feature_flag(*, code: str, user: User):
+        feature, _ = Feature.objects.get_or_create(code=code)
+        FeatureFlag.objects.create(feature=feature, user=user)
 
     @mock_gcp_storage
     def create_workspace(self, principal: User, name, description, *args, **kwargs):
@@ -46,3 +51,32 @@ class DatasetTestMixin:
             **kwargs
         )
         return dataset
+
+    @staticmethod
+    def create_dataset_version(
+        principal: User, *, dataset: Dataset, name="v1", description=None, **kwargs
+    ) -> DatasetVersion:
+        return DatasetVersion.objects.create_if_has_perm(
+            principal=principal,
+            dataset=dataset,
+            name=name,
+            description=description,
+            **kwargs
+        )
+
+    @staticmethod
+    def create_dataset_version_file(
+        principal: User,
+        *,
+        dataset_version: DatasetVersion,
+        uri: str = "some-uri.csv",
+        content_type="text/csv",
+        **kwargs
+    ) -> DatasetVersionFile:
+        return DatasetVersionFile.objects.create_if_has_perm(
+            principal=principal,
+            dataset_version=dataset_version,
+            uri=uri,
+            **kwargs,
+            content_type=content_type
+        )

--- a/hexa/files/tests/mocks/blob.py
+++ b/hexa/files/tests/mocks/blob.py
@@ -26,5 +26,8 @@ class MockBlob:
     def updated(self):
         return None
 
+    def generate_signed_url(self, *args, **kwargs):
+        return f"http://signed-url/{self.name}"
+
     def __repr__(self) -> str:
         return f"<MockBlob: {self.name}>"

--- a/hexa/files/tests/mocks/bucket.py
+++ b/hexa/files/tests/mocks/bucket.py
@@ -27,6 +27,9 @@ class MockBucket:
     def list_blobs(self, *args, **kwargs):
         return self.client.list_blobs(self, *args, **kwargs)
 
+    def get_blob(self, blob_name, *args, **kwargs):
+        return MockBlob(blob_name, self)
+
     def blob(self, *args, **kwargs):
         b = MockBlob(*args, bucket=self, **kwargs)
         self._blobs.append(b)


### PR DESCRIPTION
Seems that we weren't using the proper check for the download dataset version file mutation.

## Changes

- Fix permission check
- Add test
- Add missing pieces to the GCS mock setup

## How/what to test

Download dataset files as a viewer.