### PR TITLE
fix(Analytics): use X_FORWARDED_FOR header for an accurate ip

### DIFF
--- a/hexa/analytics/api.py
+++ b/hexa/analytics/api.py
@@ -4,6 +4,7 @@ from mixpanel import Mixpanel
 from sentry_sdk import capture_exception
 from ua_parser import user_agent_parser
 
+from hexa.analytics.utils import get_ip_address
 from hexa.user_management.models import AnonymousUser, User
 
 mixpanel = None
@@ -50,7 +51,7 @@ def track(
                     "$browser": parsed["user_agent"]["family"],
                     "$device": parsed["device"]["family"],
                     "$os": parsed["os"]["family"],
-                    "ip": request.META["REMOTE_ADDR"],
+                    "ip": get_ip_address(request),
                 }
             )
         mixpanel.track(

--- a/hexa/analytics/tests/test_utils.py
+++ b/hexa/analytics/tests/test_utils.py
@@ -1,0 +1,27 @@
+from django.test import RequestFactory
+
+from hexa.analytics.utils import get_ip_address
+from hexa.core.test import TestCase
+
+
+class TestUtils(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.factory = RequestFactory()
+
+    def test_get_ip_address(self):
+        request = self.factory.post("/pipelines/")
+        request.headers = {
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
+        }
+        request.META["REMOTE_ADDR"] = "127.0.0.1"
+        self.assertEqual(get_ip_address(request), "127.0.0.1")
+
+    def test_get_ip_address_forwarded(self):
+        request = self.factory.post("/pipelines/")
+        request.headers = {
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
+        }
+        request.META["REMOTE_ADDR"] = "127.0.0.1"
+        request.META["HTTP_X_FORWARDED_FOR"] = "203.0.113.195, 192.168.1.1, 192.168.1.2"
+        self.assertEqual(get_ip_address(request), "203.0.113.195")

--- a/hexa/analytics/utils.py
+++ b/hexa/analytics/utils.py
@@ -1,0 +1,11 @@
+from django.http import HttpRequest
+
+
+def get_ip_address(request: HttpRequest) -> str:
+    """Get the IP address from the request object."""
+    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+    if x_forwarded_for:
+        ip = x_forwarded_for.split(",")[0]
+    else:
+        ip = request.META["REMOTE_ADDR"]
+    return ip


### PR DESCRIPTION
Events tracked  on Mixpanel were missing user geolocation information despite the fact user IP was in the properties
sent to Mixpanel API. 
## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Use X_FORWARED_FOR header to retrieve origin ip if available.
- Update track method and add tests.

## How/what to test

Launch an action that use the track method (run pipeline, open dataset, download file...) the user geolocation information should be tracked on  Mixpanel
