### PR TITLE
Fix pipeline run user perms

### DIFF
--- a/hexa/analytics/urls.py
+++ b/hexa/analytics/urls.py
@@ -5,5 +5,5 @@ from . import views
 app_name = "analytics"
 
 urlpatterns = [
-    path("track", views.track_event, name="track"),
+    path("track/", views.track_event, name="track"),
 ]

--- a/hexa/datasets/schema/mutations.py
+++ b/hexa/datasets/schema/mutations.py
@@ -19,13 +19,9 @@ def resolve_create_dataset(_, info, **kwargs):
     mutation_input = kwargs["input"]
 
     try:
-        # FIXME: Use a generic permission system instead of differencing between User and PipelineRunUser
-        if isinstance(request.user, PipelineRunUser):
-            workspace = request.user.pipeline_run.pipeline.workspace
-        else:
-            workspace = Workspace.objects.filter_for_user(request.user).get(
-                slug=mutation_input["workspaceSlug"]
-            )
+        workspace = Workspace.objects.filter_for_user(request.user).get(
+            slug=mutation_input["workspaceSlug"]
+        )
         dataset = Dataset.objects.create_if_has_perm(
             principal=request.user,
             workspace=workspace,

--- a/hexa/pipelines/signals.py
+++ b/hexa/pipelines/signals.py
@@ -1,7 +1,7 @@
 from corsheaders.signals import check_request_enabled
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
-from django.urls import ResolverMatch, resolve
+from django.urls import NoReverseMatch, resolve
 
 from hexa.workspaces.models import WorkspaceMembership
 
@@ -27,5 +27,5 @@ def cors_allow_pipeline_run(sender, request, **kwargs):
     try:
         match = resolve(request.path)
         return match.view_name in ("pipelines:run", "pipelines:run_with_version")
-    except ResolverMatch:
+    except NoReverseMatch:
         return False

--- a/hexa/workspaces/models.py
+++ b/hexa/workspaces/models.py
@@ -122,7 +122,7 @@ class WorkspaceQuerySet(BaseQuerySet):
         if isinstance(user, PipelineRunUser):
             return self._filter_for_user_and_query_object(
                 user,
-                Q(workspace=user.pipeline_run.pipeline.workspace, archived=False),
+                Q(id=user.pipeline_run.pipeline.workspace.id, archived=False),
                 return_all_if_superuser=False,
             )
         else:


### PR DESCRIPTION
- The filtering clause set in the `filter_for_user` to handle the PipelineRunUser users was incorrect.
- Analytics endpoint should end with a trailing slash
