### PR TITLE
fix(analytics): PipelineRunUser should be excluded

### DIFF
--- a/hexa/analytics/tests/test_analytics.py
+++ b/hexa/analytics/tests/test_analytics.py
@@ -137,9 +137,7 @@ class AnalyticsTest(TestCase):
             }
 
             track(None, event, properties)
-            mock_mixpanel.track.assert_called_once_with(
-                distinct_id=None, event_name=event, properties=properties
-            )
+            mock_mixpanel.track.assert_not_called()
 
     @mock.patch("hexa.analytics.api.mixpanel")
     def test_create_user_profile(


### PR DESCRIPTION
In the case of pipelines, the user of the request is an instance of `PipelineRunUser`. In this situation, we do not have the `analytics_enabled` flag on it