### PR TITLE
Redirect the url already hosted on Vercel to the new one in Django.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 ### Backend ###
 *.env
+data/
 .coverage
 .local/
 .cache/

--- a/backend/hexa/superset/api.py
+++ b/backend/hexa/superset/api.py
@@ -105,3 +105,8 @@ class SupersetClient:
             return response.json()["token"]
         except HTTPError as e:
             raise SupersetError(f"Failed to get guest token: {e}", response=e.response)
+
+    def request(self, method: str, endpoint: str, **kwargs):
+        response = self.session.request(method, self.base_url + endpoint, **kwargs)
+        response.raise_for_status()
+        return response.json()

--- a/frontend/server/index.mjs
+++ b/frontend/server/index.mjs
@@ -12,6 +12,12 @@ const handle = app.getRequestHandler();
 app.prepare().then(async () => {
   const server = express();
 
+  // Redirect /dashboards/[externalId] to /superset/dashboards/external/[externalId]
+  // This is a temporary redirect until we have completely migrated from the older dashboard embedding solution
+  server.get("/dashboards/:externalId", (req, res) => {
+    res.redirect(301, `/superset/dashboard/external/${req.params.externalId}`);
+  });
+
   server.use(
     "/",
     proxy(api_url, {


### PR DESCRIPTION
+ Add logging in Sentry to know which dashboards are still reached using the former url