### PR TITLE
fix(Datasets): snake case for datasetlink id

### DIFF
--- a/hexa/datasets/schema/mutations.py
+++ b/hexa/datasets/schema/mutations.py
@@ -296,7 +296,7 @@ def resolve_pin_dataset(_, info, **kwargs):
     mutation_input = kwargs["input"]
 
     try:
-        link = DatasetLink.objects.get(id=mutation_input["linkId"])
+        link = DatasetLink.objects.get(id=mutation_input["link_id"])
 
         if not request.user.has_perm("datasets.pin_dataset", link):
             raise PermissionDenied


### PR DESCRIPTION
Small fix : forgot to migrate to snake case the linkId used in pinDataset mutation.

## Changes

Please list / describe the changes in the codebase for the reviewer(s).

- Use snake case for link id.

## How/what to test

Call the pinDataset mutation with correct input, it shouldn't break.