### PR TITLE
fix: Malformed URL for password reset (HEXA-1222)

### DIFF
--- a/hexa/user_management/schema.py
+++ b/hexa/user_management/schema.py
@@ -1,6 +1,7 @@
 import binascii
 import logging
 import pathlib
+from urllib.parse import urlparse
 
 import django_otp
 from ariadne import (
@@ -387,7 +388,10 @@ def resolve_reset_password(_, info, input, **kwargs):
     request: HttpRequest = info.context["request"]
     form = PasswordResetForm({"email": input["email"]})
     if form.is_valid():
-        form.save(request=request, domain_override=settings.NEW_FRONTEND_DOMAIN)
+        parsed_url = urlparse(settings.NEW_FRONTEND_DOMAIN)
+        domain_override = parsed_url.netloc
+        use_https = parsed_url.scheme == "https"
+        form.save(request=request, domain_override=domain_override, use_https=use_https)
         return {"success": True}
     else:
         return {"success": False}

--- a/hexa/user_management/schema.py
+++ b/hexa/user_management/schema.py
@@ -390,7 +390,7 @@ def resolve_reset_password(_, info, input, **kwargs):
     if form.is_valid():
         parsed_url = urlparse(settings.NEW_FRONTEND_DOMAIN)
         domain_override = parsed_url.netloc
-        use_https = parsed_url.scheme == "https"
+        use_https = settings.SCHEME == "https"
         form.save(request=request, domain_override=domain_override, use_https=use_https)
         return {"success": True}
     else:

--- a/hexa/user_management/schema.py
+++ b/hexa/user_management/schema.py
@@ -390,7 +390,7 @@ def resolve_reset_password(_, info, input, **kwargs):
     if form.is_valid():
         parsed_url = urlparse(settings.NEW_FRONTEND_DOMAIN)
         domain_override = parsed_url.netloc
-        use_https = settings.SCHEME == "https"
+        use_https = parsed_url.scheme == "https"
         form.save(request=request, domain_override=domain_override, use_https=use_https)
         return {"success": True}
     else:

--- a/hexa/user_management/tests/test_schema.py
+++ b/hexa/user_management/tests/test_schema.py
@@ -539,6 +539,7 @@ class SchemaTest(GraphQLTestCase):
             r["data"]["me"],
         )
 
+    @override_settings(SCHEME="https")
     @override_settings(NEW_FRONTEND_DOMAIN="https://newfrontend.example.com")
     def test_reset_password(self):
         r = self.run_query(

--- a/hexa/user_management/tests/test_schema.py
+++ b/hexa/user_management/tests/test_schema.py
@@ -539,7 +539,6 @@ class SchemaTest(GraphQLTestCase):
             r["data"]["me"],
         )
 
-    @override_settings(SCHEME="https")
     @override_settings(NEW_FRONTEND_DOMAIN="https://newfrontend.example.com")
     def test_reset_password(self):
         r = self.run_query(

--- a/hexa/user_management/tests/test_schema.py
+++ b/hexa/user_management/tests/test_schema.py
@@ -539,15 +539,16 @@ class SchemaTest(GraphQLTestCase):
             r["data"]["me"],
         )
 
+    @override_settings(NEW_FRONTEND_DOMAIN="https://newfrontend.example.com")
     def test_reset_password(self):
         r = self.run_query(
             """
-              mutation resetPassword($input: ResetPasswordInput!) {
-                resetPassword(input: $input) {
-                  success
-                }
-              }
-            """,
+                  mutation resetPassword($input: ResetPasswordInput!) {
+                    resetPassword(input: $input) {
+                      success
+                    }
+                  }
+                """,
             {"input": {"email": self.USER_JIM.email}},
         )
 
@@ -557,8 +558,16 @@ class SchemaTest(GraphQLTestCase):
         )
 
         self.assertEqual(len(mail.outbox), 1)
+        self.assertIn(
+            "Please go to the following page and choose a new password:",
+            mail.outbox[0].body,
+        )
+        self.assertIn(
+            "https://newfrontend.example.com/auth/reset/", mail.outbox[0].body
+        )
         self.assertEqual(
-            mail.outbox[0].subject, "Password reset on http://localhost:3000"
+            mail.outbox[0].subject,
+            "Password reset on newfrontend.example.com",
         )
 
     def test_reset_password_wrong_email(self):


### PR DESCRIPTION
Password reset email was like :

```
Please go to the following page and choose a new password:

http://https://app.openhexa.org/auth/reset/ODFhOTRlY2MtNTI5Zi00N2ZjLThi
```
## Changes

- Ensure the domain and protocol are correct and not doubled
- Cover with unit test
