### PR TITLE
HEXA-1283 Remove deprecated `requiredStatusChecks`...

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,6 @@
     "automerge": true
   },
   "prConcurrentLimit": 5,
-  "requiredStatusChecks": null,
   "pip_requirements": {
     "enabled": false
   },


### PR DESCRIPTION
from renovate.json.

See: https://github.com/renovatebot/renovate/discussions/28461

From the docs:

> Currently Renovate's default behavior is to only automerge if every status check has succeeded.

Source: https://docs.renovatebot.com/configuration-options/#ignoretests

Let's see if removing this line will fix the issue of prematurely auto-merged PRs.