### PR TITLE
feat: Improve Web apps UI : favorites handling, iframe permissions,... (PATHWAYS-414)

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/pages/workspaces/[workspaceSlug]/webapps/[webappId]/play/index.tsx
+++ b/frontend/src/pages/workspaces/[workspaceSlug]/webapps/[webappId]/play/index.tsx
@@ -10,30 +10,23 @@ import {
 } from "workspaces/graphql/queries.generated";
 import WorkspaceLayout from "workspaces/layouts/WorkspaceLayout";
 import Breadcrumbs from "core/components/Breadcrumbs";
-import WebappForm from "webapps/features/WebappForm";
-import { TrashIcon } from "@heroicons/react/24/outline";
-import Button from "core/components/Button";
-import { useState } from "react";
-import DeleteWebappDialog from "workspaces/features/DeleteWebappDialog/DeleteWebappDialog";
-import useCacheKey from "core/hooks/useCacheKey";
+import WebappIframe from "webapps/features/WebappIframe";
 
 type Props = {
   webappId: string;
   workspaceSlug: string;
 };
 
-const WorkspaceWebappPage: NextPageWithLayout = (props: Props) => {
+const WorkspaceWebappPlayPage: NextPageWithLayout = (props: Props) => {
   const { webappId, workspaceSlug } = props;
   const { t } = useTranslation();
-  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
-  const { data, refetch } = useWorkspaceWebappPageQuery({
+  const { data } = useWorkspaceWebappPageQuery({
     variables: {
       workspaceSlug,
       webappId,
     },
   });
-  useCacheKey("webapps", refetch);
 
   if (!data?.workspace || !data?.webapp) {
     return null;
@@ -70,33 +63,18 @@ const WorkspaceWebappPage: NextPageWithLayout = (props: Props) => {
                 {webapp.name}
               </Breadcrumbs.Part>
             </Breadcrumbs>
-            {webapp?.permissions.delete && (
-              <Button
-                variant={"danger"}
-                leadingIcon={<TrashIcon className="h-4 w-4" />}
-                onClick={() => setIsDeleteDialogOpen(true)}
-              >
-                {t("Delete")}
-              </Button>
-            )}
           </>
         }
       >
         <WorkspaceLayout.PageContent>
-          <WebappForm workspace={workspace} webapp={webapp} />
+          <WebappIframe url={webapp.url} />
         </WorkspaceLayout.PageContent>
       </WorkspaceLayout>
-      <DeleteWebappDialog
-        open={isDeleteDialogOpen}
-        onClose={() => setIsDeleteDialogOpen(false)}
-        webapp={webapp}
-        workspace={workspace}
-      />
     </Page>
   );
 };
 
-WorkspaceWebappPage.getLayout = (page) => page;
+WorkspaceWebappPlayPage.getLayout = (page) => page;
 
 export const getServerSideProps = createGetServerSideProps({
   requireAuth: true,
@@ -128,4 +106,4 @@ export const getServerSideProps = createGetServerSideProps({
   },
 });
 
-export default WorkspaceWebappPage;
+export default WorkspaceWebappPlayPage;

--- a/frontend/src/pages/workspaces/[workspaceSlug]/webapps/create/index.tsx
+++ b/frontend/src/pages/workspaces/[workspaceSlug]/webapps/create/index.tsx
@@ -55,6 +55,7 @@ const WebappCreatePage = ({ workspace }: any) => {
 export const getServerSideProps = createGetServerSideProps({
   requireAuth: true,
   getServerSideProps: async (ctx, client) => {
+    await WorkspaceLayout.prefetch(ctx, client);
     const { data } = await client.query<WorkspacePageQuery>({
       query: WorkspacePageDocument,
       variables: {

--- a/frontend/src/pages/workspaces/[workspaceSlug]/webapps/index.tsx
+++ b/frontend/src/pages/workspaces/[workspaceSlug]/webapps/index.tsx
@@ -7,11 +7,11 @@ import Link from "core/components/Link";
 import { createGetServerSideProps } from "core/helpers/page";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import Button from "core/components/Button";
 import WorkspaceLayout from "workspaces/layouts/WorkspaceLayout";
 import Breadcrumbs from "core/components/Breadcrumbs";
-import { PlusIcon, StarIcon } from "@heroicons/react/24/outline";
+import { PlayIcon, PlusIcon } from "@heroicons/react/24/outline";
 import {
   useWorkspaceWebappsPageQuery,
   WorkspaceWebappsPageDocument,
@@ -21,13 +21,10 @@ import {
 import useCacheKey from "core/hooks/useCacheKey";
 import Title from "core/components/Title";
 import UserAvatar from "identity/features/UserAvatar";
+import FavoriteWebappButton from "webapps/features/FavoriteWebappButton";
+import LinkColumn from "core/components/DataGrid/LinkColumn";
 import clsx from "clsx";
-import {
-  useAddToFavoritesMutation,
-  useRemoveFromFavoritesMutation,
-} from "webapps/graphql/mutations.generated";
-import { toast } from "react-toastify";
-import Spinner from "core/components/Spinner";
+import WebappCard from "webapps/features/WebappCard";
 
 type Props = {
   page: number;
@@ -45,28 +42,6 @@ const WebappsPage = (props: Props) => {
     variables: { workspaceSlug, page, perPage },
   });
   useCacheKey("webapps", refetch);
-
-  const [addToFavorites] = useAddToFavoritesMutation();
-  const [removeFromFavorites] = useRemoveFromFavoritesMutation();
-  const [settingFavoriteOf, setSettingFavoriteOf] = useState<string | null>();
-
-  const handleFavoriteClick = async (webappId: string, isFavorite: boolean) => {
-    try {
-      setSettingFavoriteOf(webappId);
-      if (isFavorite) {
-        await removeFromFavorites({ variables: { input: { webappId } } });
-        toast.success(t("Removed from favorites"));
-      } else {
-        await addToFavorites({ variables: { input: { webappId } } });
-        toast.success(t("Added to favorites"));
-      }
-      refetch();
-    } catch (error) {
-      toast.error(t("Error updating favorites"));
-    } finally {
-      setSettingFavoriteOf(null);
-    }
-  };
 
   const onChangePage = ({ page }: { page: number }) => {
     refetch({ page }).then();
@@ -118,7 +93,21 @@ const WebappsPage = (props: Props) => {
         }
       >
         <WorkspaceLayout.PageContent>
-          <Title level={2}>{t("All apps")}</Title>
+          {data.favoriteWebapps.items.length > 0 && (
+            <>
+              <div
+                className={clsx(
+                  "grid gap-4 mb-6",
+                  `grid-cols-${data.favoriteWebapps.items.length}`,
+                )}
+              >
+                {data.favoriteWebapps.items.map((webapp) => (
+                  <WebappCard key={webapp.id} webapp={webapp} />
+                ))}
+              </div>
+              <Title level={2}>{t("All apps")}</Title>
+            </>
+          )}
           <Block>
             <DataGrid
               defaultPageSize={perPage}
@@ -129,20 +118,7 @@ const WebappsPage = (props: Props) => {
               <BaseColumn id="name" label={t("Name")}>
                 {(item) => (
                   <div className="flex items-center space-x-1">
-                    {settingFavoriteOf === item.id ? (
-                      <Spinner size={"xs"} />
-                    ) : (
-                      <StarIcon
-                        data-testid={`star-icon-${item.id}`}
-                        className={clsx(
-                          "h-5 w-5 cursor-pointer text-yellow-500",
-                          item.isFavorite && "fill-yellow-500",
-                        )}
-                        onClick={() =>
-                          handleFavoriteClick(item.id, item.isFavorite)
-                        }
-                      />
-                    )}
+                    <FavoriteWebappButton webapp={item} />
                     <img
                       src={item.icon}
                       className={clsx(
@@ -170,6 +146,21 @@ const WebappsPage = (props: Props) => {
                 )}
               </BaseColumn>
               <TextColumn label={t("Workspace")} accessor="workspace.name" />
+              <LinkColumn
+                id="play"
+                url={(item) => ({
+                  pathname: `/workspaces/${encodeURIComponent(workspace.slug)}/webapps/${item.id}/play`,
+                })}
+                className={"flex items-center justify-center"}
+              >
+                <div
+                  className={
+                    "flex items-center justify-center bg-blue-500 rounded-full h-6 w-6 hover:bg-blue-600 cursor-pointer hover:scale-110"
+                  }
+                >
+                  <PlayIcon className="h-3 w-3 text-white fill-white translate-x-0.25" />
+                </div>
+              </LinkColumn>
               <ChevronLinkColumn
                 accessor="id"
                 url={(value: any) => ({
@@ -187,6 +178,7 @@ const WebappsPage = (props: Props) => {
 export const getServerSideProps = createGetServerSideProps({
   requireAuth: true,
   getServerSideProps: async (ctx, client) => {
+    await WorkspaceLayout.prefetch(ctx, client);
     const { workspaceSlug } = ctx.params!;
     const page = (ctx.query.page as string)
       ? parseInt(ctx.query.page as string, 10)

--- a/frontend/src/webapps/features/FavoriteWebappButton/FavoriteWebappButton.generated.tsx
+++ b/frontend/src/webapps/features/FavoriteWebappButton/FavoriteWebappButton.generated.tsx
@@ -1,0 +1,11 @@
+import * as Types from '../../../graphql/types';
+
+import { gql } from '@apollo/client';
+export type FavoriteWebappButton_WebappFragment = { __typename?: 'Webapp', id: string, isFavorite: boolean };
+
+export const FavoriteWebappButton_WebappFragmentDoc = gql`
+    fragment FavoriteWebappButton_webapp on Webapp {
+  id
+  isFavorite
+}
+    `;

--- a/frontend/src/webapps/features/FavoriteWebappButton/FavoriteWebappButton.tsx
+++ b/frontend/src/webapps/features/FavoriteWebappButton/FavoriteWebappButton.tsx
@@ -1,0 +1,71 @@
+import { StarIcon as OutlineStarIcon } from "@heroicons/react/24/outline";
+import { StarIcon as SolidStarIcon } from "@heroicons/react/24/solid";
+import { gql } from "@apollo/client";
+import useCacheKey from "core/hooks/useCacheKey";
+import { toast } from "react-toastify";
+import {
+  useAddToFavoritesMutation,
+  useRemoveFromFavoritesMutation,
+} from "webapps/graphql/mutations.generated";
+import { useTranslation } from "next-i18next";
+import { FavoriteWebappButton_WebappFragment } from "./FavoriteWebappButton.generated";
+
+type FavoriteWebappButtonProps = {
+  webapp: FavoriteWebappButton_WebappFragment;
+};
+
+const FavoriteWebappButton = ({
+  webapp: { id: webappId, isFavorite },
+}: FavoriteWebappButtonProps) => {
+  const { t } = useTranslation();
+  const [addToFavorites] = useAddToFavoritesMutation();
+  const [removeFromFavorites] = useRemoveFromFavoritesMutation();
+
+  const clearCache = useCacheKey(["webapps"]);
+
+  const handleFavoriteClick = async () => {
+    try {
+      if (isFavorite) {
+        await removeFromFavorites({ variables: { input: { webappId } } });
+        toast.success(t("Removed from favorites"));
+      } else {
+        await addToFavorites({ variables: { input: { webappId } } });
+        toast.success(t("Added to favorites"));
+      }
+      clearCache();
+    } catch (error) {
+      toast.error(t("Error updating favorites"));
+    }
+  };
+
+  const iconClassName = "h-5 w-5 group-hover/pin:scale-125 text-amber-400";
+
+  const icon = isFavorite ? (
+    <SolidStarIcon className={iconClassName} />
+  ) : (
+    <OutlineStarIcon strokeWidth={2} className={iconClassName} />
+  );
+
+  return (
+    <button
+      className={
+        "cursor-pointer w-8 h-8 group/pin hover:p-1 transition-all flex items-center justify-center rounded-full"
+      }
+      onClick={handleFavoriteClick}
+      data-testid={`favorite-button-${webappId}`}
+    >
+      {icon}
+    </button>
+  );
+};
+
+FavoriteWebappButton.fragments = {
+  webapp: gql`
+    fragment FavoriteWebappButton_webapp on Webapp {
+      id
+      isFavorite
+    }
+  `,
+};
+
+export default FavoriteWebappButton;

--- a/frontend/src/webapps/features/FavoriteWebappButton/index.ts
+++ b/frontend/src/webapps/features/FavoriteWebappButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FavoriteWebappButton";

--- a/frontend/src/webapps/features/WebappCard/WebappCard.generated.tsx
+++ b/frontend/src/webapps/features/WebappCard/WebappCard.generated.tsx
@@ -1,0 +1,16 @@
+import * as Types from '../../../graphql/types';
+
+import { gql } from '@apollo/client';
+export type WebappCard_WebappFragment = { __typename?: 'Webapp', id: string, icon?: string | null, name: string, workspace: { __typename?: 'Workspace', slug: string, name: string } };
+
+export const WebappCard_WebappFragmentDoc = gql`
+    fragment WebappCard_webapp on Webapp {
+  id
+  icon
+  name
+  workspace {
+    slug
+    name
+  }
+}
+    `;

--- a/frontend/src/webapps/features/WebappCard/WebappCard.tsx
+++ b/frontend/src/webapps/features/WebappCard/WebappCard.tsx
@@ -1,0 +1,55 @@
+import { gql } from "@apollo/client";
+import Card from "core/components/Card";
+import { WebappCard_WebappFragment } from "./WebappCard.generated";
+import React from "react";
+import { PlayIcon } from "@heroicons/react/24/outline";
+
+type WebappCardProps = {
+  webapp: WebappCard_WebappFragment;
+};
+
+const WebappCard = ({ webapp }: WebappCardProps) => {
+  const { workspace, id, name, icon } = webapp;
+  return (
+    <Card
+      href={{
+        pathname: "/workspaces/[workspaceSlug]/webapps/[webappId]/play",
+        query: { workspaceSlug: workspace.slug, webappId: id },
+      }}
+      title={
+        <div className={"flex items-center"}>
+          {icon && (
+            <img src={icon} className="h-8 w-8 rounded mr-3" alt={"Icon"} />
+          )}
+          <h3 className="text-lg font-semibold">{name}</h3>
+        </div>
+      }
+    >
+      <div className={"flex items-center justify-end"}>
+        <div
+          className={
+            "flex items-center justify-center bg-blue-500 rounded-full h-8 w-8 hover:bg-blue-600 cursor-pointer hover:scale-110"
+          }
+        >
+          <PlayIcon className="h-4 w-4 text-white fill-white translate-x-0.25" />
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+WebappCard.fragments = {
+  webapp: gql`
+    fragment WebappCard_webapp on Webapp {
+      id
+      icon
+      name
+      workspace {
+        slug
+        name
+      }
+    }
+  `,
+};
+
+export default WebappCard;

--- a/frontend/src/webapps/features/WebappCard/index.ts
+++ b/frontend/src/webapps/features/WebappCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./WebappCard";

--- a/frontend/src/webapps/features/WebappForm/WebappForm.tsx
+++ b/frontend/src/webapps/features/WebappForm/WebappForm.tsx
@@ -16,9 +16,8 @@ import TextProperty from "core/components/DataCard/TextProperty";
 import WorkspaceLayout from "workspaces/layouts/WorkspaceLayout";
 import useCacheKey from "core/hooks/useCacheKey";
 import ImageProperty from "core/components/DataCard/ImageProperty";
-import Spinner from "core/components/Spinner";
-import clsx from "clsx";
 import useDebounce from "core/hooks/useDebounce";
+import WebappIframe from "webapps/features/WebappIframe";
 
 type WebappFormProps = {
   webapp?: WebappForm_WebappFragment;
@@ -32,7 +31,6 @@ const WebappForm = ({ workspace, webapp }: WebappFormProps) => {
   const [updateWebapp] = useUpdateWebappMutation();
   const [loading, setLoading] = useState(false);
   const [url, setUrl] = useState(webapp?.url || "");
-  const [iframeLoading, setIframeLoading] = useState(false);
   const debouncedUrl = useDebounce(url, 500);
 
   const clearCache = useCacheKey("webapps");
@@ -63,9 +61,7 @@ const WebappForm = ({ workspace, webapp }: WebappFormProps) => {
           throw new Error("Webapp creation failed");
         }
         toast.success(t("Webapp created successfully"));
-        router.push(
-          `/workspaces/${workspace.slug}/webapps/${data.createWebapp.webapp.id}`,
-        );
+        router.push(`/workspaces/${workspace.slug}/webapps`);
       });
     } catch (error) {
       toast.error(t("An error occurred while creating the webapp"));
@@ -115,7 +111,6 @@ const WebappForm = ({ workspace, webapp }: WebappFormProps) => {
           required
           onChange={(e) => {
             setUrl(e.target.value);
-            setIframeLoading(true);
           }}
         />
       </DataCard.FormSection>
@@ -125,19 +120,7 @@ const WebappForm = ({ workspace, webapp }: WebappFormProps) => {
           collapsible={false}
           loading={loading}
         >
-          <div
-            className={"flex justify-center items-center"}
-            style={{ height: "50vh" }}
-          >
-            {iframeLoading && <Spinner size="md" />}{" "}
-            <iframe
-              src={debouncedUrl}
-              className={clsx("w-full h-full", iframeLoading && "hidden")}
-              sandbox="allow-forms allow-popups allow-downloads allow-presentation allow-modals allow-scripts"
-              onLoad={() => setIframeLoading(false)}
-              onError={() => setIframeLoading(false)}
-            />
-          </div>
+          <WebappIframe url={debouncedUrl} style={{ height: "65vh" }} />
         </DataCard.Section>
       )}
     </DataCard>

--- a/frontend/src/webapps/features/WebappIframe/WebappIframe.test.tsx
+++ b/frontend/src/webapps/features/WebappIframe/WebappIframe.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import WebappIframe from "./WebappIframe";
+
+describe("WebappIframe", () => {
+  it("⚠️ should not allow same origin iframe attribute for url of same origin", () => {
+    const url = window.location.origin + "/some-path";
+    render(<WebappIframe url={url} />);
+
+    const iframe = screen.getByTestId("webapp-iframe");
+    expect(iframe).toHaveAttribute(
+      "sandbox",
+      "allow-forms allow-popups allow-downloads allow-presentation allow-modals allow-scripts",
+    );
+    expect(iframe.getAttribute("sandbox")).not.toContain("allow-same-origin");
+  });
+
+  it("should set sandbox permissions correctly for different origin url", () => {
+    const url = "https://different-origin.com/some-path";
+    render(<WebappIframe url={url} />);
+
+    const iframe = screen.getByTestId("webapp-iframe");
+    expect(iframe).toHaveAttribute(
+      "sandbox",
+      "allow-forms allow-popups allow-downloads allow-presentation allow-modals allow-scripts allow-same-origin",
+    );
+  });
+});

--- a/frontend/src/webapps/features/WebappIframe/WebappIframe.tsx
+++ b/frontend/src/webapps/features/WebappIframe/WebappIframe.tsx
@@ -1,0 +1,51 @@
+import clsx from "clsx";
+import React, { useEffect, useMemo, useState } from "react";
+import Spinner from "core/components/Spinner";
+
+type WebappIframeProps = {
+  url: string;
+  className?: string;
+  style?: React.CSSProperties;
+};
+
+const WebappIframe = ({ url, className, style }: WebappIframeProps) => {
+  const [iframeLoading, setIframeLoading] = useState(true);
+
+  useEffect(() => {
+    setIframeLoading(true);
+  }, [url]);
+
+  const isSameOrigin = useMemo(() => {
+    try {
+      const { origin } = new URL(url);
+      return origin === window.location.origin;
+    } catch {
+      return false;
+    }
+  }, [url]);
+
+  const commonPermissions =
+    "allow-forms allow-popups allow-downloads allow-presentation allow-modals allow-scripts";
+  const sandboxPermissions = isSameOrigin
+    ? commonPermissions // Do not allow same origin requests if it's an OpenHexa URL
+    : `${commonPermissions} allow-same-origin`;
+
+  return (
+    <div
+      className={clsx("flex justify-center items-center", className)}
+      style={{ height: "90vh", ...style }}
+    >
+      {iframeLoading && <Spinner size="md" />}{" "}
+      <iframe
+        src={url}
+        className={clsx("w-full h-full", iframeLoading && "hidden")}
+        sandbox={sandboxPermissions}
+        onLoad={() => setIframeLoading(false)}
+        onError={() => setIframeLoading(false)}
+        data-testid="webapp-iframe"
+      />
+    </div>
+  );
+};
+
+export default WebappIframe;

--- a/frontend/src/webapps/features/WebappIframe/index.tsx
+++ b/frontend/src/webapps/features/WebappIframe/index.tsx
@@ -1,0 +1,3 @@
+import WebappIframe from "./WebappIframe";
+
+export default WebappIframe;

--- a/frontend/src/webapps/tests/WebappsPage.test.tsx
+++ b/frontend/src/webapps/tests/WebappsPage.test.tsx
@@ -111,6 +111,11 @@ const graphqlMocks: MockedResponse[] = [
             webapp((index + 1).toString()),
           ),
         },
+        favoriteWebapps: {
+          items: [],
+          totalPages: 0,
+          totalItems: 0,
+        },
       },
     },
   },
@@ -155,7 +160,7 @@ describe("WebappsPage", () => {
       expect(screen.getByText("Webapp 1")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByTestId("star-icon-1"));
+    fireEvent.click(screen.getByTestId("favorite-button-1"));
 
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith("Added to favorites");
@@ -188,7 +193,7 @@ describe("WebappsPage", () => {
       expect(screen.getByText("Webapp 2")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByTestId("star-icon-2"));
+    fireEvent.click(screen.getByTestId("favorite-button-2"));
 
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith("Removed from favorites");

--- a/frontend/src/workspaces/features/DeleteConnectionTrigger/DeleteConnectionTrigger.test.tsx
+++ b/frontend/src/workspaces/features/DeleteConnectionTrigger/DeleteConnectionTrigger.test.tsx
@@ -18,8 +18,11 @@ describe("DeleteConnectionTrigger", () => {
       },
     };
     const Children = jest.fn().mockReturnValue(null);
-    const { container } = render(
-      <DeleteConnectionTrigger workspace={{ id: "1" }} connection={CONNECTION}>
+    render(
+      <DeleteConnectionTrigger
+        workspace={{ slug: "1" }}
+        connection={CONNECTION}
+      >
         {Children}
       </DeleteConnectionTrigger>,
     );
@@ -36,8 +39,8 @@ describe("DeleteConnectionTrigger", () => {
       },
     };
     const Children = jest.fn().mockReturnValue(null);
-    const { container } = render(
-      <DeleteConnectionTrigger workspace={{ id: "" }} connection={CONNECTION}>
+    render(
+      <DeleteConnectionTrigger workspace={{ slug: "" }} connection={CONNECTION}>
         {Children}
       </DeleteConnectionTrigger>,
     );
@@ -54,9 +57,9 @@ describe("DeleteConnectionTrigger", () => {
       },
     };
     const Children = jest.fn().mockReturnValue(null);
-    const { container } = render(
+    render(
       <DeleteConnectionTrigger
-        workspace={{ id: "W_ID" }}
+        workspace={{ slug: "W_ID" }}
         connection={CONNECTION}
       >
         {Children}

--- a/frontend/src/workspaces/graphql/queries.generated.tsx
+++ b/frontend/src/workspaces/graphql/queries.generated.tsx
@@ -35,6 +35,7 @@ import { ConnectionFieldsSection_ConnectionFragmentDoc } from '../features/Conne
 import { TemplateCard_TemplateFragmentDoc } from '../features/TemplateCard/TemplateCard.generated';
 import { TemplateLayout_TemplateFragmentDoc } from '../layouts/TemplateLayout/TemplateLayout.generated';
 import { TemplateVersionCard_VersionFragmentDoc } from '../../pipelines/features/TemplateVersionCard/TemplateVersionCard.generated';
+import { WebappCard_WebappFragmentDoc } from '../../webapps/features/WebappCard/WebappCard.generated';
 import { WebappForm_WorkspaceFragmentDoc, WebappForm_WebappFragmentDoc } from '../../webapps/features/WebappForm/WebappForm.generated';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
@@ -242,7 +243,7 @@ export type WorkspaceWebappsPageQueryVariables = Types.Exact<{
 }>;
 
 
-export type WorkspaceWebappsPageQuery = { __typename?: 'Query', workspace?: { __typename?: 'Workspace', slug: string, name: string, permissions: { __typename?: 'WorkspacePermissions', manageMembers: boolean, update: boolean, launchNotebookServer: boolean }, countries: Array<{ __typename?: 'Country', flag: string, code: string }> } | null, webapps: { __typename?: 'WebappsPage', totalPages: number, totalItems: number, items: Array<{ __typename?: 'Webapp', id: string, name: string, icon?: string | null, description?: string | null, url: string, isFavorite: boolean, createdBy: { __typename?: 'User', firstName?: string | null, lastName?: string | null, id: string, email: string, displayName: string, avatar: { __typename?: 'Avatar', initials: string, color: string } }, workspace: { __typename?: 'Workspace', slug: string, name: string }, permissions: { __typename?: 'WebappPermissions', update: boolean, delete: boolean } }> } };
+export type WorkspaceWebappsPageQuery = { __typename?: 'Query', workspace?: { __typename?: 'Workspace', slug: string, name: string, permissions: { __typename?: 'WorkspacePermissions', manageMembers: boolean, update: boolean, launchNotebookServer: boolean }, countries: Array<{ __typename?: 'Country', flag: string, code: string }> } | null, webapps: { __typename?: 'WebappsPage', totalPages: number, totalItems: number, items: Array<{ __typename?: 'Webapp', id: string, name: string, icon?: string | null, description?: string | null, url: string, isFavorite: boolean, createdBy: { __typename?: 'User', firstName?: string | null, lastName?: string | null, id: string, email: string, displayName: string, avatar: { __typename?: 'Avatar', initials: string, color: string } }, workspace: { __typename?: 'Workspace', slug: string, name: string }, permissions: { __typename?: 'WebappPermissions', update: boolean, delete: boolean } }> }, favoriteWebapps: { __typename?: 'WebappsPage', items: Array<{ __typename?: 'Webapp', id: string, icon?: string | null, name: string, workspace: { __typename?: 'Workspace', slug: string, name: string } }> } };
 
 export type WorkspaceWebappPageQueryVariables = Types.Exact<{
   workspaceSlug: Types.Scalars['String']['input'];
@@ -1750,9 +1751,20 @@ export const WorkspaceWebappsPageDocument = gql`
       }
     }
   }
+  favoriteWebapps: webapps(
+    workspaceSlug: $workspaceSlug
+    favorite: true
+    page: 1
+    perPage: 6
+  ) {
+    items {
+      ...WebappCard_webapp
+    }
+  }
 }
     ${WorkspaceLayout_WorkspaceFragmentDoc}
-${User_UserFragmentDoc}`;
+${User_UserFragmentDoc}
+${WebappCard_WebappFragmentDoc}`;
 
 /**
  * __useWorkspaceWebappsPageQuery__

--- a/frontend/src/workspaces/graphql/queries.graphql
+++ b/frontend/src/workspaces/graphql/queries.graphql
@@ -700,6 +700,16 @@ query WorkspaceWebappsPage(
       }
     }
   }
+  favoriteWebapps: webapps(
+    workspaceSlug: $workspaceSlug
+    favorite: true
+    page: 1
+    perPage: 6
+  ) {
+    items {
+      ...WebappCard_webapp
+    }
+  }
 }
 
 query WorkspaceWebappPage($workspaceSlug: String!, $webappId: UUID!) {


### PR DESCRIPTION
Improve Web apps UI base don Mariano's feedback after testing

## Changes

- Update GraphQL schema according to latest backend version in https://github.com/BLSQ/openhexa-app/pull/959
- Add missing `await WorkspaceLayout.prefetch(ctx, client);` to avoid SRR issues
- Add a list of favorites
- Add a play button in the web apps grid
- `FavoriteWebappButton` based on Datasets example
- `WebappCard` to show favorites
- Encapsulate `iframe` logic in `WebappIframe`
- Ensure the `iframe` has the correct permissive attributes with a uni test


## Screenshots / screencast

![Screenshot 2025-03-31 at 10 19 31](https://github.com/user-attachments/assets/27fd62f9-37f9-4158-b583-a16befda1e47)
![Screenshot 2025-03-31 at 10 19 43](https://github.com/user-attachments/assets/3759d4a4-b2ca-4fc8-9b78-4a9f8c75ae88)