### PR TITLE
chore(Templates): Add missing fixture to create the feature flag

### DIFF
--- a/hexa/pipeline_templates/fixtures/base.json
+++ b/hexa/pipeline_templates/fixtures/base.json
@@ -1,0 +1,11 @@
+[
+  {
+    "model": "user_management.feature",
+    "fields": {
+        "created_at": "2025-01-14T00:00:00.000Z",
+        "updated_at": "2025-01-14T00:00:00.000Z",
+        "code": "pipeline_templates",
+        "force_activate": false
+    }
+  }
+]


### PR DESCRIPTION
It's better to use the fixture mechanism of Django to manage feature flags.