### PR TITLE
fix: The name of the latest version of a dataset cannot be edited (HEXA-1257)

### DIFF
--- a/frontend/src/pages/workspaces/[workspaceSlug]/datasets/[datasetSlug]/index.tsx
+++ b/frontend/src/pages/workspaces/[workspaceSlug]/datasets/[datasetSlug]/index.tsx
@@ -144,12 +144,7 @@ const WorkspaceDatasetPage: NextPageWithLayout = (
                 label={t("Changelog")}
                 sm
               />
-              <TextProperty
-                id="name"
-                accessor="name"
-                label={t("Name")}
-                visible={({ isEditing }) => isEditing || isSpecificVersion}
-              />
+              <TextProperty id="name" accessor="name" label={t("Name")} />
               <DateProperty
                 id="createdAt"
                 accessor="createdAt"


### PR DESCRIPTION
We want to be able to edit the name of the last version of a dataset