### PR TITLE
fix(Analytics): use pipeline code for id

### DIFF
--- a/hexa/analytics/api.py
+++ b/hexa/analytics/api.py
@@ -53,11 +53,11 @@ def track(
                     "ip": request.META["REMOTE_ADDR"],
                 }
             )
-            mixpanel.track(
-                distinct_id=str(people.id) if people else None,
-                event_name=event,
-                properties=properties,
-            )
+        mixpanel.track(
+            distinct_id=str(people.id) if people else None,
+            event_name=event,
+            properties=properties,
+        )
     except Exception as e:
         capture_exception(e)
 

--- a/hexa/analytics/tests/test_analytics.py
+++ b/hexa/analytics/tests/test_analytics.py
@@ -1,5 +1,4 @@
 from unittest import mock
-from uuid import uuid4
 
 from django.test import RequestFactory
 
@@ -66,7 +65,7 @@ class AnalyticsTest(TestCase):
         self.USER.save()
 
         mixpanel_token = "token"
-        # mock the flush method of the BufferedConsumer
+
         with self.settings(MIXPANEL_TOKEN=mixpanel_token):
             request = self.factory.post("/dataset")
             request.headers = {
@@ -77,7 +76,7 @@ class AnalyticsTest(TestCase):
             event = "dataset_version_created"
             properties = {
                 "dataset_version": "version",
-                "dataset_id": str(uuid4()),
+                "dataset_id": "slug",
                 "creation_source": "SDK",
                 "workspace": self.WORKSPACE.slug,
             }
@@ -119,7 +118,7 @@ class AnalyticsTest(TestCase):
         mock_mixpanel,
     ):
         mixpanel_token = "token"
-        # mock the flush method of the BufferedConsumer
+
         with self.settings(MIXPANEL_TOKEN=mixpanel_token):
             self.PIPELINE.run(
                 user=None,
@@ -131,13 +130,22 @@ class AnalyticsTest(TestCase):
             event = "dataset_version_created"
             properties = {
                 "dataset_version": "version",
-                "dataset_id": str(uuid4()),
+                "dataset_id": "slug",
                 "creation_source": "SDK",
                 "workspace": self.WORKSPACE.slug,
             }
 
             track(None, event, properties)
-            mock_mixpanel.track.assert_not_called()
+            mock_mixpanel.track.assert_called_once_with(
+                distinct_id=None,
+                event_name="dataset_version_created",
+                properties={
+                    "dataset_version": "version",
+                    "dataset_id": "slug",
+                    "creation_source": "SDK",
+                    "workspace": self.WORKSPACE.slug,
+                },
+            )
 
     @mock.patch("hexa.analytics.api.mixpanel")
     def test_create_user_profile(
@@ -145,7 +153,7 @@ class AnalyticsTest(TestCase):
         mock_mixpanel,
     ):
         mixpanel_token = "token"
-        # mock the flush method of the BufferedConsumer
+
         with self.settings(MIXPANEL_TOKEN=mixpanel_token):
             set_user_properties(self.USER)
 

--- a/hexa/datasets/schema/mutations.py
+++ b/hexa/datasets/schema/mutations.py
@@ -110,7 +110,7 @@ def resolve_create_dataset_version(_, info, **kwargs):
             "datasets.dataset_version_created",
             {
                 "dataset_version": version.name,
-                "dataset_id": str(dataset.id),
+                "dataset_id": dataset.slug,
                 "creation_source": (
                     "SDK" if isinstance(request.user, PipelineRunUser) else "UI"
                 ),

--- a/hexa/pipelines/management/commands/pipelines_scheduler.py
+++ b/hexa/pipelines/management/commands/pipelines_scheduler.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
                     request=None,
                     event="pipelines.pipeline_run",
                     properties={
-                        "pipeline_id": str(pipeline.id),
+                        "pipeline_id": pipeline.code,
                         "version_name": pipeline.last_version.name,
                         "version_id": str(pipeline.last_version.id),
                         "trigger": PipelineRunTrigger.SCHEDULED,

--- a/hexa/pipelines/schema/mutations.py
+++ b/hexa/pipelines/schema/mutations.py
@@ -216,7 +216,7 @@ def resolve_run_pipeline(_, info, **kwargs):
             request,
             "pipelines.pipeline_run",
             {
-                "pipeline_id": str(pipeline.id),
+                "pipeline_id": pipeline.code,
                 "version_name": version.name,
                 "version_id": str(version.id),
                 "trigger": PipelineRunTrigger.MANUAL,

--- a/hexa/pipelines/views.py
+++ b/hexa/pipelines/views.py
@@ -192,7 +192,7 @@ def run_pipeline(
             request,
             "pipelines.pipeline_run",
             {
-                "pipeline_id": str(pipeline.id),
+                "pipeline_id": pipeline.code,
                 "version_name": pipeline_version.name if pipeline_version else None,
                 "version_id": pipeline_version.id if pipeline_version else None,
                 "trigger": PipelineRunTrigger.WEBHOOK,


### PR DESCRIPTION
Track more meaningful properties for pipeline_run event.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- use pipeline_code instead of pipeline_id