### PR TITLE
chore: Make the Django admin a bit more userfriendly

### DIFF
--- a/backend/hexa/datasets/admin.py
+++ b/backend/hexa/datasets/admin.py
@@ -23,12 +23,17 @@ class DatasetVersionAdmin(admin.ModelAdmin):
 
 
 @admin.register(DatasetVersionFile)
-class DatasetVersionObjectAdmin(admin.ModelAdmin):
+class DatasetVersionFileAdmin(admin.ModelAdmin):
     list_display = (
         "filename",
         "dataset_version",
     )
     list_filter = ("dataset_version__dataset", "created_by")
+    search_fields = (
+        "id",
+        "uri",
+        "dataset_version__id",
+    )
 
 
 @admin.register(DatasetLink)

--- a/backend/hexa/pipelines/admin.py
+++ b/backend/hexa/pipelines/admin.py
@@ -26,6 +26,7 @@ class PipelineAdmin(GlobalObjectsModelAdmin):
 
 @admin.register(PipelineRun)
 class PipelineRunAdmin(admin.ModelAdmin):
+    readonly_fields = ("pipeline", "pipeline_version")
     list_display = ("pipeline", "trigger_mode", "state", "execution_date")
     list_filter = ("trigger_mode", "state", "execution_date", "pipeline")
     search_fields = ("pipeline__name", "pipeline__code", "pipeline__id", "id")

--- a/backend/hexa/user_management/admin.py
+++ b/backend/hexa/user_management/admin.py
@@ -174,6 +174,7 @@ class CustomUserAdmin(UserAdmin):
 
 class OrganizationMembershipInline(admin.TabularInline):
     fields = ("user", "role")
+    autocomplete_fields = ("user",)
     model = OrganizationMembership
     extra = 0
 
@@ -226,6 +227,7 @@ class FeatureFlagAdmin(admin.ModelAdmin):
 
 @admin.register(OrganizationMembership)
 class OrganizationMembershipAdmin(admin.ModelAdmin):
+    autocomplete_fields = ("user",)
     list_display = (
         "organization",
         "user",

--- a/backend/hexa/workspaces/admin.py
+++ b/backend/hexa/workspaces/admin.py
@@ -43,6 +43,17 @@ class WorkspaceMembershipAdmin(admin.ModelAdmin):
         "updated_at",
     )
     readonly_fields = ("notebooks_server_hash",)
+    search_fields = (
+        "user__email",
+        "user__first_name",
+        "user__last_name",
+        "workspace__name",
+        "workspace__slug",
+    )
+    autocomplete_fields = (
+        "workspace",
+        "user",
+    )
 
 
 class ConnectionFieldInline(admin.StackedInline):


### PR DESCRIPTION
Investigating stuff is difficult, with pages timing out (pipeline runs) and massive user/workspace-select lists.

Example autocomplete box:
<img width="3213" height="1198" alt="image" src="https://github.com/user-attachments/assets/3c074fb3-8838-4be2-9279-d10a21f306c2" />
