### PR TITLE
chore: comment unused GraphQL types (HEXA-1238)

### DIFF
--- a/backend/hexa/plugins/connector_dhis2/graphql/schema.graphql
+++ b/backend/hexa/plugins/connector_dhis2/graphql/schema.graphql
@@ -1,20 +1,21 @@
-type DHIS2Instance {
-    id: String!
-    name: String!
-    url: String
-}
-
-type DHIS2DataElement {
-    id: String!
-    name: String!  # TODO: complete
-    code: String!
-    createdAt: DateTime!
-    updatedAt: DateTime!
-    instance: DHIS2Instance!
-}
-type DHIS2DataElementPage {
-    pageNumber: Int!
-    totalPages: Int!
-    totalItems: Int!
-    items: [DHIS2DataElement!]!
-}
+# Not imported by Ariadne, so commenting out for now
+#type DHIS2Instance {
+#    id: String!
+#    name: String!
+#    url: String
+#}
+#
+#type DHIS2DataElement {
+#    id: String!
+#    name: String!  # TODO: complete
+#    code: String!
+#    createdAt: DateTime!
+#    updatedAt: DateTime!
+#    instance: DHIS2Instance!
+#}
+#type DHIS2DataElementPage {
+#    pageNumber: Int!
+#    totalPages: Int!
+#    totalItems: Int!
+#    items: [DHIS2DataElement!]!
+#}

--- a/frontend/schema.generated.graphql
+++ b/frontend/schema.generated.graphql
@@ -1027,28 +1027,6 @@ enum DHIS2ConnectionStatus {
   UP
 }
 
-type DHIS2DataElement {
-  code: String!
-  createdAt: DateTime!
-  id: String!
-  instance: DHIS2Instance!
-  name: String!
-  updatedAt: DateTime!
-}
-
-type DHIS2DataElementPage {
-  items: [DHIS2DataElement!]!
-  pageNumber: Int!
-  totalItems: Int!
-  totalPages: Int!
-}
-
-type DHIS2Instance {
-  id: String!
-  name: String!
-  url: String
-}
-
 """DHIS2 metadata item"""
 type DHIS2MetadataItem {
   id: String

--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -1100,31 +1100,6 @@ export enum Dhis2ConnectionStatus {
   Up = 'UP'
 }
 
-export type Dhis2DataElement = {
-  __typename?: 'DHIS2DataElement';
-  code: Scalars['String']['output'];
-  createdAt: Scalars['DateTime']['output'];
-  id: Scalars['String']['output'];
-  instance: Dhis2Instance;
-  name: Scalars['String']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-};
-
-export type Dhis2DataElementPage = {
-  __typename?: 'DHIS2DataElementPage';
-  items: Array<Dhis2DataElement>;
-  pageNumber: Scalars['Int']['output'];
-  totalItems: Scalars['Int']['output'];
-  totalPages: Scalars['Int']['output'];
-};
-
-export type Dhis2Instance = {
-  __typename?: 'DHIS2Instance';
-  id: Scalars['String']['output'];
-  name: Scalars['String']['output'];
-  url?: Maybe<Scalars['String']['output']>;
-};
-
 /** DHIS2 metadata item */
 export type Dhis2MetadataItem = {
   __typename?: 'DHIS2MetadataItem';


### PR DESCRIPTION
To allow https://github.com/BLSQ/openhexa-sdk-python/pull/260 , we need to remove/ignore unimplemented types
 
## Changes

- Remove `connector_dhis2` types and run codegen