### PR TITLE
fix(Analytics): add support for PipelineRunUser and Ano

### DIFF
--- a/hexa/analytics/api.py
+++ b/hexa/analytics/api.py
@@ -62,7 +62,7 @@ def track(
 
 
 def set_user_properties(user: User):
-    if mixpanel is None or user.analytics_enabled is False:
+    if mixpanel is None or user is None or user.analytics_enabled is False:
         return
 
     try:

--- a/hexa/analytics/middlewares.py
+++ b/hexa/analytics/middlewares.py
@@ -3,6 +3,7 @@ from typing import Callable
 from django.http import HttpRequest, HttpResponse
 
 from hexa.analytics.api import set_user_properties
+from hexa.pipelines.authentication import PipelineRunUser
 
 
 def set_analytics_middleware(
@@ -13,7 +14,12 @@ def set_analytics_middleware(
     def middleware(request: HttpRequest) -> HttpResponse:
         response = get_response(request)
         if getattr(request, "user") and request.user.is_authenticated:
-            set_user_properties(request.user)
+            tracked_user = (
+                request.user.pipeline_run.user
+                if isinstance(request.user, PipelineRunUser)
+                else request.user
+            )
+            set_user_properties(tracked_user)
         return response
 
     return middleware

--- a/hexa/analytics/tests/test_analytics.py
+++ b/hexa/analytics/tests/test_analytics.py
@@ -66,7 +66,7 @@ class AnalyticsTest(TestCase):
         self.USER.save()
 
         mixpanel_token = "token"
-        # mock the flush method of the BufferedConsumer
+
         with self.settings(MIXPANEL_TOKEN=mixpanel_token):
             request = self.factory.post("/dataset")
             request.headers = {
@@ -119,7 +119,7 @@ class AnalyticsTest(TestCase):
         mock_mixpanel,
     ):
         mixpanel_token = "token"
-        # mock the flush method of the BufferedConsumer
+
         with self.settings(MIXPANEL_TOKEN=mixpanel_token):
             self.PIPELINE.run(
                 user=None,
@@ -147,8 +147,11 @@ class AnalyticsTest(TestCase):
         mock_mixpanel,
     ):
         mixpanel_token = "token"
-        # mock the flush method of the BufferedConsumer
+
         with self.settings(MIXPANEL_TOKEN=mixpanel_token):
+            self.USER.analytics_enabled = True
+            self.USER.save()
+
             set_user_properties(self.USER)
 
             mock_mixpanel.people_set.assert_called_once_with(
@@ -161,3 +164,27 @@ class AnalyticsTest(TestCase):
                     "features_flag": [],
                 },
             )
+
+    @mock.patch("hexa.analytics.api.mixpanel")
+    def test_create_user_profile_none(
+        self,
+        mock_mixpanel,
+    ):
+        mixpanel_token = "token"
+
+        with self.settings(MIXPANEL_TOKEN=mixpanel_token):
+            set_user_properties(None)
+            mock_mixpanel.assert_not_called()
+
+    @mock.patch("hexa.analytics.api.mixpanel")
+    def test_create_user_profile_analytics_disabled(
+        self,
+        mock_mixpanel,
+    ):
+        mixpanel_token = "token"
+        self.USER.analytics_enabled = False
+        self.USER.save()
+
+        with self.settings(MIXPANEL_TOKEN=mixpanel_token):
+            set_user_properties(self.USER)
+            mock_mixpanel.assert_not_called()


### PR DESCRIPTION
The set_user_properties didn't check if User is defined before checking if the analytics are enabled, and  PipelineRunUser was not taken into account.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Retrieve the concrete user on analytics_middleware if user is an instance of PipelineRunUser model.
-  Check if user is defined on set_user_properties.
