### PR TITLE
chore(GCP): Set the workspace as a label on the bucket of the workspace

### DIFF
--- a/hexa/files/basefs.py
+++ b/hexa/files/basefs.py
@@ -35,7 +35,7 @@ class BaseClient(ABC):
         NotFound = NotFound
 
     @abstractmethod
-    def create_bucket(self, bucket_name: str):
+    def create_bucket(self, bucket_name: str, *args, **kwargs):
         pass
 
     @abstractmethod

--- a/hexa/files/gcp.py
+++ b/hexa/files/gcp.py
@@ -84,11 +84,11 @@ def ensure_is_folder(object_key: str):
 
 
 class GCPClient(BaseClient):
-    def create_bucket(self, bucket_name: str):
+    def create_bucket(self, bucket_name: str, labels: dict = None, *args, **kwargs):
         client = get_storage_client()
         try:
             bucket = client.create_bucket(
-                bucket_name, location=settings.WORKSPACE_BUCKET_REGION
+                bucket_name, location=settings.WORKSPACE_BUCKET_REGION, labels=labels
             )
             bucket.storage_class = "STANDARD"  # Default storage class
 
@@ -128,6 +128,7 @@ class GCPClient(BaseClient):
                     "condition": {"isLive": False, "numNewerVersions": 3},
                 },
             ]
+
             bucket.cors = [
                 {
                     "origin": settings.CORS_ALLOWED_ORIGINS,

--- a/hexa/files/s3.py
+++ b/hexa/files/s3.py
@@ -110,7 +110,7 @@ def _get_bucket_object(bucket_name: str, object_key: str):
 
 
 class S3Client(BaseClient):
-    def create_bucket(self, bucket_name: str):
+    def create_bucket(self, bucket_name: str, *args, **kwargs):
         s3 = get_storage_client()
         try:
             s3.create_bucket(

--- a/hexa/files/tests/mocks/bucket.py
+++ b/hexa/files/tests/mocks/bucket.py
@@ -9,9 +9,10 @@ class MockBucket:
     versioning_enabled = False
     lifecycle_rules = []
 
-    def __init__(self, client, name=None, user_project=None):
+    def __init__(self, client, name=None, user_project=None, labels: dict = None):
         name = _validate_name(name)
         self.name = name
+        self.labels = labels or {}
         self._client = client
         self._user_project = user_project
         self._blobs = []

--- a/hexa/files/tests/mocks/client.py
+++ b/hexa/files/tests/mocks/client.py
@@ -185,13 +185,16 @@ class MockClient:
         except NotFound:
             return None
 
-    def create_bucket(self, bucket_or_name=None, Bucket=None, *args, **kwargs):
+    def create_bucket(
+        self, bucket_or_name=None, Bucket=None, labels=None, *args, **kwargs
+    ):
         bucket_or_name = bucket_or_name or Bucket
         bucket = self._bucket_arg_to_bucket(bucket_or_name)
         if bucket is None:
             bucket = MockBucket(
                 client=self,
                 name=bucket_or_name,
+                labels=labels,
             )
 
         if bucket.name in self.backend.buckets.keys():

--- a/hexa/files/tests/test_api.py
+++ b/hexa/files/tests/test_api.py
@@ -363,6 +363,10 @@ class OnlyGCP:
         )
         self.assertEqual(bucket.storage_class, "STANDARD")
 
+    def test_create_bucket_labels(self):
+        bucket = self.get_client().create_bucket("bucket", labels={"key": "value"})
+        self.assertEqual(bucket.labels, {"key": "value"})
+
 
 class OnlyS3:
     def test_generate_upload_url_raise_existing_dont_raise(self):

--- a/hexa/workspaces/models.py
+++ b/hexa/workspaces/models.py
@@ -96,7 +96,9 @@ class WorkspaceManager(models.Manager):
         create_kwargs["db_name"] = db_name
         create_database(db_name, db_password)
 
-        bucket = get_storage().create_bucket(settings.WORKSPACE_BUCKET_PREFIX + slug)
+        bucket = get_storage().create_bucket(
+            settings.WORKSPACE_BUCKET_PREFIX + slug, labels={"hexa-workspace": slug}
+        )
         create_kwargs["bucket_name"] = bucket.name
 
         if load_sample_data:


### PR DESCRIPTION
The goal is to be able to easily know on the billing export on GCP which workspace consume what