### PR TITLE
fix(dataset): wraps long filename to display download button, PATHWAY…

### DIFF
--- a/frontend/src/datasets/features/DatasetVersionFilesDataGrid/DatasetVersionFilesDataGrid.tsx
+++ b/frontend/src/datasets/features/DatasetVersionFilesDataGrid/DatasetVersionFilesDataGrid.tsx
@@ -77,11 +77,23 @@ const DatasetVersionFilesDataGrid = (
       fetchData={onFetchData}
       fixedLayout={false}
     >
-      <TextColumn label={t("Filename")} accessor="filename" />
-      <DateColumn label={t("Created at")} accessor="createdAt" />
-      <TextColumn label={t("Content type")} accessor="contentType" />
+      <TextColumn 
+        label={t("Filename")} 
+        accessor="filename"
+        className="min-w-0 flex-1"
+      />
+      <DateColumn 
+        label={t("Created at")} 
+        accessor="createdAt"
+        className="whitespace-nowrap"
+      />
+      <TextColumn 
+        label={t("Content type")} 
+        accessor="contentType"
+        className="whitespace-nowrap"
+      />
       {version.permissions.download && (
-        <BaseColumn className="text-right">
+        <BaseColumn className="flex-shrink-0 text-right whitespace-nowrap">
           {(item) => (
             <DownloadVersionFile file={item} variant="outlined" size="sm" />
           )}


### PR DESCRIPTION
Fixes long filename hiding download button

<img width="1749" height="488" alt="Screenshot 2025-08-12 at 12 42 20" src="https://github.com/user-attachments/assets/40e82069-d59f-4834-95ae-cac02789f774" />
