### PR TITLE
fix: Allow Superset dashboard in web apps

### DIFF
--- a/frontend/src/webapps/features/WebappIframe/WebappIframe.test.tsx
+++ b/frontend/src/webapps/features/WebappIframe/WebappIframe.test.tsx
@@ -15,6 +15,19 @@ describe("WebappIframe", () => {
     expect(iframe.getAttribute("sandbox")).not.toContain("allow-same-origin");
   });
 
+  it("⚠️ exceptionally allows same origin iframe attribute for Superset dashboards", () => {
+    const url =
+      window.location.origin +
+      "/superset/dashboard/f140a424-5817-4e07-a8fa-eab36257ea6e/";
+    render(<WebappIframe url={url} />);
+
+    const iframe = screen.getByTestId("webapp-iframe");
+    expect(iframe).toHaveAttribute(
+      "sandbox",
+      "allow-forms allow-popups allow-downloads allow-presentation allow-modals allow-scripts allow-same-origin",
+    );
+  });
+
   it("should set sandbox permissions correctly for different origin url", () => {
     const url = "https://different-origin.com/some-path";
     render(<WebappIframe url={url} />);


### PR DESCRIPTION
The comment explains it. I think the "correct" solution is to not embed Superset using and `iframe` inside an `iframe`, but rather have a dedicated module in OpenHEXA for "Dashboards".

In the meantime, I see no other way than to use the unsafe setting to unblock our users. In the end, I don't even think it's really unsafe since the HTML we're serving here is 100% by us, and the second iframe that actually embeds the dashboard is serving from another domain.