### PR TITLE
fix: progress overlay

### DIFF
--- a/frontend/src/pages/OverlayProgress.tsx
+++ b/frontend/src/pages/OverlayProgress.tsx
@@ -15,7 +15,11 @@ const OverlayProgress = () => {
         workspaceSlug: string | undefined;
       };
 
-      if (!workspaceSlug || !url.includes(workspaceSlug)) {
+      if (
+        workspaceSlug &&
+        url.includes("/workspaces/") &&
+        !url.includes(workspaceSlug)
+      ) {
         setIsVisible(true);
       }
     };


### PR DESCRIPTION
Switching workspace overlay should only appear when moving between workspaces