### PR TITLE
fix(Pipelines): Put back 'number' on PipelineVersion to not break backward compatibility with SDK < 1.0.0

### DIFF
--- a/hexa/pipelines/graphql/schema.graphql
+++ b/hexa/pipelines/graphql/schema.graphql
@@ -111,6 +111,7 @@ type PipelineVersion {
   user: User  # The user who created the pipeline version.
   pipeline: Pipeline!  # The pipeline associated with the version.
   name: String  # The optional name of the pipeline version.
+  number: Int @deprecated(reason: "Use 'versionNumber' instead")  # The version number of the pipeline version.
   versionNumber: Int!  # The version number of the pipeline version.
   versionName: String!  # The version name of the pipeline version including the versionNumber and the optional name.
   description: String  # The description of the pipeline version.

--- a/hexa/pipelines/schema/types.py
+++ b/hexa/pipelines/schema/types.py
@@ -226,6 +226,9 @@ def resolve_pipeline_version_version_name(version: PipelineVersion, info, **kwar
     return version.version_name
 
 
+pipeline_version_object.set_alias("number", "versionNumber")
+
+
 @pipeline_version_object.field("isLatestVersion")
 def resolve_pipeline_version_is_latest(version: PipelineVersion, info, **kwargs):
     return version.is_latest_version


### PR DESCRIPTION
Fixes OPENHEXA-1BT

## Changes

I added the `number` field again on `PipelineVersion`

## How/what to test

Try uploading & downloading pipelines using a version of openhexa.sdk < 1.0.0
