### PR TITLE
fix(Datasets): use dataset last version to track update

### DIFF
--- a/hexa/datasets/schema/types.py
+++ b/hexa/datasets/schema/types.py
@@ -101,6 +101,15 @@ def resolve_dataset_permissions(obj: Dataset, info, **kwargs):
     return obj
 
 
+@dataset_object.field("updatedAt")
+def resolve_dataset_updated_at(obj: Dataset, info, **kwargs):
+    return (
+        max(obj.updated_at, obj.latest_version.updated_at)
+        if obj.latest_version
+        else obj.updated_at
+    )
+
+
 @dataset_link_object.field("permissions")
 def resolve_dataset_link_permissions(obj: DatasetLink, info, **kwargs):
     return obj


### PR DESCRIPTION
Last updated should match the date of the version upload, [see](https://bluesquare.atlassian.net/jira/software/c/projects/HEXA/boards/330?assignee=712020%3A1d0055ff-af59-47b7-b48d-4d37e2a0d0b9&selectedIssue=HEXA-995). 

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Return dataset last_version updated_at field if it exists.
