### PR TITLE
fix: apollo deprecated config after dependency upgrade (HEXA-1357)

### DIFF
--- a/frontend/src/core/helpers/apollo.ts
+++ b/frontend/src/core/helpers/apollo.ts
@@ -24,7 +24,6 @@ let apolloClient: CustomApolloClient | undefined;
 const CACHE_CONFIG: InMemoryCacheConfig = {
   // possibleTypes must be provided to cache correctly unions and interfaces
   // https://www.apollographql.com/docs/react/data/fragments/#using-fragments-with-unions-and-interfaces
-  addTypename: true,
   possibleTypes: require("graphql/possibleTypes.json").possibleTypes,
   typePolicies: {
     Team: {

--- a/frontend/src/core/helpers/testutils.tsx
+++ b/frontend/src/core/helpers/testutils.tsx
@@ -24,7 +24,7 @@ export function TestApp(props: TestAppProps) {
     ...(props.me ?? {}),
   };
   return (
-    <MockedProvider addTypename={true} mocks={props.mocks ?? []}>
+    <MockedProvider mocks={props.mocks ?? []}>
       <MeProvider me={me}>{props.children}</MeProvider>
     </MockedProvider>
   );


### PR DESCRIPTION
After some dependency upgrade, I am getting 

https://www.apollographql.com/docs/react/errors#%7B%22version%22%3A%223.14.0%22%2C%22message%22%3A104%2C%22args%22%3A%5B%22InMemoryCache%22%2C%22addTypename%22%2C%22Please%20remove%20the%20%60addTypename%60%20option%20when%20initializing%20%60InMemoryCache%60.%22%5D%7D

Remove the config