### PR TITLE
fix: logout handling for Django 5

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -234,9 +234,7 @@ COMMENTS_APP = "hexa.comments"
 
 # Notebooks component
 NOTEBOOKS_URL = os.environ.get("NOTEBOOKS_URL", "http://localhost:8001")
-NOTEBOOKS_API_URL = os.environ.get(
-    "NOTEBOOKS_API_URL", "http://jupyterhub:8000/hub/api"
-)
+NOTEBOOKS_HUB_URL = os.environ.get("NOTEBOOKS_HUB_URL", "http://jupyterhub:8000/hub")
 HUB_API_TOKEN = os.environ.get("HUB_API_TOKEN", "notatoken")
 
 GRAPHQL_DEFAULT_PAGE_SIZE = 10

--- a/config/urls.py
+++ b/config/urls.py
@@ -16,10 +16,10 @@ Including another URLconf
 from ariadne_django.views import GraphQLView
 from django.conf import settings
 from django.contrib import admin
-from django.contrib.auth import views as auth_views
 from django.urls import include, path, re_path
 
 from hexa.app import get_hexa_app_configs
+from hexa.user_management.views import LogoutView
 
 from .schema import schema
 
@@ -44,7 +44,7 @@ urlpatterns = [
     # TODO: use API (https://github.com/jupyterhub/jupyterhub/issues/3688)
     path(
         "auth/logout/",
-        auth_views.LogoutView.as_view(next_page=f"{settings.NOTEBOOKS_URL}/hub/logout"),
+        LogoutView.as_view(),
         name="logout",
     ),
     path("auth/", include("django.contrib.auth.urls")),

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ x-app: &common
       - WORKSPACES_DATABASE_DEFAULT_DB=hexa-app
       - WORKSPACES_DATABASE_PROXY_HOST=db
       - WORKSPACE_DATASETS_BUCKET
-      - NOTEBOOKS_API_URL=http://jupyterhub:8000/hub/api
+      - NOTEBOOKS_HUB_URL=http://jupyterhub:8000/hub
       - HUB_API_TOKEN=cbb352d6a412e266d7494fb014dd699373645ec8d353e00c7aa9dc79ca87800d
       - GCS_SERVICE_ACCOUNT_KEY
       - WORKSPACE_BUCKET_PREFIX=hexa-test-

--- a/hexa/notebooks/api.py
+++ b/hexa/notebooks/api.py
@@ -6,7 +6,7 @@ from django.conf import settings
 
 def get_user(username: str) -> typing.Optional[typing.Mapping[str, typing.Any]]:
     user_response = requests.get(
-        f"{settings.NOTEBOOKS_API_URL}/users/{username}",
+        f"{settings.NOTEBOOKS_HUB_URL}/api/users/{username}",
         headers={"Authorization": f"token {settings.HUB_API_TOKEN}"},
     )
     if user_response.status_code == 404:
@@ -18,7 +18,7 @@ def get_user(username: str) -> typing.Optional[typing.Mapping[str, typing.Any]]:
 
 def create_user(username: str):
     user_response = requests.post(
-        f"{settings.NOTEBOOKS_API_URL}/users/{username}",
+        f"{settings.NOTEBOOKS_HUB_URL}/api/users/{username}",
         headers={"Authorization": f"token {settings.HUB_API_TOKEN}"},
     )
     user_response.raise_for_status()
@@ -26,7 +26,7 @@ def create_user(username: str):
 
 def create_server(username: str, server_name: str, cookies: typing.Mapping[str, str]):
     server_response = requests.post(
-        f"{settings.NOTEBOOKS_API_URL}/users/{username}/servers/{server_name}",
+        f"{settings.NOTEBOOKS_HUB_URL}/api/users/{username}/servers/{server_name}",
         headers={"Authorization": f"token {settings.HUB_API_TOKEN}"},
         cookies=cookies,
     )
@@ -35,7 +35,7 @@ def create_server(username: str, server_name: str, cookies: typing.Mapping[str, 
 
 def server_ready(username: str, server_name: str = "") -> bool:
     r = requests.get(
-        f"{settings.NOTEBOOKS_API_URL}/users/{username}",
+        f"{settings.NOTEBOOKS_HUB_URL}/api/users/{username}",
         headers={"Authorization": f"token {settings.HUB_API_TOKEN}"},
     )
     r.raise_for_status()

--- a/hexa/notebooks/tests/test_schema.py
+++ b/hexa/notebooks/tests/test_schema.py
@@ -108,18 +108,18 @@ class NotebooksTest(GraphQLTestCase):
 
     @responses.activate
     def test_launch_workspace_notebook_create_user_failed(self):
-        with self.settings(NOTEBOOKS_API_URL="http://localhost:8081"):
+        with self.settings(NOTEBOOKS_HUB_URL="http://localhost:8081"):
             self.client.force_login(self.USER_JULIA)
             responses.add(
                 responses.GET,
-                f"{settings.NOTEBOOKS_API_URL}/users/{self.USER_JULIA.email}",
+                f"{settings.NOTEBOOKS_HUB_URL}/api/users/{self.USER_JULIA.email}",
                 json={},
                 status=404,
                 headers="",
             )
             responses.add(
                 responses.POST,
-                f"{settings.NOTEBOOKS_API_URL}/users/{self.USER_JULIA.email}",
+                f"{settings.NOTEBOOKS_HUB_URL}/api/users/{self.USER_JULIA.email}",
                 json={},
                 status=500,
                 headers="",
@@ -139,25 +139,25 @@ class NotebooksTest(GraphQLTestCase):
 
     @responses.activate
     def test_launch_workspace_notebook_create_server_failed(self):
-        with self.settings(NOTEBOOKS_API_URL="http://localhost:8081"):
+        with self.settings(NOTEBOOKS_HUB_URL="http://localhost:8081"):
             self.client.force_login(self.USER_JULIA)
             responses.add(
                 responses.GET,
-                f"{settings.NOTEBOOKS_API_URL}/users/{self.USER_JULIA.email}",
+                f"{settings.NOTEBOOKS_HUB_URL}/api/users/{self.USER_JULIA.email}",
                 json={},
                 status=404,
                 headers="",
             )
             responses.add(
                 responses.POST,
-                f"{settings.NOTEBOOKS_API_URL}/users/{self.USER_JULIA.email}",
+                f"{settings.NOTEBOOKS_HUB_URL}/api/users/{self.USER_JULIA.email}",
                 json={"servers": {}},
                 status=201,
                 headers="",
             )
             responses.add(
                 responses.POST,
-                f"{settings.NOTEBOOKS_API_URL}/users/{self.USER_JULIA.email}/servers/{self.WORKSPACE.slug}",
+                f"{settings.NOTEBOOKS_HUB_URL}/api/users/{self.USER_JULIA.email}/servers/{self.WORKSPACE.slug}",
                 json={},
                 status=500,
                 headers="",
@@ -182,14 +182,14 @@ class NotebooksTest(GraphQLTestCase):
     @responses.activate
     def test_launch_workspace_notebook(self):
         with self.settings(
-            NOTEBOOKS_API_URL="http://localhost:8081",
+            NOTEBOOKS_HUB_URL="http://localhost:8081",
             NOTEBOOKS_URL="http://localhost:8000",
         ):
             self.client.force_login(self.USER_JULIA)
             # First GET user -> 404
             responses.add(
                 responses.GET,
-                f"{settings.NOTEBOOKS_API_URL}/users/{self.USER_JULIA.email}",
+                f"{settings.NOTEBOOKS_HUB_URL}/api/users/{self.USER_JULIA.email}",
                 json={},
                 status=404,
                 headers="",
@@ -197,21 +197,21 @@ class NotebooksTest(GraphQLTestCase):
             # Create user
             responses.add(
                 responses.POST,
-                f"{settings.NOTEBOOKS_API_URL}/users/{self.USER_JULIA.email}",
+                f"{settings.NOTEBOOKS_HUB_URL}/api/users/{self.USER_JULIA.email}",
                 status=201,
                 headers="",
             )
             # Create server
             responses.add(
                 responses.POST,
-                f"{settings.NOTEBOOKS_API_URL}/users/{self.USER_JULIA.email}/servers/{self.WORKSPACE.slug}",
+                f"{settings.NOTEBOOKS_HUB_URL}/api/users/{self.USER_JULIA.email}/servers/{self.WORKSPACE.slug}",
                 status=202,
                 headers="",
             )
             # Second GET user (after creation) -> ok but no server
             responses.add(
                 responses.GET,
-                f"{settings.NOTEBOOKS_API_URL}/users/{self.USER_JULIA.email}",
+                f"{settings.NOTEBOOKS_HUB_URL}/api/users/{self.USER_JULIA.email}",
                 json={"servers": {}},
                 status=200,
                 headers="",
@@ -219,7 +219,7 @@ class NotebooksTest(GraphQLTestCase):
             # Third GET user (for server_ready) -> ok, server not ready
             responses.add(
                 responses.GET,
-                f"{settings.NOTEBOOKS_API_URL}/users/{self.USER_JULIA.email}",
+                f"{settings.NOTEBOOKS_HUB_URL}/api/users/{self.USER_JULIA.email}",
                 json={"servers": {self.WORKSPACE.slug: {"ready": False}}},
                 status=200,
                 headers="",
@@ -227,7 +227,7 @@ class NotebooksTest(GraphQLTestCase):
             # Fourth GET user (second mutation call) -> ok, ready
             responses.add(
                 responses.GET,
-                f"{settings.NOTEBOOKS_API_URL}/users/{self.USER_JULIA.email}",
+                f"{settings.NOTEBOOKS_HUB_URL}/api/users/{self.USER_JULIA.email}",
                 json={"servers": {self.WORKSPACE.slug: {"ready": True}}},
                 status=200,
                 headers="",
@@ -235,7 +235,7 @@ class NotebooksTest(GraphQLTestCase):
             # Fifth GET user (second mutation call, for server_ready) -> ok, ready
             responses.add(
                 responses.GET,
-                f"{settings.NOTEBOOKS_API_URL}/users/{self.USER_JULIA.email}",
+                f"{settings.NOTEBOOKS_HUB_URL}/api/users/{self.USER_JULIA.email}",
                 json={"servers": {self.WORKSPACE.slug: {"ready": True}}},
                 status=200,
                 headers="",

--- a/hexa/user_management/tests/test_views.py
+++ b/hexa/user_management/tests/test_views.py
@@ -1,5 +1,6 @@
 from unittest import skip
 
+import responses
 from django import test
 from django.conf import settings
 from django.urls import reverse
@@ -30,13 +31,20 @@ class ViewsTest(TestCase):
 
         self.assertEqual(response.status_code, 302)
 
+    @responses.activate
     def test_logout_302(self):
+        responses.add(
+            responses.GET,
+            f"{settings.NOTEBOOKS_HUB_URL}/logout",
+            status=302,
+        )
+
         self.client.login(email="john@bluesquarehub.com", password="regular")
         response = self.client.post(reverse("logout"))
 
         # Check that the response is temporary redirection to JupyterHub logout.
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, f"{settings.NOTEBOOKS_URL}/hub/logout")
+        self.assertEqual(response.url, "/login")
 
     def test_graphql_anonymous(self):
         response = self.client.get(reverse("graphql"))

--- a/hexa/user_management/views.py
+++ b/hexa/user_management/views.py
@@ -1,3 +1,6 @@
+import requests
+from django.conf import settings
+from django.contrib.auth.views import LogoutView as BaseLogoutView
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -11,3 +14,16 @@ def accept_tos(request: HttpRequest) -> HttpResponse:
         request.user.save()
 
     return redirect(reverse("core:login"))
+
+
+class LogoutView(BaseLogoutView):
+    def post(self, request, *args, **kwargs):
+        response = super().post(request, *args, **kwargs)
+        hub_response = requests.get(
+            f"{settings.NOTEBOOKS_HUB_URL}/logout",
+            cookies={"sessionid": request.session.session_key},
+            allow_redirects=False,
+        )
+        hub_response.raise_for_status()
+
+        return response


### PR DESCRIPTION
This PR simplifies logout by integrating the jupyterhub logout call in the logout view.

This allows us to logout through a simple POST request from the frontend (POST is required since Django 5) without any CORS issues caused by a redirection chain.

## Changes

- Add a custom `LogoutView` that performs a `GET` logout request on Jupyterhub
- Replaced `NOTEBOOKS_API_URL` by `NOTEBOOKS_HUB_URL` (used both for API calls and logout)

## How/what to test

- Login
- Logout (in legacy, in workspace menu, on account page...)