### PR TITLE
fix: searching when changing page of results & UI glitch caused by z-index (HEXA-1293)

### DIFF
--- a/frontend/src/core/components/forms/Input/Input.tsx
+++ b/frontend/src/core/components/forms/Input/Input.tsx
@@ -22,16 +22,16 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     leading = null,
     value,
     fullWidth = false,
-    zIndex = "focus:z-10",
+    zIndex = "z-10",
     ...delegated
   } = props;
 
   const inputClassName = clsx(
     classNameOverrides,
     "form-input appearance-none relative block",
-    "px-3 py-2 border rounded-md focus:outline-hidden sm:text-sm",
-    zIndex,
-    "disabled:opacity-50 disabled:cursor-not-allowed",
+    "px-3 py-2 border rounded-md focus:outline-hidden",
+    "focus:" + zIndex,
+    "sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed",
     error
       ? "border-red-300 placeholder-red-300  text-red-900  focus:ring-red-500  focus:border-red-500"
       : "border-gray-300 placeholder-gray-500 text-gray-900 focus:ring-blue-500 focus:border-blue-500",
@@ -58,8 +58,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
       {leading && (
         <div
           className={clsx(
-            "absolute inset-y-0 left-0 inline-flex items-center justify-center pl-2.5",
+            "absolute inset-y-0 left-0",
             zIndex,
+            "inline-flex items-center justify-center pl-2.5",
           )}
         >
           {leading}
@@ -68,8 +69,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
       {trailingIcon && (
         <div
           className={clsx(
-            "absolute inset-y-0 right-0 inline-flex items-center justify-center pr-2.5",
+            "absolute inset-y-0 right-0",
             zIndex,
+            "inline-flex items-center justify-center pr-2.5",
           )}
         >
           {trailingIcon}

--- a/frontend/src/core/components/forms/Input/Input.tsx
+++ b/frontend/src/core/components/forms/Input/Input.tsx
@@ -7,7 +7,7 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   leading?: ReactNode;
   fullWidth?: boolean;
   classNameOverrides?: string;
-  zIndex?: string;
+  iconZIndex?: string;
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
@@ -22,7 +22,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     leading = null,
     value,
     fullWidth = false,
-    zIndex = "z-10",
+    iconZIndex = "z-10",
     ...delegated
   } = props;
 
@@ -30,7 +30,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     classNameOverrides,
     "form-input appearance-none relative block",
     "px-3 py-2 border rounded-md focus:outline-hidden",
-    "focus:" + zIndex,
+    "focus:" + iconZIndex,
     "sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed",
     error
       ? "border-red-300 placeholder-red-300  text-red-900  focus:ring-red-500  focus:border-red-500"
@@ -59,7 +59,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
         <div
           className={clsx(
             "absolute inset-y-0 left-0",
-            zIndex,
+            iconZIndex,
             "inline-flex items-center justify-center pl-2.5",
           )}
         >
@@ -70,7 +70,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
         <div
           className={clsx(
             "absolute inset-y-0 right-0",
-            zIndex,
+            iconZIndex,
             "inline-flex items-center justify-center pr-2.5",
           )}
         >

--- a/frontend/src/core/components/forms/Input/Input.tsx
+++ b/frontend/src/core/components/forms/Input/Input.tsx
@@ -7,6 +7,7 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   leading?: ReactNode;
   fullWidth?: boolean;
   classNameOverrides?: string;
+  zIndex?: string;
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
@@ -21,6 +22,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     leading = null,
     value,
     fullWidth = false,
+    zIndex = "focus:z-10",
     ...delegated
   } = props;
 
@@ -28,7 +30,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     classNameOverrides,
     "form-input appearance-none relative block",
     "px-3 py-2 border rounded-md focus:outline-hidden sm:text-sm",
-    classNameOverrides?.includes("focus:z-") && "focus:z-10",
+    zIndex,
     "disabled:opacity-50 disabled:cursor-not-allowed",
     error
       ? "border-red-300 placeholder-red-300  text-red-900  focus:ring-red-500  focus:border-red-500"
@@ -54,12 +56,22 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
         ref={ref}
       />
       {leading && (
-        <div className="absolute inset-y-0 left-0 z-10 inline-flex items-center justify-center pl-2.5">
+        <div
+          className={clsx(
+            "absolute inset-y-0 left-0 inline-flex items-center justify-center pl-2.5",
+            zIndex,
+          )}
+        >
           {leading}
         </div>
       )}
       {trailingIcon && (
-        <div className="absolute inset-y-0 right-0 z-10 inline-flex items-center justify-center pr-2.5">
+        <div
+          className={clsx(
+            "absolute inset-y-0 right-0 inline-flex items-center justify-center pr-2.5",
+            zIndex,
+          )}
+        >
           {trailingIcon}
         </div>
       )}

--- a/frontend/src/core/components/forms/Input/Input.tsx
+++ b/frontend/src/core/components/forms/Input/Input.tsx
@@ -27,7 +27,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const inputClassName = clsx(
     classNameOverrides,
     "form-input appearance-none relative block",
-    "px-3 py-2 border rounded-md focus:outline-hidden sm:text-sm",
+    "px-3 py-2 border rounded-md focus:outline-hidden focus:z-10 sm:text-sm",
     "disabled:opacity-50 disabled:cursor-not-allowed",
     error
       ? "border-red-300 placeholder-red-300  text-red-900  focus:ring-red-500  focus:border-red-500"
@@ -53,12 +53,12 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
         ref={ref}
       />
       {leading && (
-        <div className="absolute inset-y-0 left-0 inline-flex items-center justify-center pl-2.5">
+        <div className="absolute inset-y-0 left-0 z-10 inline-flex items-center justify-center pl-2.5">
           {leading}
         </div>
       )}
       {trailingIcon && (
-        <div className="absolute inset-y-0 right-0 inline-flex items-center justify-center pr-2.5">
+        <div className="absolute inset-y-0 right-0 z-10 inline-flex items-center justify-center pr-2.5">
           {trailingIcon}
         </div>
       )}

--- a/frontend/src/core/components/forms/Input/Input.tsx
+++ b/frontend/src/core/components/forms/Input/Input.tsx
@@ -27,7 +27,8 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const inputClassName = clsx(
     classNameOverrides,
     "form-input appearance-none relative block",
-    "px-3 py-2 border rounded-md focus:outline-hidden focus:z-10 sm:text-sm",
+    "px-3 py-2 border rounded-md focus:outline-hidden sm:text-sm",
+    classNameOverrides?.includes("focus:z-") && "focus:z-10",
     "disabled:opacity-50 disabled:cursor-not-allowed",
     error
       ? "border-red-300 placeholder-red-300  text-red-900  focus:ring-red-500  focus:border-red-500"

--- a/frontend/src/core/components/forms/Input/Input.tsx
+++ b/frontend/src/core/components/forms/Input/Input.tsx
@@ -27,7 +27,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const inputClassName = clsx(
     classNameOverrides,
     "form-input appearance-none relative block",
-    "px-3 py-2 border rounded-md focus:outline-hidden focus:z-10 sm:text-sm",
+    "px-3 py-2 border rounded-md focus:outline-hidden sm:text-sm",
     "disabled:opacity-50 disabled:cursor-not-allowed",
     error
       ? "border-red-300 placeholder-red-300  text-red-900  focus:ring-red-500  focus:border-red-500"
@@ -53,12 +53,12 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
         ref={ref}
       />
       {leading && (
-        <div className="absolute inset-y-0 left-0 z-10 inline-flex items-center justify-center pl-2.5">
+        <div className="absolute inset-y-0 left-0 inline-flex items-center justify-center pl-2.5">
           {leading}
         </div>
       )}
       {trailingIcon && (
-        <div className="absolute inset-y-0 right-0 z-10 inline-flex items-center justify-center pr-2.5">
+        <div className="absolute inset-y-0 right-0 inline-flex items-center justify-center pr-2.5">
           {trailingIcon}
         </div>
       )}

--- a/frontend/src/core/features/SearchInput.tsx
+++ b/frontend/src/core/features/SearchInput.tsx
@@ -31,7 +31,7 @@ const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           autoComplete="off"
           trailingIcon={loading && <Spinner size="xs" />}
           className={className}
-          zIndex="z-0"
+          iconZIndex="z-0"
           placeholder={placeholder}
           {...delegated}
         />

--- a/frontend/src/core/features/SearchInput.tsx
+++ b/frontend/src/core/features/SearchInput.tsx
@@ -31,6 +31,7 @@ const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           autoComplete="off"
           trailingIcon={loading && <Spinner size="xs" />}
           className={className}
+          classNameOverrides="z-0"
           placeholder={placeholder}
           {...delegated}
         />

--- a/frontend/src/core/features/SearchInput.tsx
+++ b/frontend/src/core/features/SearchInput.tsx
@@ -31,7 +31,7 @@ const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
           autoComplete="off"
           trailingIcon={loading && <Spinner size="xs" />}
           className={className}
-          classNameOverrides="z-0"
+          zIndex="z-0"
           placeholder={placeholder}
           {...delegated}
         />

--- a/frontend/src/core/hooks/useDebounce.ts
+++ b/frontend/src/core/hooks/useDebounce.ts
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react";
 
 // Comes from usehooks.com
-export default function useDebounce<T = any>(value: T, delay = 300) {
+export default function useDebounce<T = any>(
+  value: T,
+  delay = 300,
+  callback?: (debouncedValue: T) => void,
+) {
   // State and setters for debounced value
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
 
@@ -10,6 +14,9 @@ export default function useDebounce<T = any>(value: T, delay = 300) {
       // Update debounced value after delay
       const handler = setTimeout(() => {
         setDebouncedValue(value);
+        if (callback) {
+          callback(value);
+        }
       }, delay);
 
       // Cancel the timeout if value changes (also on delay change or unmount)

--- a/frontend/src/pipelines/features/Pipelines/GridView.tsx
+++ b/frontend/src/pipelines/features/Pipelines/GridView.tsx
@@ -20,6 +20,7 @@ type GridViewProps = {
 const GridView = ({
   items,
   workspace,
+  page,
   perPage,
   totalItems,
   setPage,
@@ -32,6 +33,7 @@ const GridView = ({
         data={items}
         defaultPageSize={perPage}
         totalItems={totalItems}
+        defaultPageIndex={page - 1}
         fetchData={({ page }) => setPage(page)}
         fixedLayout={false}
       >

--- a/frontend/src/pipelines/features/Pipelines/Pipelines.tsx
+++ b/frontend/src/pipelines/features/Pipelines/Pipelines.tsx
@@ -22,7 +22,9 @@ const Pipelines = ({
   search: initialSearch,
 }: PipelinesProps) => {
   const [searchQuery, setSearchQuery] = useState(initialSearch);
-  const debouncedSearchQuery = useDebounce(searchQuery, 300);
+  const debouncedSearchQuery = useDebounce(searchQuery, 300, () => {
+    setPage(1); // Reset to first page when debounce completes
+  });
   const [view, setView] = useState<"grid" | "card">("grid");
   const [page, setPage] = useState(initialPage);
 


### PR DESCRIPTION
We receive a [sentry alert ](https://bluesquareorg.sentry.io/issues/6635357862/?alert_rule_id=7767430&alert_type=issue&notification_uuid=30177688-c53d-40a9-91a9-280093fd7dc0&project=5893042&referrer=slack) because when changing page of results while searching for pipelines and then searching again, the page is not reset to 1.

- Reset the page to 1 after the debounce when the query is changing
- Fix a UI glitch caused by z-indexes 