### PR TITLE
fix: Caching and SRR of pipelines (HEXA-1262)

### DIFF
--- a/frontend/src/pipelines/features/Pipelines/Pipelines.generated.tsx
+++ b/frontend/src/pipelines/features/Pipelines/Pipelines.generated.tsx
@@ -1,19 +1,6 @@
 import * as Types from '../../../graphql/types';
 
 import { gql } from '@apollo/client';
-import { PipelineCard_PipelineFragmentDoc } from '../../../workspaces/features/PipelineCard/PipelineCard.generated';
-import * as Apollo from '@apollo/client';
-const defaultOptions = {} as const;
-export type GetPipelinesQueryVariables = Types.Exact<{
-  page: Types.Scalars['Int']['input'];
-  perPage: Types.Scalars['Int']['input'];
-  search?: Types.InputMaybe<Types.Scalars['String']['input']>;
-  workspaceSlug?: Types.InputMaybe<Types.Scalars['String']['input']>;
-}>;
-
-
-export type GetPipelinesQuery = { __typename?: 'Query', pipelines: { __typename?: 'PipelinesPage', pageNumber: number, totalPages: number, totalItems: number, items: Array<{ __typename?: 'Pipeline', id: string, code: string, name?: string | null, schedule?: string | null, description?: string | null, type: Types.PipelineType, currentVersion?: { __typename?: 'PipelineVersion', versionName: string, createdAt: any, user?: { __typename?: 'User', id: string, email: string, displayName: string, avatar: { __typename?: 'Avatar', initials: string, color: string } } | null } | null, lastRuns: { __typename?: 'PipelineRunPage', items: Array<{ __typename?: 'PipelineRun', id: string, status: Types.PipelineRunStatus }> } }> } };
-
 export type Pipelines_WorkspaceFragment = { __typename?: 'Workspace', slug: string };
 
 export const Pipelines_WorkspaceFragmentDoc = gql`
@@ -21,56 +8,3 @@ export const Pipelines_WorkspaceFragmentDoc = gql`
   slug
 }
     `;
-export const GetPipelinesDocument = gql`
-    query GetPipelines($page: Int!, $perPage: Int!, $search: String, $workspaceSlug: String) {
-  pipelines(
-    page: $page
-    perPage: $perPage
-    search: $search
-    workspaceSlug: $workspaceSlug
-  ) {
-    pageNumber
-    totalPages
-    totalItems
-    items {
-      ...PipelineCard_pipeline
-    }
-  }
-}
-    ${PipelineCard_PipelineFragmentDoc}`;
-
-/**
- * __useGetPipelinesQuery__
- *
- * To run a query within a React component, call `useGetPipelinesQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetPipelinesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetPipelinesQuery({
- *   variables: {
- *      page: // value for 'page'
- *      perPage: // value for 'perPage'
- *      search: // value for 'search'
- *      workspaceSlug: // value for 'workspaceSlug'
- *   },
- * });
- */
-export function useGetPipelinesQuery(baseOptions: Apollo.QueryHookOptions<GetPipelinesQuery, GetPipelinesQueryVariables> & ({ variables: GetPipelinesQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetPipelinesQuery, GetPipelinesQueryVariables>(GetPipelinesDocument, options);
-      }
-export function useGetPipelinesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetPipelinesQuery, GetPipelinesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetPipelinesQuery, GetPipelinesQueryVariables>(GetPipelinesDocument, options);
-        }
-export function useGetPipelinesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetPipelinesQuery, GetPipelinesQueryVariables>) {
-          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
-          return Apollo.useSuspenseQuery<GetPipelinesQuery, GetPipelinesQueryVariables>(GetPipelinesDocument, options);
-        }
-export type GetPipelinesQueryHookResult = ReturnType<typeof useGetPipelinesQuery>;
-export type GetPipelinesLazyQueryHookResult = ReturnType<typeof useGetPipelinesLazyQuery>;
-export type GetPipelinesSuspenseQueryHookResult = ReturnType<typeof useGetPipelinesSuspenseQuery>;
-export type GetPipelinesQueryResult = Apollo.QueryResult<GetPipelinesQuery, GetPipelinesQueryVariables>;

--- a/frontend/src/pipelines/features/Pipelines/Pipelines.tsx
+++ b/frontend/src/pipelines/features/Pipelines/Pipelines.tsx
@@ -1,14 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { gql } from "@apollo/client";
-import {
-  Pipelines_WorkspaceFragment,
-  useGetPipelinesQuery,
-} from "./Pipelines.generated";
+import { Pipelines_WorkspaceFragment } from "./Pipelines.generated";
 import Header from "../PipelineTemplates/Header";
 import GridView from "./GridView";
 import CardView from "./CardView";
 import useDebounce from "core/hooks/useDebounce";
 import Spinner from "core/components/Spinner";
+import { useWorkspacePipelinesPageQuery } from "workspaces/graphql/queries.generated";
 
 type PipelinesProps = {
   workspace: Pipelines_WorkspaceFragment;
@@ -21,7 +19,7 @@ const Pipelines = ({ workspace }: PipelinesProps) => {
   const [page, setPage] = useState(1);
   const perPage = 10;
 
-  const { data, loading } = useGetPipelinesQuery({
+  const { data, loading } = useWorkspacePipelinesPageQuery({
     variables: {
       workspaceSlug: workspace.slug,
       search: debouncedSearchQuery,
@@ -69,29 +67,6 @@ const Pipelines = ({ workspace }: PipelinesProps) => {
     </div>
   );
 };
-
-const GET_PIPELINES = gql`
-  query GetPipelines(
-    $page: Int!
-    $perPage: Int!
-    $search: String
-    $workspaceSlug: String
-  ) {
-    pipelines(
-      page: $page
-      perPage: $perPage
-      search: $search
-      workspaceSlug: $workspaceSlug
-    ) {
-      pageNumber
-      totalPages
-      totalItems
-      items {
-        ...PipelineCard_pipeline
-      }
-    }
-  }
-`;
 
 Pipelines.fragments = {
   workspace: gql`

--- a/frontend/src/pipelines/features/Pipelines/Pipelines.tsx
+++ b/frontend/src/pipelines/features/Pipelines/Pipelines.tsx
@@ -10,14 +10,21 @@ import { useWorkspacePipelinesPageQuery } from "workspaces/graphql/queries.gener
 
 type PipelinesProps = {
   workspace: Pipelines_WorkspaceFragment;
+  page: number;
+  perPage: number;
+  search: string;
 };
 
-const Pipelines = ({ workspace }: PipelinesProps) => {
-  const [searchQuery, setSearchQuery] = useState("");
+const Pipelines = ({
+  workspace,
+  page: initialPage,
+  perPage,
+  search: initialSearch,
+}: PipelinesProps) => {
+  const [searchQuery, setSearchQuery] = useState(initialSearch);
   const debouncedSearchQuery = useDebounce(searchQuery, 300);
   const [view, setView] = useState<"grid" | "card">("grid");
-  const [page, setPage] = useState(1);
-  const perPage = 10;
+  const [page, setPage] = useState(initialPage);
 
   const { data, loading } = useWorkspacePipelinesPageQuery({
     variables: {

--- a/frontend/src/workspaces/graphql/queries.generated.tsx
+++ b/frontend/src/workspaces/graphql/queries.generated.tsx
@@ -53,6 +53,7 @@ export type WorkspacePageQuery = { __typename?: 'Query', workspace?: { __typenam
 
 export type WorkspacePipelinesPageQueryVariables = Types.Exact<{
   workspaceSlug: Types.Scalars['String']['input'];
+  search?: Types.InputMaybe<Types.Scalars['String']['input']>;
   page?: Types.InputMaybe<Types.Scalars['Int']['input']>;
   perPage?: Types.InputMaybe<Types.Scalars['Int']['input']>;
 }>;
@@ -354,14 +355,19 @@ export type WorkspacePageLazyQueryHookResult = ReturnType<typeof useWorkspacePag
 export type WorkspacePageSuspenseQueryHookResult = ReturnType<typeof useWorkspacePageSuspenseQuery>;
 export type WorkspacePageQueryResult = Apollo.QueryResult<WorkspacePageQuery, WorkspacePageQueryVariables>;
 export const WorkspacePipelinesPageDocument = gql`
-    query WorkspacePipelinesPage($workspaceSlug: String!, $page: Int, $perPage: Int) {
+    query WorkspacePipelinesPage($workspaceSlug: String!, $search: String, $page: Int, $perPage: Int) {
   workspace(slug: $workspaceSlug) {
     slug
     name
     ...WorkspaceLayout_workspace
     ...CreatePipelineDialog_workspace
   }
-  pipelines(workspaceSlug: $workspaceSlug, page: $page, perPage: $perPage) {
+  pipelines(
+    workspaceSlug: $workspaceSlug
+    search: $search
+    page: $page
+    perPage: $perPage
+  ) {
     items {
       ...PipelineCard_pipeline
     }
@@ -387,6 +393,7 @@ ${PipelineCard_PipelineFragmentDoc}`;
  * const { data, loading, error } = useWorkspacePipelinesPageQuery({
  *   variables: {
  *      workspaceSlug: // value for 'workspaceSlug'
+ *      search: // value for 'search'
  *      page: // value for 'page'
  *      perPage: // value for 'perPage'
  *   },

--- a/frontend/src/workspaces/graphql/queries.graphql
+++ b/frontend/src/workspaces/graphql/queries.graphql
@@ -30,6 +30,7 @@ query WorkspacePage($slug: String!) {
 
 query WorkspacePipelinesPage(
   $workspaceSlug: String!
+  $search: String
   $page: Int
   $perPage: Int
 ) {
@@ -40,7 +41,7 @@ query WorkspacePipelinesPage(
     ...CreatePipelineDialog_workspace
   }
 
-  pipelines(workspaceSlug: $workspaceSlug, page: $page, perPage: $perPage) {
+  pipelines(workspaceSlug: $workspaceSlug, search: $search, page: $page, perPage: $perPage) {
     items {
       ...PipelineCard_pipeline
     }


### PR DESCRIPTION
Loading the pipelines page was causing unneeded data fetching since the data was in the apollo cache

## Changes

- Ensure the pipelines are queried during SRR
- Pass down the variables used for the query to the Pipelines component
- Leverage `useWorkspacePipelinesPageQuery` instead of defining a GraphQL query inline
