### PR TITLE
Keep comm with JupyterHub API internal to the Docker network

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -234,7 +234,9 @@ COMMENTS_APP = "hexa.comments"
 
 # Notebooks component
 NOTEBOOKS_URL = os.environ.get("NOTEBOOKS_URL", "http://localhost:8001")
-NOTEBOOKS_API_URL = os.environ.get("NOTEBOOKS_API_URL", "http://localhost:8001/hub/api")
+NOTEBOOKS_API_URL = os.environ.get(
+    "NOTEBOOKS_API_URL", "http://jupyterhub:8000/hub/api"
+)
 HUB_API_TOKEN = os.environ.get("HUB_API_TOKEN", "notatoken")
 
 GRAPHQL_DEFAULT_PAGE_SIZE = 10

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ x-app: &common
       - WORKSPACES_DATABASE_DEFAULT_DB=hexa-app
       - WORKSPACES_DATABASE_PROXY_HOST=db
       - WORKSPACE_DATASETS_BUCKET
-      - NOTEBOOKS_API_URL=http://host.docker.internal:8001/hub/api
+      - NOTEBOOKS_API_URL=http://jupyterhub:8000/hub/api
       - HUB_API_TOKEN=cbb352d6a412e266d7494fb014dd699373645ec8d353e00c7aa9dc79ca87800d
       - GCS_SERVICE_ACCOUNT_KEY
       - WORKSPACE_BUCKET_PREFIX=hexa-test-


### PR DESCRIPTION
When working with Docker (locally), the backend has to communicate with the JupyterHub API. Previously, it used the host URL as JupyterHub is exposed on its port 8001. It is not necessary to go through the host. The communication can be done to the Docker network dedicated to OpenHexa services.

Issue BLSQ/openhexa-team#617