### PR TITLE
fix: web hook toggle can be changed while not in edit mode (HEXA-1264)

### DIFF
--- a/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/index.tsx
+++ b/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/index.tsx
@@ -270,8 +270,13 @@ const WorkspacePipelinePage: NextPageWithLayout = (props: Props) => {
             {(property, section) => (
               <div className="flex items-center gap-2">
                 <Switch
-                  checked={property.formValue}
+                  checked={
+                    section.isEdited
+                      ? property.formValue
+                      : property.displayValue
+                  }
                   onChange={property.setValue}
+                  disabled={!section.isEdited}
                 />
                 {section.isEdited && (
                   <span className="text-xs text-gray-500">


### PR DESCRIPTION
Prevent the web hook toggle to be edited if not in edit mode. And also ensure that the checked value is always defined (it caused errors in the console)