### PR TITLE
fix(Pipelines): Run outputs can be a StorageObject instance

### DIFF
--- a/hexa/files/backends/dummy.py
+++ b/hexa/files/backends/dummy.py
@@ -114,7 +114,7 @@ class DummyStorageClient(Storage):
             raise self.exceptions.NotFound(
                 f"Object '{object_key}' not found in bucket '{bucket_name}'."
             )
-        return self.to_storage_object(bucket_name, object_key)
+        return self._to_storage_object(bucket_name, object_key)
 
     def list_bucket_objects(
         self,


### PR DESCRIPTION
The changes for the new storage backend had an impact on the PipelineRun outputs.