### PR TITLE
Add missing superset route to the anonymous routes

### DIFF
--- a/backend/hexa/superset/apps.py
+++ b/backend/hexa/superset/apps.py
@@ -5,4 +5,4 @@ class SupersetConfig(CoreAppConfig):
     name = "hexa.superset"
     label = "superset"
 
-    ANONYMOUS_URLS = ["superset:dashboard"]
+    ANONYMOUS_URLS = ["superset:dashboard", "superset:dashboard-external"]


### PR DESCRIPTION
The default route was accessible without authentication but not the one used to replace the former system on Vercel.
