### PR TITLE
Fix int overflow in the schema

### DIFF
--- a/config/graphql/schema.graphql
+++ b/config/graphql/schema.graphql
@@ -4,6 +4,6 @@ scalar URL
 scalar JSON
 scalar UUID
 scalar Generic
-
+scalar BigInt
 type Query
 type Mutation

--- a/hexa/files/graphql/schema.graphql
+++ b/hexa/files/graphql/schema.graphql
@@ -12,7 +12,7 @@ type BucketObject {
   key: String!
   name: String!
   path: String!
-  size: Int
+  size: BigInt
   updatedAt: DateTime
   type: BucketObjectType!
 }


### PR DESCRIPTION
The size of workspace's objects can be bigger than an 32bit int.
