### PR TITLE
Revert "chore(deps): update graphqlcodegenerator monorepo (#1165)"

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3396,18 +3396,16 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/near-operation-file-preset": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/near-operation-file-preset/-/near-operation-file-preset-3.0.1.tgz",
-      "integrity": "sha512-78eINBoKLUQlQh49R+D7RaYNyGv0fQWaLkY2PXMM4ShJqcFLxrgA68MTYX5Q4ceK/m4TDIqD6kbD62EkAGEBFQ==",
+      "version": "3.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-codegen/add": "^3.2.1",
         "@graphql-codegen/plugin-helpers": "^3.0.0",
-        "@graphql-codegen/visitor-plugin-common": "2.13.8",
+        "@graphql-codegen/visitor-plugin-common": "2.13.1",
         "@graphql-tools/utils": "^10.0.0",
         "parse-filepath": "^1.0.2",
-        "tslib": "^2.8.1"
+        "tslib": "~2.6.0"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -3418,8 +3416,6 @@
     },
     "node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-codegen/plugin-helpers": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
-      "integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3436,8 +3432,6 @@
     },
     "node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-codegen/plugin-helpers/node_modules/@graphql-tools/utils": {
       "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3450,22 +3444,17 @@
     },
     "node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/near-operation-file-preset/node_modules/@graphql-tools/utils": {
-      "version": "10.8.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.6.tgz",
-      "integrity": "sha512-Alc9Vyg0oOsGhRapfL3xvqh1zV8nKoFUdtLhXX7Ki4nClaIJXckrA86j+uxEuG3ic6j4jlM1nvcWXRn/71AVLQ==",
+      "version": "10.1.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
-        "@whatwg-node/promise-helpers": "^1.0.0",
-        "cross-inspect": "1.0.1",
-        "dset": "^3.1.4",
+        "cross-inspect": "1.0.0",
+        "dset": "^3.1.2",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -3477,8 +3466,6 @@
     },
     "node_modules/@graphql-codegen/near-operation-file-preset/node_modules/change-case-all": {
       "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.15.tgz",
-      "integrity": "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3494,23 +3481,8 @@
         "upper-case-first": "^2.0.2"
       }
     },
-    "node_modules/@graphql-codegen/near-operation-file-preset/node_modules/cross-inspect": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
-      "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@graphql-codegen/near-operation-file-preset/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "version": "2.6.2",
       "dev": true,
       "license": "0BSD"
     },
@@ -4027,17 +3999,17 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/typescript-react-apollo": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-react-apollo/-/typescript-react-apollo-4.3.3.tgz",
-      "integrity": "sha512-ecuzzqoZEHCtlxaEXL1LQTrfzVYwNNtbVUBHc/KQDfkJIQZon+dG5ZXOoJ4BpbRA2L99yTx+TZc2VkpOVfSypw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-react-apollo/-/typescript-react-apollo-4.3.2.tgz",
+      "integrity": "sha512-io2tWfeehBqOB2X6llqLE6B9wjjsXZT/GTZlguGVXdbR7WhSJO9GXyLflXYKxom/h2bPjkVL534Ev6wZLcs0wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^3.0.0",
-        "@graphql-codegen/visitor-plugin-common": "2.13.8",
+        "@graphql-codegen/visitor-plugin-common": "2.13.1",
         "auto-bind": "~4.0.0",
         "change-case-all": "1.0.15",
-        "tslib": "^2.8.1"
+        "tslib": "~2.6.0"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -4105,9 +4077,9 @@
       }
     },
     "node_modules/@graphql-codegen/typescript-react-apollo/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
       "dev": true,
       "license": "0BSD"
     },
@@ -4293,18 +4265,16 @@
       "license": "0BSD"
     },
     "node_modules/@graphql-codegen/visitor-plugin-common": {
-      "version": "2.13.8",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-2.13.8.tgz",
-      "integrity": "sha512-IQWu99YV4wt8hGxIbBQPtqRuaWZhkQRG2IZKbMoSvh0vGeWb3dB0n0hSgKaOOxDY+tljtOf9MTcUYvJslQucMQ==",
+      "version": "2.13.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@graphql-codegen/plugin-helpers": "^3.1.2",
+        "@graphql-codegen/plugin-helpers": "^2.7.2",
         "@graphql-tools/optimize": "^1.3.0",
         "@graphql-tools/relay-operation-optimizer": "^6.5.0",
-        "@graphql-tools/utils": "^9.0.0",
+        "@graphql-tools/utils": "^8.8.0",
         "auto-bind": "~4.0.0",
-        "change-case-all": "1.0.15",
+        "change-case-all": "1.0.14",
         "dependency-graph": "^0.11.0",
         "graphql-tag": "^2.11.0",
         "parse-filepath": "^1.0.2",
@@ -4312,57 +4282,6 @@
       },
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-codegen/plugin-helpers": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-3.1.2.tgz",
-      "integrity": "sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-tools/utils": "^9.0.0",
-        "change-case-all": "1.0.15",
-        "common-tags": "1.8.2",
-        "import-from": "4.0.0",
-        "lodash": "~4.17.0",
-        "tslib": "~2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/change-case-all": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/change-case-all/-/change-case-all-1.0.15.tgz",
-      "integrity": "sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^4.1.2",
-        "is-lower-case": "^2.0.2",
-        "is-upper-case": "^2.0.2",
-        "lower-case": "^2.0.2",
-        "lower-case-first": "^2.0.2",
-        "sponge-case": "^1.0.1",
-        "swap-case": "^2.0.2",
-        "title-case": "^3.0.3",
-        "upper-case": "^2.0.2",
-        "upper-case-first": "^2.0.2"
       }
     },
     "node_modules/@graphql-tools/apollo-engine-loader": {


### PR DESCRIPTION
This reverts commit 6e036791c26fb92b96257570e9ac733ffb493843.

This patch update broke our build by removing GraphQL fragments after running `npm run codegen`.