### PR TITLE
fix: profiling and sampling issue with infinity (HEXA-1278)

### DIFF
--- a/backend/hexa/datasets/queue.py
+++ b/backend/hexa/datasets/queue.py
@@ -116,7 +116,9 @@ def generate_profile(df: pd.DataFrame) -> list:
         constant_values = df.apply(lambda x: x.nunique() == 1).astype("bool").to_dict()
         count = df.count().to_dict()
 
-        numeric_df = df.select_dtypes(include=["number"])
+        numeric_df = df.select_dtypes(include=["number"]).replace(
+            [np.inf, -np.inf], np.nan
+        )
         numeric_df = numeric_df.dropna(
             how="all", axis=1
         )  # Drop numeric columns with all NaN values

--- a/backend/hexa/datasets/queue.py
+++ b/backend/hexa/datasets/queue.py
@@ -81,8 +81,8 @@ def generate_sample(
                 replace=True,
             )
             sample = sample.replace(
-                [np.inf, -np.inf], np.nan
-            )  # We are not supporting Infinity
+                {np.inf: "inf", -np.inf: "-inf"}
+            )  # We are not supporting Infinity as numbers
             dataset_file_sample.sample = sample.to_dict(orient="records")
         dataset_file_sample.status = DatasetFileSample.STATUS_FINISHED
     except Exception as e:

--- a/backend/hexa/datasets/queue.py
+++ b/backend/hexa/datasets/queue.py
@@ -80,6 +80,9 @@ def generate_sample(
                 random_state=SAMPLING_SEED,
                 replace=True,
             )
+            sample = sample.replace(
+                [np.inf, -np.inf], np.nan
+            )  # We are not supporting Infinity
             dataset_file_sample.sample = sample.to_dict(orient="records")
         dataset_file_sample.status = DatasetFileSample.STATUS_FINISHED
     except Exception as e:

--- a/backend/hexa/datasets/tests/test_generate_sample.py
+++ b/backend/hexa/datasets/tests/test_generate_sample.py
@@ -271,6 +271,7 @@ class TestCreateDatasetFileSampleTask(TestCase, DatasetTestMixin):
             {
                 1234: [2, 4, 6, 8, 10],
                 12345: [1.0, None, None, None, None],
+                123456: ["inf", "-inf", "inf", "inf", "-inf"],
                 "str_column": ["a", "b", "c", "d", "e"],
             }
         )
@@ -309,6 +310,15 @@ class TestCreateDatasetFileSampleTask(TestCase, DatasetTestMixin):
                     "maximum": 1.0,
                     "quantiles25": 1.0,
                     "quantiles75": 1.0,
+                },
+                {
+                    "column_name": "123456",
+                    "constant_values": False,
+                    "count": 5,
+                    "data_type": "string",
+                    "distinct_values": 2,
+                    "missing_values": 0,
+                    "unique_values": 2,
                 },
                 {
                     "column_name": "str_column",

--- a/backend/hexa/datasets/tests/test_generate_sample.py
+++ b/backend/hexa/datasets/tests/test_generate_sample.py
@@ -1,6 +1,7 @@
 import os
 from unittest.mock import patch
 
+import numpy as np
 import pandas as pd
 from django.contrib.contenttypes.models import ContentType
 from django.test import override_settings
@@ -271,7 +272,7 @@ class TestCreateDatasetFileSampleTask(TestCase, DatasetTestMixin):
             {
                 1234: [2, 4, 6, 8, 10],
                 12345: [1.0, None, None, None, None],
-                123456: ["inf", "-inf", "inf", "inf", "-inf"],
+                123456: [np.inf, -np.inf, np.inf, -np.inf, np.inf],
                 "str_column": ["a", "b", "c", "d", "e"],
             }
         )
@@ -315,7 +316,7 @@ class TestCreateDatasetFileSampleTask(TestCase, DatasetTestMixin):
                     "column_name": "123456",
                     "constant_values": False,
                     "count": 5,
-                    "data_type": "string",
+                    "data_type": "float64",
                     "distinct_values": 2,
                     "missing_values": 0,
                     "unique_values": 2,


### PR DESCRIPTION
We have errors coming up when infinity is used in column numbers. But it's not supported well by postgresql and our statistics methods

## Changes

- Replace infinity by the equivalent string for sampling
- Replace infinity by 0 for profiling
- Update the profiling unit test 