### PR TITLE
fix: OPENHEXA-1BV snake_case issue in create bucket folder

### DIFF
--- a/hexa/files/schema/mutations.py
+++ b/hexa/files/schema/mutations.py
@@ -82,7 +82,7 @@ def resolve_create_bucket_folder(_, info, **kwargs):
         )
         if not request.user.has_perm("files.create_object", workspace):
             return {"success": False, "errors": ["PERMISSION_DENIED"]}
-        folder_key = mutation_input["folderKey"]
+        folder_key = mutation_input["folder_key"]
         folder_object = storage.create_bucket_folder(workspace.bucket_name, folder_key)
 
         return {"success": True, "folder": folder_object, "errors": []}


### PR DESCRIPTION
When upgrading the ariadne snake case system (https://github.com/BLSQ/openhexa-app/commit/e1a1b2c813b5942183dd13f04898df6643eb9848), we forgot to modify this specific key 

## Changes

- Fix and test

## How/what to test

A folder can be created 
