### PR TITLE
Feat/add cors for webapps

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -111,7 +111,7 @@ if "CORS_ALLOWED_ORIGINS" in os.environ:
 
 CORS_ALLOWED_ORIGIN_REGEXES = []
 if "CORS_ALLOWED_ORIGIN_REGEXES" in os.environ:
-    CORS_ALLOWED_ORIGIN_REGEXES = os.environ.get("CORS_ALLOWED_ORIGIN_REGEXES").split(
+    CORS_ALLOWED_ORIGIN_REGEXES += os.environ.get("CORS_ALLOWED_ORIGIN_REGEXES").split(
         ","
     )
 

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -109,6 +109,10 @@ else:
 if "CORS_ALLOWED_ORIGINS" in os.environ:
     CORS_ALLOWED_ORIGINS += os.environ.get("CORS_ALLOWED_ORIGINS").split(",")
 
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"^https?://.*\.app\.openhexa\.org$",
+]
+
 CORS_URLS_REGEX = r"^/graphql/(\w+/)?|^/analytics/track/|^/files/[\w/]+/?$"
 CORS_ALLOW_CREDENTIALS = True
 

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -109,9 +109,11 @@ else:
 if "CORS_ALLOWED_ORIGINS" in os.environ:
     CORS_ALLOWED_ORIGINS += os.environ.get("CORS_ALLOWED_ORIGINS").split(",")
 
-CORS_ALLOWED_ORIGIN_REGEXES = [
-    r"^https?://.*\.app\.openhexa\.org$",
-]
+CORS_ALLOWED_ORIGIN_REGEXES = []
+if "CORS_ALLOWED_ORIGIN_REGEXES" in os.environ:
+    CORS_ALLOWED_ORIGIN_REGEXES = os.environ.get("CORS_ALLOWED_ORIGIN_REGEXES").split(
+        ","
+    )
 
 CORS_URLS_REGEX = r"^/graphql/(\w+/)?|^/analytics/track/|^/files/[\w/]+/?$"
 CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
 CORS rule for django, from https://pypi.org/project/django-cors-headers/
django app to allow any *.app.openhexa.org or *.app.demo.openhexa.org to be configured in infra, for more relaxed cors policy. 