### PR TITLE
feat: feature flag for workspace creation

### DIFF
--- a/backend/hexa/user_management/fixtures/base.json
+++ b/backend/hexa/user_management/fixtures/base.json
@@ -16,5 +16,14 @@
         "code": "organization",
         "force_activate": false
     }
+  },
+  {
+    "model": "user_management.feature",
+    "fields": {
+        "created_at": "2025-09-18T10:48:06.183Z",
+        "updated_at": "2025-09-18T10:55:32.486Z",
+        "code": "workspaces.create",
+        "force_activate": false
+    }
   }
 ]

--- a/backend/hexa/user_management/permissions.py
+++ b/backend/hexa/user_management/permissions.py
@@ -55,9 +55,9 @@ def manage_members(principal: User, organization: Organization):
 
 def create_workspace(principal: User, organization: Organization):
     """Only admin and owner users can create a workspace"""
-    return principal.is_organization_admin_or_owner(
+    return (principal.is_organization_admin_or_owner(
         organization
-    ) and not principal.has_feature_flag("workspaces.prevent_create")
+    ) or principal.has_feature_flag("workspaces.create")) and not principal.has_feature_flag("workspaces.prevent_create")
 
 
 def archive_workspace(principal: User, organization: Organization):

--- a/backend/hexa/user_management/permissions.py
+++ b/backend/hexa/user_management/permissions.py
@@ -57,6 +57,7 @@ def create_workspace(principal: User, organization: Organization):
     """Only admin and owner users can create a workspace"""
     return (principal.is_organization_admin_or_owner(
         organization
+
     ) or principal.has_feature_flag("workspaces.create")) and not principal.has_feature_flag("workspaces.prevent_create")
 
 

--- a/backend/hexa/user_management/permissions.py
+++ b/backend/hexa/user_management/permissions.py
@@ -55,10 +55,10 @@ def manage_members(principal: User, organization: Organization):
 
 def create_workspace(principal: User, organization: Organization):
     """Only admin and owner users can create a workspace"""
-    return (principal.is_organization_admin_or_owner(
-        organization
-
-    ) or principal.has_feature_flag("workspaces.create")) and not principal.has_feature_flag("workspaces.prevent_create")
+    return (
+        principal.is_organization_admin_or_owner(organization)
+        or principal.has_feature_flag("workspaces.create")
+    ) and not principal.has_feature_flag("workspaces.prevent_create")
 
 
 def archive_workspace(principal: User, organization: Organization):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openhexa-frontend",
-  "version": "2.3.1",
+  "version": "2.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openhexa-frontend",
-      "version": "2.3.1",
+      "version": "2.3.5",
       "dependencies": {
         "@apollo/client": "^3.11.8",
         "@apollo/link-error": "^2.0.0-beta.3",


### PR DESCRIPTION
Right now, only org admins can create workspace
We want to allow some users to bypass this check to unblock them while we find a more granular system