### PR TITLE
chore: Expose globally enabled feature flags to users via GraphQL & remove FeatureFlag.config from GraphQL (not used)

### DIFF
--- a/backend/hexa/analytics/api.py
+++ b/backend/hexa/analytics/api.py
@@ -4,7 +4,7 @@ from mixpanel import Mixpanel
 from sentry_sdk import capture_exception
 from ua_parser import user_agent_parser
 
-from hexa.user_management.models import AnonymousUser, User
+from hexa.user_management.models import AnonymousUser, Feature, User
 
 mixpanel = None
 if settings.MIXPANEL_TOKEN:
@@ -86,7 +86,11 @@ def set_user_properties(user: User):
                 "$name": user.display_name,
                 "is_staff": user.is_staff,
                 "is_superuser": user.is_superuser,
-                "features_flag": [f.feature.code for f in user.featureflag_set.all()],
+                "features_flag": list(
+                    Feature.objects.are_enabled_for_user(user=user).values_list(
+                        "code", flat=True
+                    )
+                ),
             },
         )
     except Exception as e:

--- a/backend/hexa/user_management/graphql/schema.graphql
+++ b/backend/hexa/user_management/graphql/schema.graphql
@@ -1026,11 +1026,10 @@ type FeatureFlag {
     The code of the feature flag.
     """
     code: String!
-
     """
-    The configuration of the feature flag.
+    The configuration of the feature flag (deprecated).
     """
-    config: JSON!
+    config: JSON! @deprecated(reason: "This field is deprecated and will be removed in the next version. In the meantime it always returns an empty object.")
 }
 
 extend type Query {

--- a/backend/hexa/user_management/tests/test_schema.py
+++ b/backend/hexa/user_management/tests/test_schema.py
@@ -70,7 +70,7 @@ class SchemaTest(GraphQLTestCase):
 
         cls.FEATURE = Feature.objects.create(code="nice_feature")
         cls.TAYLOR_FEATURE_FLAG = FeatureFlag.objects.create(
-            feature=cls.FEATURE, user=cls.USER_TAYLOR, config={"config_argument": 10}
+            feature=cls.FEATURE, user=cls.USER_TAYLOR
         )
 
         cls.USER_JANE.emaildevice_set.create(name="default", user=cls.USER_JANE)
@@ -128,7 +128,6 @@ class SchemaTest(GraphQLTestCase):
                   }
                   features {
                     code
-                    config
                   }
                   permissions {
                     createTeam
@@ -168,7 +167,6 @@ class SchemaTest(GraphQLTestCase):
                 me {
                   features {
                     code
-                    config
                   }
                   user {
                     id
@@ -183,7 +181,6 @@ class SchemaTest(GraphQLTestCase):
                 "features": [
                     {
                         "code": self.TAYLOR_FEATURE_FLAG.feature.code,
-                        "config": self.TAYLOR_FEATURE_FLAG.config,
                     }
                 ],
                 "user": {

--- a/frontend/schema.generated.graphql
+++ b/frontend/schema.generated.graphql
@@ -1745,8 +1745,8 @@ type FeatureFlag {
   """The code of the feature flag."""
   code: String!
 
-  """The configuration of the feature flag."""
-  config: JSON!
+  """The configuration of the feature flag (deprecated)."""
+  config: JSON! @deprecated(reason: "This field is deprecated and will be removed in the next version. In the meantime it always returns an empty object.")
 }
 
 type File {

--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -1858,7 +1858,10 @@ export type FeatureFlag = {
   __typename?: 'FeatureFlag';
   /** The code of the feature flag. */
   code: Scalars['String']['output'];
-  /** The configuration of the feature flag. */
+  /**
+   * The configuration of the feature flag (deprecated).
+   * @deprecated This field is deprecated and will be removed in the next version. In the meantime it always returns an empty object.
+   */
   config: Scalars['JSON']['output'];
 };
 

--- a/frontend/src/identity/graphql/queries.generated.tsx
+++ b/frontend/src/identity/graphql/queries.generated.tsx
@@ -8,7 +8,7 @@ const defaultOptions = {} as const;
 export type GetUserQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type GetUserQuery = { __typename?: 'Query', me: { __typename?: 'Me', hasTwoFactorEnabled: boolean, permissions: { __typename?: 'MePermissions', adminPanel: boolean, superUser: boolean, createWorkspace: boolean }, features: Array<{ __typename?: 'FeatureFlag', code: string, config: any }>, user?: { __typename?: 'User', email: string, id: string, firstName?: string | null, lastName?: string | null, displayName: string, language: string, avatar: { __typename?: 'Avatar', initials: string, color: string } } | null } };
+export type GetUserQuery = { __typename?: 'Query', me: { __typename?: 'Me', hasTwoFactorEnabled: boolean, permissions: { __typename?: 'MePermissions', adminPanel: boolean, superUser: boolean, createWorkspace: boolean }, features: Array<{ __typename?: 'FeatureFlag', code: string }>, user?: { __typename?: 'User', email: string, id: string, firstName?: string | null, lastName?: string | null, displayName: string, language: string, avatar: { __typename?: 'Avatar', initials: string, color: string } } | null } };
 
 export type AccountPageQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
@@ -32,7 +32,6 @@ export const GetUserDocument = gql`
     }
     features {
       code
-      config
     }
     user {
       ...UserAvatar_user

--- a/frontend/src/identity/graphql/queries.graphql
+++ b/frontend/src/identity/graphql/queries.graphql
@@ -8,7 +8,6 @@ query GetUser {
     }
     features {
       code
-      config
     }
     user {
       ...UserAvatar_user

--- a/frontend/src/identity/hooks/__tests__/useFeature.test.tsx
+++ b/frontend/src/identity/hooks/__tests__/useFeature.test.tsx
@@ -3,7 +3,7 @@ import useFeature from "../useFeature";
 
 const FEATURES = [
   { code: "a_feature", config: {} },
-  { code: "b_feature", config: { specialConfig: "xyz" } },
+  { code: "b_feature", config: {} },
 ];
 
 const mockMe = jest.fn(() => ({
@@ -17,23 +17,23 @@ describe("useFeature", () => {
     const { result } = renderHook((props) => useFeature(props.code), {
       initialProps: { code: "unknown" },
     });
-    expect(result.current).toEqual([false, null]);
+    expect(result.current).toEqual([false]);
   });
   it("returns the feature and its config", async () => {
     const { result } = renderHook(() => useFeature("b_feature"));
-    expect(result.current).toEqual([true, { specialConfig: "xyz" }]);
+    expect(result.current).toEqual([true]);
   });
   it("returns the new feature if the code changes on render", async () => {
     const { result, rerender } = renderHook((props) => useFeature(props.code), {
       initialProps: { code: "unknown" },
     });
 
-    expect(result.current).toEqual([false, null]);
+    expect(result.current).toEqual([false]);
 
     rerender({ code: "a_feature" });
-    expect(result.current).toEqual([true, {}]);
+    expect(result.current).toEqual([true]);
 
     rerender({ code: "b_feature" });
-    expect(result.current).toEqual([true, { specialConfig: "xyz" }]);
+    expect(result.current).toEqual([true]);
   });
 });

--- a/frontend/src/identity/hooks/useFeature.ts
+++ b/frontend/src/identity/hooks/useFeature.ts
@@ -1,10 +1,7 @@
 import { useMemo } from "react";
 import useMe from "./useMe";
 
-type UseFeatureResult = [
-  isEnabled: boolean,
-  config: { [key: string]: any } | null,
-];
+type UseFeatureResult = [isEnabled: boolean];
 
 export default function useFeature(code: string): UseFeatureResult {
   const me = useMe();
@@ -14,5 +11,5 @@ export default function useFeature(code: string): UseFeatureResult {
     [me, code],
   );
 
-  return [Boolean(feature), feature?.config ?? null];
+  return [Boolean(feature)];
 }


### PR DESCRIPTION
Globally enabled features were not sent to the frontend via `me.features`.
The new implementation returns all the features flags (global & user enabled).
The FeatureFlag.config has been removed from the API as it has never been used. 

## How/what to test

- Test with a feature with `force_activate = True`. It should be returned as a feature flag of the user
