### PR TITLE
Make the Docker image "rootless"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,8 @@ jobs:
         run: docker compose build --build-arg DJANGO_SETTINGS_MODULE="config.settings.dev"
 
       - name: Run Django tests
-        run: docker compose run -e DEBUG=false app coveraged-test
+        run: |
+          docker compose run -e DEBUG=false -u $(id -u):$(id -g) app coveraged-test
 
       # Push on main
       - name: Build and push (on main)


### PR DESCRIPTION
The previous image set root as the default user. This means that a process has the root rights and can create files with this id in a mounted volume from the host. This is a common attack vector.

## Changes

With the present change, the container will run under a normal user `openhexa` without any root permission.

Noticed that doesn't make Docker rootless. This requires to prepare the Docker engine to run in a normal userspace. This goes beyond the present change.

## How/what to test

run the whole app and test it