### PR TITLE
fix(Notebooks): Logout the user from jupyterhub on logout

### DIFF
--- a/hexa/user_management/views.py
+++ b/hexa/user_management/views.py
@@ -2,16 +2,23 @@ import requests
 from django.conf import settings
 from django.contrib.auth.views import LogoutView as BaseLogoutView
 from django.http import HttpRequest, HttpResponse
+from django.middleware.csrf import get_token
+from sentry_sdk import capture_exception
 
 
 class LogoutView(BaseLogoutView):
     def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
-        response = super().post(request, *args, **kwargs)
-        hub_response = requests.get(
-            f"{settings.NOTEBOOKS_HUB_URL}/logout",
-            cookies={"sessionid": request.session.session_key},
-            allow_redirects=False,
-        )
-        hub_response.raise_for_status()
-
-        return response
+        try:
+            hub_response = requests.get(
+                f"{settings.NOTEBOOKS_HUB_URL}/logout",
+                cookies={
+                    "sessionid": request.session.session_key,
+                    "csrftoken": get_token(request),
+                },
+                allow_redirects=False,
+            )
+            hub_response.raise_for_status()
+        except requests.HTTPError as e:
+            capture_exception(e)
+        finally:
+            return super().post(request, *args, **kwargs)


### PR DESCRIPTION
We call jupyterhub before logging out the user to also log him out of the hub. 