### PR TITLE
Remove cors decorator

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ x-app: &common
       context: .
       dockerfile: Dockerfile
       target: app
+    platform: linux/amd64
     networks:
       - openhexa
     environment:

--- a/hexa/core/views_utils.py
+++ b/hexa/core/views_utils.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from django.conf import settings
 from django.http import Http404, HttpRequest
 from django.shortcuts import redirect
@@ -11,3 +13,12 @@ def redirect_to_new_frontend(request: HttpRequest, *_, **__):
             )
         )
     raise Http404("Page not found")
+
+
+def disable_cors(view_func):
+    @wraps(view_func)
+    def _wrapped_view(request, *args, **kwargs):
+        request._cors_enabled = False
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped_view

--- a/hexa/pipelines/signals.py
+++ b/hexa/pipelines/signals.py
@@ -1,7 +1,5 @@
-from corsheaders.signals import check_request_enabled
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
-from django.urls import NoReverseMatch, resolve
 
 from hexa.workspaces.models import WorkspaceMembership
 
@@ -20,12 +18,3 @@ def delete_member_handler(sender: type, instance: WorkspaceMembership, **kwargs)
         ).delete()
     except PipelineRecipient.DoesNotExist:
         pass
-
-
-@check_request_enabled.connect
-def cors_allow_pipeline_run(sender, request, **kwargs):
-    try:
-        match = resolve(request.path)
-        return match.view_name in ("pipelines:run", "pipelines:run_with_version")
-    except NoReverseMatch:
-        return False

--- a/hexa/pipelines/views.py
+++ b/hexa/pipelines/views.py
@@ -18,6 +18,7 @@ from django.views.decorators.http import require_POST
 
 from hexa.analytics.api import track
 from hexa.app import get_hexa_app_configs
+from hexa.core.views_utils import disable_cors
 from hexa.pipelines.models import Environment
 
 from .credentials import PipelinesCredentials
@@ -94,6 +95,7 @@ def credentials(request: HttpRequest) -> HttpResponse:
 
 @require_POST
 @csrf_exempt
+@disable_cors
 def run_pipeline(
     request: HttpRequest, token: str, version_id: uuid.UUID = None
 ) -> HttpResponse:


### PR DESCRIPTION
The signal that I added prevent the frontend to load the static assets of the admin. By changing the implementation, I've fixed the static problem and kept the deactivation of the cors on the `run_pipeline` endpoint