### PR TITLE
fix: url of dataset when searching (PATHWAYS-895)

### DIFF
--- a/frontend/src/core/features/SpotlightSearch/mapper.ts
+++ b/frontend/src/core/features/SpotlightSearch/mapper.ts
@@ -170,6 +170,9 @@ export const getUrl = (item: Item, currentWorkspaceSlug?: string): Url => {
       query: object.type === FileType.File ? { q: object.name } : {},
     };
   }
+  if (item.__typename === "DatasetResult") {
+    return `/workspaces/${encodeURIComponent(workspaceSlug)}/${getUrlName(item.__typename)}/${getUrlId(item)}/from/${encodeURIComponent(item.dataset.workspace?.slug ?? workspaceSlug)}`;
+  }
   return `/workspaces/${encodeURIComponent(workspaceSlug)}/${getUrlName(item.__typename)}/${getUrlId(item)}`;
 };
 


### PR DESCRIPTION
Spotlight search url is wrong for dataset since we added a `from` part in the url