### PR TITLE
Superset improvements

### DIFF
--- a/hexa/superset/admin.py
+++ b/hexa/superset/admin.py
@@ -3,11 +3,21 @@ from django.contrib import admin
 from .models import SupersetDashboard, SupersetInstance
 
 
+class SupersetDashboardInline(admin.TabularInline):
+    model = SupersetDashboard
+    extra = 1
+    fields = (
+        "name",
+        "external_id",
+    )
+
+
 @admin.register(SupersetInstance)
 class SupersetInstanceAdmin(admin.ModelAdmin):
     list_display = ("name", "url", "created_at", "updated_at")
     search_fields = ("name", "url")
     list_filter = ("created_at", "updated_at")
+    inlines = [SupersetDashboardInline]
 
 
 @admin.register(SupersetDashboard)

--- a/hexa/superset/models.py
+++ b/hexa/superset/models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import models
 from django.urls import reverse
 
@@ -26,7 +27,7 @@ class SupersetDashboard(Base):
 
     def get_absolute_url(self):
         """Returns the URL to access this dashboard."""
-        return reverse("superset:dashboard", kwargs={"dashboard_id": self.id})
+        return f"{settings.NEW_FRONTEND_DOMAIN}{reverse('superset:dashboard', kwargs={'dashboard_id': self.id})}"
 
     class Meta:
         unique_together = ("external_id", "superset_instance")

--- a/hexa/superset/urls.py
+++ b/hexa/superset/urls.py
@@ -1,10 +1,18 @@
 from django.urls import path
 
-from hexa.superset.views import view_superset_dashboard
+from hexa.superset.views import (
+    view_superset_dashboard,
+    view_superset_dashboard_by_external_id,
+)
 
 app_name = "superset"
 
 urlpatterns = [
+    path(
+        "dashboard/external/<str:external_id>/",
+        view_superset_dashboard_by_external_id,
+        name="dashboard-external",
+    ),
     path(
         "dashboard/<str:dashboard_id>/",
         view_superset_dashboard,

--- a/hexa/superset/views.py
+++ b/hexa/superset/views.py
@@ -1,7 +1,11 @@
+from logging import getLogger
+
 from django.http import HttpRequest, HttpResponse
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, redirect, render
 
 from hexa.superset.models import SupersetDashboard
+
+logger = getLogger(__name__)
 
 
 def view_superset_dashboard(request: HttpRequest, dashboard_id: str) -> HttpResponse:
@@ -32,3 +36,21 @@ def view_superset_dashboard(request: HttpRequest, dashboard_id: str) -> HttpResp
         "superset/dashboard.html",
         {"dashboard": dashboard, "guest_token": guest_token},
     )
+
+
+def view_superset_dashboard_by_external_id(
+    request: HttpRequest, external_id: str
+) -> HttpResponse:
+    """
+    Warning: This endpoint is only implemented to ease the migration from the Vercel app to the new system of embedded dashboard.
+    It has to be removed in the future once the app https://vercel.com/bluesquare/superset-dashboards-poc is deleted.
+    """
+    logger.error(
+        "view_superset_dashboard_by_external_id is deprecated. Use view_superset_dashboard instead.",
+        extra={"request": request, "external_id": external_id},
+    )
+
+    dashboard: SupersetDashboard = get_object_or_404(
+        SupersetDashboard, external_id=external_id
+    )
+    return redirect(dashboard.get_absolute_url())


### PR DESCRIPTION
## Changes


- "View on site" link in the Django admin redirects to the embedded dashboard on app.openhexa.org and not api.openhexa.org (it's now using `NEW_FRONTEND_DOMAIN`)
- Add inline panel to add dashboards directly from the admin page of a superset instance
- Add temporary endpoint to support getting dashboard by their external id (this is what's used by the former system)

## How/what to test

- Click on "view on site", you should arrive on http://localhost:3000
- Test the endpoint `/superset/dashboard/external/<external_id>`

