### PR TITLE
fix: UI of the code editor is moving on file modification and error (HEXA-1365)

### DIFF
--- a/frontend/src/workspaces/features/FilesEditor/FilesEditor.tsx
+++ b/frontend/src/workspaces/features/FilesEditor/FilesEditor.tsx
@@ -76,9 +76,12 @@ const FileTreeNode = ({
         <DocumentIcon className="w-4 h-4 mr-2 text-gray-400" />
         <span className="flex items-center gap-2">
           {node.name}
-          {isModified && (
-            <span className="inline-block w-1.5 h-1.5 bg-blue-500 rounded-full" />
-          )}
+          <span
+            className={clsx(
+              "inline-block w-1.5 h-1.5 bg-blue-500 rounded-full",
+              isModified ? "visible" : "invisible",
+            )}
+          />
         </span>
       </div>
     );


### PR DESCRIPTION
When modifying or getting an error, the code editor layout is moving, we want to avoid that

## Changes

- Move the error message
- The modified icon is invisible (takes room) when not modified

## Screenshots / screencast

<img width="993" height="101" alt="Screenshot 2025-09-17 at 09 26 42" src="https://github.com/user-attachments/assets/974e5bab-b1c4-4527-b839-0102b8740e4c" />
