### PR TITLE
feat: add existing member into a workspace and automate invitation ac…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.env
 .coverage
+.cache/
+.local/
 htmlcov/
 venv
 k8s/*
@@ -18,3 +20,4 @@ static/uploads/*
 __pycache__
 
 docker-compose.debug.yaml
+docker-compose.dev.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN groupadd --gid 1000 $GROUP &&\
   passwd -d $USER
 
 RUN chown -R $USER:$GROUP /code/
-RUN mkdir /data && chown $USER:$GROUP /data
+RUN mkdir /data && chown -R $USER:$GROUP /data && chmod 777 -R /data
 USER $USER:$GROUP
 
 # Entry point

--- a/hexa/user_management/graphql/schema.graphql
+++ b/hexa/user_management/graphql/schema.graphql
@@ -662,12 +662,14 @@ enum DeleteTeamError {
     PERMISSION_DENIED
 }
 
+
 extend type Query {
     # Retrieves a team by its unique identifier.
     team(id: UUID!): Team
     # Search for teams.
     teams(term: String, page: Int, perPage: Int): TeamPage!
 }
+
 extend type Mutation {
     # Creates a new team.
     createTeam(input: CreateTeamInput!): CreateTeamResult! @loginRequired

--- a/hexa/workspaces/graphql/schema.graphql
+++ b/hexa/workspaces/graphql/schema.graphql
@@ -177,7 +177,9 @@ enum WorkspaceMembershipRole {
   VIEWER  # The user can view the workspace and its contents.
 }
 
-
+type WorkspaceCandidatesResult {
+    items: [User!]!
+}
 
 extend type Query {
   # Returns a workspace by its unique identifier.
@@ -186,9 +188,10 @@ extend type Query {
   workspaces(query: String, page: Int, perPage: Int): WorkspacePage! @loginRequired
   # Returns the invitations to workspaces of the current user.
   pendingWorkspaceInvitations(page: Int! = 1, perPage: Int = 10): WorkspaceInvitationPage!
-
   # Returns a database table by its identifier.
   databaseTable(id:String!): DatabaseTable @loginRequired
+  # Returns a list of registered users not yet members of the workspace.
+  workspaceCandidates(query: String, workspace: String): WorkspaceCandidatesResult! @loginRequired
 }
 
 
@@ -233,6 +236,16 @@ enum InviteWorkspaceMembershipError {
   USER_NOT_FOUND
   WORKSPACE_NOT_FOUND
 }
+
+  """
+  Enum representing the possible errors that can occur when inviting a user to a workspace.
+  """
+  enum InsertWorkspaceMembershipError {
+    ALREADY_EXISTS
+    PERMISSION_DENIED
+    WORKSPACE_NOT_FOUND
+    SERVER_ERROR
+  }
 
 """
 Enum representing the possible errors that can occur when deleting a workspace member.
@@ -299,6 +312,20 @@ type ArchiveWorkspaceResult {
   # The errors that occurred during the archiving.
   errors: [ArchiveWorkspaceError!]!
 }
+
+  """
+  Represents the result of inserting a member to a workspace.
+  """
+  type InsertWorkspaceMemberResult {
+    # Indicates whether the invitation was successful.
+    success: Boolean!    
+    
+    # The errors that occurred during the insertion.
+    errors: [InsertWorkspaceMembershipError!]!
+
+    # The workspace membership associated with the invitation.
+    workspaceMembership: WorkspaceMembership
+  }
 
 """
 Represents the result of inviting a member to a workspace.
@@ -386,6 +413,20 @@ input DeleteWorkspaceInput {
   # The slug of the workspace to delete.
   slug: String!
 }
+
+  """
+  Represents the input for inserting a member to a workspace.
+  """
+  input InsertWorkspaceMemberInput {
+    # The slug of the workspace.
+    workspaceSlug: String!
+
+    # The email address of the user to invite.
+    userEmail: String!
+
+    # The role of the user in the workspace.
+    role: WorkspaceMembershipRole!
+  }
 
 """
 Represents the input for inviting a member to a workspace.
@@ -613,6 +654,7 @@ extend type Mutation {
   deleteWorkspace(input: DeleteWorkspaceInput!): DeleteWorkspaceResult! @loginRequired
   archiveWorkspace(input: ArchiveWorkspaceInput!): ArchiveWorkspaceResult! @loginRequired
   inviteWorkspaceMember(input: InviteWorkspaceMemberInput!): InviteWorkspaceMemberResult! @loginRequired
+  insertWorkspaceMember(input: InsertWorkspaceMemberInput!): InsertWorkspaceMemberResult! @loginRequired
   updateWorkspaceMember(input: UpdateWorkspaceMemberInput!): UpdateWorkspaceMemberResult! @loginRequired
   deleteWorkspaceMember(input: DeleteWorkspaceMemberInput!): DeleteWorkspaceMemberResult! @loginRequired
   generateWorkspaceToken(input: GenerateWorkspaceTokenInput!): GenerateWorkspaceTokenResult! @loginRequired

--- a/hexa/workspaces/templates/workspaces/mails/insert_user.html
+++ b/hexa/workspaces/templates/workspaces/mails/insert_user.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+{% autoescape off %}
+
+{% blocktranslate %}Dear,{% endblocktranslate %}
+
+<br/>
+<br/>
+
+{% blocktranslate %}
+    <p>You have been added to the workspace <b>{{workspace}}</b> by {{owner}}.</p>
+{% endblocktranslate %}
+
+{% blocktranslate %}
+    <p>Please go to the following page to access to the workspace: {{ url }}.</p>
+{% endblocktranslate %}
+
+<br/>
+<br/>
+
+{% blocktranslate %}The OpenHEXA team{% endblocktranslate %}
+
+{% endautoescape %}

--- a/hexa/workspaces/templates/workspaces/mails/insert_user.txt
+++ b/hexa/workspaces/templates/workspaces/mails/insert_user.txt
@@ -1,0 +1,11 @@
+{% load i18n %}
+
+{% blocktranslate %}
+Dear,
+
+Your have been added to the workspace {{workspace}} by {{owner}}.
+
+Please go to the following page to access to the workspace: {{ url }}
+{% endblocktranslate %}
+
+{% blocktranslate %}The OpenHEXA team{% endblocktranslate %}

--- a/hexa/workspaces/utils.py
+++ b/hexa/workspaces/utils.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext_lazy, override
 from hexa.core.utils import send_mail
 from hexa.user_management.models import User
 
-from .models import WorkspaceInvitation
+from .models import Workspace, WorkspaceInvitation
 
 
 def send_workspace_invitation_email(
@@ -37,4 +37,25 @@ def send_workspace_invitation_email(
                 "url": action_url,
             },
             recipient_list=[invitation.email],
+        )
+
+
+def send_workspace_insertion_email(workspace: Workspace, owner: User, user: User):
+    with override(user.language):
+        title = gettext_lazy(
+            f"You've been added to the workspace {workspace.name} on OpenHEXA"
+        )
+        action_url = f"{settings.NEW_FRONTEND_DOMAIN}/workspaces/{workspace.slug}"
+        variables = {
+            "workspace": workspace.name,
+            "owner": owner.display_name,
+            "user": user,
+            "url": action_url,
+        }
+
+        send_mail(
+            title=title,
+            template_name="workspaces/mails/insert_user",
+            template_variables=variables,
+            recipient_list=[user.email],
         )


### PR DESCRIPTION
## Description

Implements upgrade of the workflow invitation flow:

- Allow workspace admin to search about worskpace candidates.
- If a candidate already exists in database, allow admin to bypass the invitation flow and create a membership for this user / workspace.
- If the email address is not known, an invitation to register is sent to the email address, and automaticaly accepted when the registration is done.

## Changes

- Query WorspaceCandidates + related types + resolver
- Mutation InsertWorkspaceMember + related types + resolver
- Email + template about the insertion into the workspace
- Mutation Register

## How/what to test

- Unit tests
- Functional test needs to checkout the [related feature branch on front-end side](https://github.com/BLSQ/openhexa-frontend/tree/feature/improve-workflow-workspace-invitation)
