### PR TITLE
fix : search bar, navigating to templates can fail because the user is not member of the workspace (HEXA-1261) 

### DIFF
--- a/frontend/src/core/features/SpotlightSearch/HighlightedLink.tsx
+++ b/frontend/src/core/features/SpotlightSearch/HighlightedLink.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from "react";
 import Link from "core/components/Link";
 import { getLink, getObject } from "./mapper";
 import useHighlightRow from "./useHighlightRow";
+import { useRouter } from "next/router";
 
 type HighlightedLinkProps = {
   item: any;
@@ -16,6 +17,11 @@ const HighlightedLink = ({
   isActive,
   data,
 }: HighlightedLinkProps) => {
+  const router = useRouter();
+  const { workspaceSlug: currentWorkspaceSlug } = router.query as {
+    workspaceSlug: string | undefined;
+  };
+
   const resultRefs = useRef<(HTMLDivElement | null)[]>([]);
   useHighlightRow(resultRefs, highlightedIndex, [isActive, data]);
 
@@ -29,7 +35,9 @@ const HighlightedLink = ({
       tabIndex={-1}
       className="focus:outline-none"
     >
-      <Link href={{ pathname: getLink(item) }}>{getObject(item).name}</Link>
+      <Link href={{ pathname: getLink(item, currentWorkspaceSlug) }}>
+        {getObject(item).name}
+      </Link>
     </div>
   );
 };

--- a/frontend/src/core/features/SpotlightSearch/mapper.ts
+++ b/frontend/src/core/features/SpotlightSearch/mapper.ts
@@ -122,8 +122,11 @@ const getUrlId = (item: Item): string => {
   }
 };
 
-export const getLink = (item: Item): string => {
-  const workspaceSlug = getWorkspace(item).slug;
+export const getLink = (item: Item, currentWorkspaceSlug?: string): string => {
+  const workspaceSlug =
+    item.__typename === "PipelineTemplateResult" && currentWorkspaceSlug
+      ? currentWorkspaceSlug
+      : getWorkspace(item).slug;
   if (!item.__typename) return "";
   if (item.__typename === "FileResult") {
     const object = getObject(item);

--- a/frontend/src/core/features/SpotlightSearch/useSearchHotkeys.tsx
+++ b/frontend/src/core/features/SpotlightSearch/useSearchHotkeys.tsx
@@ -21,6 +21,9 @@ const useSearchHotkeys = ({
   setHighlightedIndex,
 }: UseSearchHotkeysParams) => {
   const router = useRouter();
+  const { workspaceSlug: currentWorkspaceSlug } = router.query as {
+    workspaceSlug: string | undefined;
+  };
 
   // Open and close the search
   useHotkeys(
@@ -70,7 +73,7 @@ const useSearchHotkeys = ({
   useHotkeys(
     "enter",
     () => {
-      const href = getLink(data[highlightedIndex]);
+      const href = getLink(data[highlightedIndex], currentWorkspaceSlug);
       href && router.push(href).then();
     },
     { enableOnFormTags: ["INPUT"], enabled: isOpen },


### PR DESCRIPTION
Templates are objects that can be shared across workspaces. If a user has no access to the workspace were the template was created, the link directing to the template page will not work. We can use the current workspace instead since the user has access to it