### PR TITLE
chore(Catalog): deprecate datasources views

### DIFF
--- a/hexa/plugins/connector_dhis2/templates/connector_dhis2/instance_detail.html
+++ b/hexa/plugins/connector_dhis2/templates/connector_dhis2/instance_detail.html
@@ -5,25 +5,28 @@
 
 {% block page_content %}
     {{ instance_card }}
-    {% include "comments/components/page_section_comments.html" with object=instance %}
-    {% embed "ui/section/section.html" with title=_("Data Elements") %}
-        {% slot content %}
-            {{ data_element_grid }}
-        {% endslot %}
-    {% endembed %}
-    {% embed "ui/section/section.html" with title=_("Indicators") %}
-        {% slot content %}
-            {{ indicator_grid }}
-        {% endslot %}
-    {% endembed %}
-    {% embed "ui/section/section.html" with title=_("Organisation Units") %}
-        {% slot content %}
-            {{ organisation_unit_grid }}
-        {% endslot %}
-    {% endembed %}
-    {% embed "ui/section/section.html" with title=_("Data sets") %}
-        {% slot content %}
-            {{ dataset_grid }}
-        {% endslot %}
-    {% endembed %}
+    {% comment  %}
+        {% include "comments/components/page_section_comments.html" with object=instance %}
+        {% embed "ui/section/section.html" with title=_("Data Elements") %}
+            {% slot content %}
+                {{ data_element_grid }}
+            {% endslot %}
+        {% endembed %}
+        {% embed "ui/section/section.html" with title=_("Indicators") %}
+            {% slot content %}
+                {{ indicator_grid }}
+            {% endslot %}
+        {% endembed %}
+        {% embed "ui/section/section.html" with title=_("Organisation Units") %}
+            {% slot content %}
+                {{ organisation_unit_grid }}
+            {% endslot %}
+        {% endembed %}
+        {% embed "ui/section/section.html" with title=_("Data sets") %}
+            {% slot content %}
+                {{ dataset_grid }}
+            {% endslot %}
+        {% endembed %}
+    {% endcomment%}
+    
 {% endblock %}

--- a/hexa/plugins/connector_postgresql/templates/connector_postgresql/datasource_detail.html
+++ b/hexa/plugins/connector_postgresql/templates/connector_postgresql/datasource_detail.html
@@ -5,10 +5,13 @@
 
 {% block page_content %}
     {{ database_card }}
-    {% include "comments/components/page_section_comments.html" with object=datasource %}
-    {% embed "ui/section/section.html" with title=_("Tables") %}
-        {% slot content %}
-            {{ table_grid }}
-        {% endslot %}
-    {% endembed %}
+    {% comment %}
+        {% include "comments/components/page_section_comments.html" with object=datasource %}
+        {% embed "ui/section/section.html" with title=_("Tables") %}
+            {% slot content %}
+                {{ table_grid }}
+            {% endslot %}
+        {% endembed %}
+    {% endcomment%}
+  
 {% endblock %}

--- a/hexa/plugins/connector_s3/templates/connector_s3/bucket_detail.html
+++ b/hexa/plugins/connector_s3/templates/connector_s3/bucket_detail.html
@@ -9,35 +9,44 @@
             {% include "catalog/components/data_header_action.html" with url=datasource.sync_url label=_("Sync") icon="refresh" %}
         {% endslot %}
     {% endembed %}
-    {% embed "ui/tabs/tabs.html" with default_tab="content" %}
+    {% embed "ui/tabs/tabs.html" with default_tab="details" %}
         {% slot navigation %}
-            {% include "ui/tabs/tab_nav_item.html" with label=_("Content") id="content" %}
+            {% comment %}
+                {% include "ui/tabs/tab_nav_item.html" with label=_("Content") id="content" %}
+            {% endcomment %}
             {% include "ui/tabs/tab_nav_item.html" with label=_("Details") id="details" %}
             {% blocktranslate asvar comment_label with count=datasource.index.comment_set.count %}
                 Comments ({{ count }})
             {% endblocktranslate %}
-            {% include "ui/tabs/tab_nav_item.html" with label=comment_label id="comments" %}
+            {% comment %}
+                {% include "ui/tabs/tab_nav_item.html" with label=comment_label id="comments" %}
+            {% endcomment %}
             {% include "ui/tabs/tab_nav_item.html" with label=_("Usage") id="usage" %}
         {% endslot %}
         {% slot tabs %}
             {# Content tab #}
-            {% embed "ui/tabs/tab.html" with id="content" %}
-                {% slot content %}
-                    {{ object_grid }}
-                {% endslot %}
-            {% endembed %}
+            {% comment %}
+                {% embed "ui/tabs/tab.html" with id="content" %}
+                    {% slot content %}
+                        {{ object_grid }}
+                    {% endslot %}
+                {% endembed %}
+            {% endcomment %}
             {# Metadata tab #}
             {% embed "ui/tabs/tab.html" with id="details" %}
                 {% slot content %}
                     {{ bucket_card }}
                 {% endslot %}
             {% endembed %}
-            {# Comments tab #}
-            {% embed "ui/tabs/tab.html" with id="comments" %}
-                {% slot content %}
-                    {% include "comments/components/page_section_comments.html" with object=datasource %}
-                {% endslot %}
-            {% endembed %}
+            {% comment %}
+                {# Comments tab #}
+                {% embed "ui/tabs/tab.html" with id="comments" %}
+                    {% slot content %}
+                        {% include "comments/components/page_section_comments.html" with object=datasource %}
+                    {% endslot %}
+                {% endembed %}
+
+            {% endcomment %}
             {# Usage tab #}
             {% embed "ui/tabs/tab.html" with id="usage" %}
                 {% slot content %}


### PR DESCRIPTION
Step 1 : remove datasources elements views (e.g : org_unit, indicator)

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Remove datasources views (only keeping datasource card for now) and details.
- Delete connector_iaso folder.

## How/what to test

A few words about what needs to be tested, along with specific testing instructions if needed.

## Screenshots / screencast

If relevant, please add some screenshots or a short video.