### PR TITLE
chore(deps): Upgrade Django from v4 to v5

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ ariadne
 ariadne_django
 colorhash
 cryptography
-Django
+Django>=5
 django-cors-headers
 django-countries
 django-debug-toolbar

--- a/requirements.txt
+++ b/requirements.txt
@@ -94,7 +94,7 @@ dhis2-py==2.3.0
     # via -r requirements.in
 diskcache==5.6.3
     # via openhexa-toolbox
-django==4.2.17
+django==5.1.5
     # via
     #   -r requirements.in
     #   ariadne-django


### PR DESCRIPTION
I upgraded Django to the latest version available.

https://docs.djangoproject.com/en/5.1/releases/5.0/