### PR TITLE
fix(datasets): Allow pipelines to download linked datasets

### DIFF
--- a/hexa/core/test/cases.py
+++ b/hexa/core/test/cases.py
@@ -5,6 +5,7 @@ from django import test
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 
+from hexa.pipelines.authentication import PipelineRunUser
 from hexa.plugins.connector_airflow.authentication import DAGRunUser
 from hexa.user_management.models import User
 from hexa.user_management.tests.cases import TwoFactorClient
@@ -23,7 +24,9 @@ class TestCase(test.TestCase):
         return _pre_setup
 
     @staticmethod
-    def mock_request(user: typing.Union[AnonymousUser, User, DAGRunUser]):
+    def mock_request(
+        user: typing.Union[AnonymousUser, User, DAGRunUser, PipelineRunUser],
+    ):
         request = HttpRequest()
         request.user = user
         request.session = {}

--- a/hexa/datasets/schema/mutations.py
+++ b/hexa/datasets/schema/mutations.py
@@ -228,14 +228,9 @@ def resolve_version_file_download(_, info, **kwargs):
         file = DatasetVersionFile.objects.filter_for_user(request.user).get(
             id=mutation_input["fileId"]
         )
-        # FIXME: Use a generic permission system instead of differencing between User and PipelineRunUser
-        if isinstance(request.user, PipelineRunUser):
-            if (
-                request.user.pipeline_run.pipeline.workspace
-                != file.dataset_version.dataset.workspace
-            ):
-                raise PermissionDenied
-        elif not request.user.has_perm(
+        # We only get the file if the user or pipeline can see the dataset either by direct access or via a link.
+        # FIXME: Implement a better permission system to be able to check if the pipeline can download the file.
+        if not isinstance(request.user, PipelineRunUser) and not request.user.has_perm(
             "datasets.download_dataset_version", file.dataset_version
         ):
             raise PermissionDenied


### PR DESCRIPTION
The pipeline is a specific type of user (unfortunately) and don't have the permission mechanic. Since we already get the file based on the workspace links, we are safe to only assert that the file is not None in case of a pipeline run user.
