### PR TITLE
fix: remove django-tailwind commands and adapt documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Other commands are available:
   manage            : run django manage.py
   fixtures          : migrate, create superuser, load fixtures and reindex
   bash              : run bash
-  tailwind          : run tailwind browser-sync
   coveraged-test    : launch django tests and show a coverage report
 
   Any arguments passed will be forwarded to the executed command
@@ -76,8 +75,6 @@ cp .env.dist .env
 docker network create openhexa
 docker compose build
 docker compose run app fixtures
-docker compose run app manage tailwind install
-docker compose run app manage tailwind build
 docker compose up
 ```
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -358,10 +358,7 @@ SAVE_REQUESTS = os.environ.get("SAVE_REQUESTS") == "true"
 if os.environ.get("DEBUG_TOOLBAR", "false") == "true":
     INSTALLED_APPS.append("debug_toolbar")
     MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
-    # Django Tailwind and Django Debug Toolbar specifically ask for INTERNAL_IPS to be set
-    # https://django-tailwind.readthedocs.io/en/latest/installation.html
-    # > Make sure that the INTERNAL_IPS list is present in the settings.py
-    # > file and contains the 127.0.0.1 ip address
+    # Django Debug Toolbar specifically ask for INTERNAL_IPS to be set
     INTERNAL_IPS = ["127.0.0.1"]
 
     DEBUG_TOOLBAR_CONFIG = {

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,7 +22,6 @@ show_help() {
   manage            : run django manage.py
   fixtures          : migrate, create superuser, load fixtures and reindex
   bash              : run bash
-  tailwind          : run tailwind browser-sync
   coveraged-test    : launch django tests and show a coverage report
 
   Any arguments passed will be forwarded to the executed command


### PR DESCRIPTION
We recently removed django-tailwind from this component (we still have tailwind classes and a CSS file generated using django-tailwind but it has been included as a static asset and won't change anymore).

This PR addresses a few leftovers.

## Changes

- Removed django-tailwind commands from entrypoint
- Adapt documentation

## How/what to test

Follow local setup instructions and make sure everything works.