### PR TITLE
chore(Datasets): Add a updateDatasetVersion mutation

### DIFF
--- a/hexa/datasets/graphql/schema.graphql
+++ b/hexa/datasets/graphql/schema.graphql
@@ -276,6 +276,32 @@ type CreateDatasetVersionResult {
 }
 
 """
+Input for updating a dataset version.
+"""
+input UpdateDatasetVersionInput {
+  versionId: ID!
+  name: String
+  changelog: String
+}
+
+"""
+Result of updating a dataset version.
+"""
+type UpdateDatasetVersionResult {
+  version: DatasetVersion
+  success: Boolean!
+  errors: [UpdateDatasetVersionError!]!
+}
+
+"""
+Errors that can occur when updating a dataset version.
+"""
+enum UpdateDatasetVersionError {
+  VERSION_NOT_FOUND
+  PERMISSION_DENIED
+}
+
+"""
 Input for deleting a dataset version.
 """
 input DeleteDatasetVersionInput {
@@ -477,6 +503,8 @@ extend type Mutation {
   deleteDataset(input: DeleteDatasetInput!): DeleteDatasetResult! @loginRequired
   "Create a new dataset version."
   createDatasetVersion(input: CreateDatasetVersionInput!): CreateDatasetVersionResult! @loginRequired
+  "Update a dataset version."
+  updateDatasetVersion(input: UpdateDatasetVersionInput!): UpdateDatasetVersionResult! @loginRequired
   "Delete a dataset version."
   deleteDatasetVersion(input: DeleteDatasetVersionInput!): DeleteDatasetVersionResult! @loginRequired
   "Create dataset version file upload url."

--- a/hexa/datasets/models.py
+++ b/hexa/datasets/models.py
@@ -212,6 +212,16 @@ class DatasetVersion(MetadataMixin, Base):
         ordering = ["-created_at"]
         unique_together = ("dataset", "name")
 
+    def update_if_has_perm(self, *, principal: User, **kwargs):
+        if not principal.has_perm("datasets.update_dataset_version", self):
+            raise PermissionDenied
+
+        for key in ["name", "changelog"]:
+            if key in kwargs:
+                setattr(self, key, kwargs[key])
+
+        return self.save()
+
     def delete_if_has_perm(self, *, principal: User):
         if not principal.has_perm("datasets.delete_dataset_version", self):
             raise PermissionDenied

--- a/hexa/datasets/schema/mutations.py
+++ b/hexa/datasets/schema/mutations.py
@@ -128,6 +128,25 @@ def resolve_create_dataset_version(_, info, **kwargs):
         return {"success": False, "errors": ["PERMISSION_DENIED"]}
 
 
+@mutations.field("updateDatasetVersion")
+def resolve_update_dataset_version(_, info, **kwargs):
+    request = info.context["request"]
+    mutation_input = kwargs["input"]
+
+    try:
+        version = DatasetVersion.objects.filter_for_user(request.user).get(
+            id=mutation_input["version_id"]
+        )
+
+        version.update_if_has_perm(principal=request.user, **mutation_input)
+
+        return {"success": True, "errors": [], "version": version}
+    except DatasetVersion.DoesNotExist:
+        return {"success": False, "errors": ["VERSION_NOT_FOUND"]}
+    except PermissionDenied:
+        return {"success": False, "errors": ["PERMISSION_DENIED"]}
+
+
 @mutations.field("deleteDatasetVersion")
 def resolve_delete_dataset_version(_, info, **kwargs):
     request = info.context["request"]

--- a/hexa/datasets/tests/test_schema.py
+++ b/hexa/datasets/tests/test_schema.py
@@ -11,7 +11,7 @@ from hexa.user_management.models import User
 from hexa.workspaces.models import WorkspaceMembershipRole
 
 from ...metadata.models import MetadataAttribute
-from ..models import Dataset, DatasetFileSample, DatasetVersionFile
+from ..models import Dataset, DatasetFileSample, DatasetVersion, DatasetVersionFile
 from .testutils import DatasetTestMixin
 
 
@@ -348,6 +348,7 @@ class DatasetVersionTest(GraphQLTestCase, DatasetTestMixin):
                     success
                     errors
                     version {
+                        id
                         name
                         changelog
                         description
@@ -363,11 +364,15 @@ class DatasetVersionTest(GraphQLTestCase, DatasetTestMixin):
                 }
             },
         )
+        version = DatasetVersion.objects.get(
+            id=r["data"]["createDatasetVersion"]["version"]["id"]
+        )
         self.assertEqual(
             {
                 "success": True,
                 "errors": [],
                 "version": {
+                    "id": str(version.id),
                     "name": "Version 1",
                     "changelog": "Version 1 changelog",
                     "description": "Version 1 changelog",
@@ -375,6 +380,7 @@ class DatasetVersionTest(GraphQLTestCase, DatasetTestMixin):
             },
             r["data"]["createDatasetVersion"],
         )
+        return version
 
     def test_create_duplicate(self):
         self.test_create_dataset_version()
@@ -711,4 +717,37 @@ class DatasetVersionTest(GraphQLTestCase, DatasetTestMixin):
                 "downloadUrl": f"http://mockstorage.com/{settings.WORKSPACE_DATASETS_BUCKET}/{version_file.uri}",
             },
             r["data"]["prepareVersionFileDownload"],
+        )
+
+    def test_update_dataset_version(self):
+        version = self.test_create_dataset_version()
+        self.client.force_login(version.created_by)
+        r = self.run_query(
+            """
+            mutation UpdateDatasetVersion ($input: UpdateDatasetVersionInput!) {
+                updateDatasetVersion(input: $input) {
+                    version {
+                        name
+                        changelog
+                    }
+                    success
+                    errors
+                }
+            }
+            """,
+            {
+                "input": {
+                    "versionId": str(version.id),
+                    "name": "New name",
+                    "changelog": "New changelog",
+                }
+            },
+        )
+        self.assertEqual(
+            {
+                "success": True,
+                "errors": [],
+                "version": {"name": "New name", "changelog": "New changelog"},
+            },
+            r["data"]["updateDatasetVersion"],
         )


### PR DESCRIPTION
Fixes PATHWAYS-308 for the backend

Add a way for admin & editors to edit the name & changelog of dataset versions of their workspaces

## How/what to test

Call the mutation 'updateDatasetVersion' via GraphiQL or wait for the frontend to be available

