### PR TITLE
fix: Support deleted source pipeline (HEXA-1169)

### DIFF
--- a/hexa/pipeline_templates/schema/mutations.py
+++ b/hexa/pipeline_templates/schema/mutations.py
@@ -17,6 +17,9 @@ def get_workspace(user, workspace_slug):
 
 
 def get_source_pipeline(user, pipeline_id):
+    """
+    Get a pipeline that the user has access to, regardless of whether it has been deleted or not.
+    """
     try:
         return Pipeline.all_objects.filter_for_user(user).get(id=pipeline_id)
     except Pipeline.DoesNotExist:

--- a/hexa/pipeline_templates/schema/mutations.py
+++ b/hexa/pipeline_templates/schema/mutations.py
@@ -18,7 +18,7 @@ def get_workspace(user, workspace_slug):
 
 def get_source_pipeline(user, pipeline_id):
     try:
-        return Pipeline.objects.filter_for_user(user).get(id=pipeline_id)
+        return Pipeline.all_objects.filter_for_user(user).get(id=pipeline_id)
     except Pipeline.DoesNotExist:
         return None
 


### PR DESCRIPTION
Support deleted source pipeline

This change should have no effect now because this method is only used when creating a new template or template version, but this is only proposed when the source pipeline is not deleted. So at this point it is for correctness or avoiding future issues.