### PR TITLE
fix:  images in emails are not shown correctly, at least in gmail (HEXA-1351)

### DIFF
--- a/backend/hexa/core/utils.py
+++ b/backend/hexa/core/utils.py
@@ -48,7 +48,7 @@ def send_mail(
 
     if attachments:
         for filename, content, mimetype in attachments:
-            if mimetype.startswith("image/"):
+            if mimetype.startswith("image/") and not mimetype == "image/svg+xml":
                 image = MIMEImage(content)
                 image.add_header("Content-ID", f"<{filename}>")
                 mail.attach(image)

--- a/backend/hexa/core/utils.py
+++ b/backend/hexa/core/utils.py
@@ -1,3 +1,4 @@
+import os
 import typing
 from email.mime.image import MIMEImage
 
@@ -5,6 +6,22 @@ from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from mjml import mjml2html
+
+
+def get_email_attachments():
+    """Get standard email attachments including OpenHEXA logo"""
+    return [
+        (
+            "logo_with_text_white.png",
+            open(
+                os.path.join(
+                    settings.BASE_DIR, "hexa/static/img/logo/logo_with_text_white.png"
+                ),
+                "rb",
+            ).read(),
+            "image/png",
+        ),
+    ]
 
 
 def send_mail(

--- a/backend/hexa/pipelines/utils.py
+++ b/backend/hexa/pipelines/utils.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 
 from django.conf import settings
 from django.utils import timezone
@@ -13,6 +14,21 @@ from .models import (
     PipelineRun,
     PipelineRunState,
 )
+
+
+def get_email_attachments():
+    return [
+        (
+            "logo_with_text_white.png",
+            open(
+                os.path.join(
+                    settings.BASE_DIR, "hexa/static/img/logo/logo_with_text_white.svg"
+                ),
+                "rb",
+            ).read(),
+            "image/png",
+        ),
+    ]
 
 
 def mail_run_recipients(run: PipelineRun):
@@ -42,6 +58,7 @@ def mail_run_recipients(run: PipelineRun):
                     "run_url": f"{settings.NEW_FRONTEND_DOMAIN}/workspaces/{workspace_slug}/pipelines/{run.pipeline.code}/runs/{run.id}",
                 },
                 recipient_list=[recipient.user.email],
+                attachments=get_email_attachments(),
             )
 
 

--- a/backend/hexa/pipelines/utils.py
+++ b/backend/hexa/pipelines/utils.py
@@ -16,21 +16,6 @@ from .models import (
 )
 
 
-def get_email_attachments():
-    return [
-        (
-            "logo_with_text_white.png",
-            open(
-                os.path.join(
-                    settings.BASE_DIR, "hexa/static/img/logo/logo_with_text_white.svg"
-                ),
-                "rb",
-            ).read(),
-            "image/png",
-        ),
-    ]
-
-
 def mail_run_recipients(run: PipelineRun):
     workspace_slug = run.pipeline.workspace.slug
     for recipient in run.pipeline.pipelinerecipient_set.all():
@@ -58,7 +43,19 @@ def mail_run_recipients(run: PipelineRun):
                     "run_url": f"{settings.NEW_FRONTEND_DOMAIN}/workspaces/{workspace_slug}/pipelines/{run.pipeline.code}/runs/{run.id}",
                 },
                 recipient_list=[recipient.user.email],
-                attachments=get_email_attachments(),
+                attachments=[
+                    (
+                        "logo_with_text_white.svg",
+                        open(
+                            os.path.join(
+                                settings.BASE_DIR,
+                                "hexa/static/img/logo/logo_with_text_white.svg",
+                            ),
+                            "rb",
+                        ).read(),
+                        "image/svg+xml",
+                    ),
+                ],
             )
 
 

--- a/backend/hexa/user_management/utils.py
+++ b/backend/hexa/user_management/utils.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timezone
 from urllib.parse import urlencode
 
+from django.conf import settings
 from django.utils.translation import gettext_lazy, override
 from django_otp import devices_for_user, user_has_device
 
-from config import settings
 from hexa.analytics.api import track
 from hexa.core.utils import get_email_attachments, send_mail
 from hexa.user_management.models import Organization

--- a/backend/hexa/user_management/utils.py
+++ b/backend/hexa/user_management/utils.py
@@ -22,26 +22,6 @@ def has_configured_two_factor(user):
     return user.is_authenticated and user_has_device(user)
 
 
-def get_email_attachments():
-    """Get standard email attachments including OpenHEXA logo"""
-    import os
-
-    from django.conf import settings
-
-    return [
-        (
-            "logo_with_text_white.png",
-            open(
-                os.path.join(
-                    settings.BASE_DIR, "hexa/static/img/logo/logo_with_text_white.png"
-                ),
-                "rb",
-            ).read(),
-            "image/png",
-        ),
-    ]
-
-
 def send_organization_invite(invitation):
     """Send invitation email to organization"""
     from datetime import datetime, timezone
@@ -51,7 +31,7 @@ def send_organization_invite(invitation):
     from django.utils.translation import gettext_lazy, override
 
     from hexa.analytics.api import track
-    from hexa.core.utils import send_mail
+    from hexa.core.utils import get_email_attachments, send_mail
 
     title = gettext_lazy(
         f"You've been invited to join the organization {invitation.organization.name} on OpenHEXA"
@@ -98,7 +78,7 @@ def send_organization_add_user_email(
     from django.utils.translation import gettext_lazy, override
 
     from hexa.analytics.api import track
-    from hexa.core.utils import send_mail
+    from hexa.core.utils import get_email_attachments, send_mail
 
     title = gettext_lazy(
         f"You've been added to the organization {organization.name} on OpenHEXA"

--- a/backend/hexa/user_management/utils.py
+++ b/backend/hexa/user_management/utils.py
@@ -1,5 +1,12 @@
+from datetime import datetime, timezone
+from urllib.parse import urlencode
+
+from django.utils.translation import gettext_lazy, override
 from django_otp import devices_for_user, user_has_device
 
+from config import settings
+from hexa.analytics.api import track
+from hexa.core.utils import get_email_attachments, send_mail
 from hexa.user_management.models import Organization
 
 USER_DEFAULT_DEVICE_ATTR_NAME = "_default_device"
@@ -24,15 +31,6 @@ def has_configured_two_factor(user):
 
 def send_organization_invite(invitation):
     """Send invitation email to organization"""
-    from datetime import datetime, timezone
-    from urllib.parse import urlencode
-
-    from django.conf import settings
-    from django.utils.translation import gettext_lazy, override
-
-    from hexa.analytics.api import track
-    from hexa.core.utils import get_email_attachments, send_mail
-
     title = gettext_lazy(
         f"You've been invited to join the organization {invitation.organization.name} on OpenHEXA"
     )
@@ -72,14 +70,6 @@ def send_organization_add_user_email(
     invited_by, organization: Organization, invitee, role, workspace_invitations=None
 ):
     """Send email to existing user when added to organization"""
-    from datetime import datetime, timezone
-
-    from django.conf import settings
-    from django.utils.translation import gettext_lazy, override
-
-    from hexa.analytics.api import track
-    from hexa.core.utils import get_email_attachments, send_mail
-
     title = gettext_lazy(
         f"You've been added to the organization {organization.name} on OpenHEXA"
     )

--- a/backend/hexa/workspaces/utils.py
+++ b/backend/hexa/workspaces/utils.py
@@ -1,4 +1,3 @@
-import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import StrEnum
@@ -9,26 +8,11 @@ from django.utils.translation import gettext_lazy, override
 from openhexa.toolbox.dhis2 import DHIS2
 from openhexa.toolbox.iaso import IASO
 
-from hexa.core.utils import send_mail as send_mail
+from hexa.core.utils import get_email_attachments, send_mail
 from hexa.user_management.models import User
 
 from ..analytics.api import track
 from .models import Connection, ConnectionType, Workspace, WorkspaceInvitation
-
-
-def get_email_attachments():
-    return [
-        (
-            "logo_with_text_white.png",
-            open(
-                os.path.join(
-                    settings.BASE_DIR, "hexa/static/img/logo/logo_with_text_white.png"
-                ),
-                "rb",
-            ).read(),
-            "image/png",
-        ),
-    ]
 
 
 def send_workspace_add_user_email(


### PR DESCRIPTION
Attachments were missing in the `send_email` call

## Changes

- Add the missing `.svg` attachment
- Extract into utils a helper method to include the `.png` logo, to be reused across the apps.