### PR TITLE
fix: permissions and redirect when revoking access to a shared dataset (HEXA-1353)

### DIFF
--- a/backend/hexa/datasets/models.py
+++ b/backend/hexa/datasets/models.py
@@ -499,7 +499,7 @@ class DatasetLink(Base):
     objects = DatasetLinkQuerySet.as_manager()
 
     def delete_if_has_perm(self, *, principal: User):
-        if not principal.has_perm("datasets.delete_linked_dataset", self):
+        if not principal.has_perm("datasets.delete_dataset_link", self):
             raise PermissionDenied
         self.delete()
 

--- a/frontend/src/core/helpers/apollo.ts
+++ b/frontend/src/core/helpers/apollo.ts
@@ -63,6 +63,9 @@ const CACHE_CONFIG: InMemoryCacheConfig = {
     DatasetPermissions: {
       merge: true,
     },
+    DatasetLinkPermissions: {
+      merge: true,
+    },
     DatabaseTable: {
       merge: true,
     },

--- a/frontend/src/datasets/features/DeleteDatasetLinkTrigger/DeleteDatasetLinkTrigger.tsx
+++ b/frontend/src/datasets/features/DeleteDatasetLinkTrigger/DeleteDatasetLinkTrigger.tsx
@@ -14,6 +14,7 @@ type DeleteDatasetLinkTriggerProps = {
 
 const DeleteDatasetLinkTrigger = (props: DeleteDatasetLinkTriggerProps) => {
   const { t } = useTranslation();
+  const router = useRouter();
   const {
     datasetLink,
     children,
@@ -33,6 +34,9 @@ const DeleteDatasetLinkTrigger = (props: DeleteDatasetLinkTriggerProps) => {
     }
     try {
       await deleteDatasetLink(datasetLink.id);
+      if(datasetLink.workspace.slug == router.query.workspaceSlug) { // If we are in the same workspace, redirect to datasets list
+        await router.push(`/workspaces/${datasetLink.workspace.slug}/datasets`);
+      }
     } catch (err: any) {
       toast.error(err.message);
     }


### PR DESCRIPTION
Correct the permission and add a redirection when the dataset is not shared anymore with the workspace