### PR TITLE
fix(CORS): Allow objects to be uploaded & download from everywhere

### DIFF
--- a/hexa/files/gcp.py
+++ b/hexa/files/gcp.py
@@ -133,17 +133,10 @@ class GCPClient(BaseClient):
 
             bucket.cors = [
                 {
-                    "origin": settings.CORS_ALLOWED_ORIGINS,
-                    "responseHeader": [
-                        "Authorization",
-                        "Content-Range",
-                        "Accept",
-                        "Content-Type",
-                        "Origin",
-                        "Range",
-                    ],
-                    "method": ["GET", "PUT"],
+                    "origin": ["*"],
+                    "method": ["*"],
                     "maxAgeSeconds": 3600,
+                    "responseHeader": ["*"],
                 }
             ]
             bucket.patch()

--- a/hexa/files/s3.py
+++ b/hexa/files/s3.py
@@ -117,31 +117,14 @@ class S3Client(BaseClient):
                 Bucket=bucket_name,
                 CreateBucketConfiguration={"LocationConstraint": default_region},
             )
-
             # Define the configuration rules
             cors_configuration = {
                 "CORSRules": [
                     {
-                        "AllowedHeaders": [
-                            "Authorization",
-                            "Content-Range",
-                            "Accept",
-                            "Content-Type",
-                            "Origin",
-                            "Range",
-                        ],
+                        "AllowedHeaders": ["*"],
                         "AllowedMethods": ["GET", "PUT"],
-                        "AllowedOrigins": settings.CORS_ALLOWED_ORIGINS,
-                        "ExposeHeaders": [
-                            "ETag",
-                            "x-amz-request-id",
-                            "Authorization",
-                            "Content-Range",
-                            "Accept",
-                            "Content-Type",
-                            "Origin",
-                            "Range",
-                        ],
+                        "AllowedOrigins": ["*"],
+                        "ExposeHeaders": ["*"],
                         "MaxAgeSeconds": 3000,
                     }
                 ]


### PR DESCRIPTION
Having CORS on every buckets prevent customers to use work with signed urls in their frontend applications