### PR TITLE
extend sentry logging

### DIFF
--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -73,8 +73,10 @@ if SENTRY_DSN:
         # Default sample rate for everything else
         return traces_sample_rate
 
-    # inject sentry into logging config. set level to ERROR, we don't really want the rest?
-    sentry_logging = LoggingIntegration(level=logging.ERROR, event_level=logging.ERROR)
+    # inject sentry into logging config. set level to WARNING for log/WARNING for event
+    sentry_logging = LoggingIntegration(
+        level=logging.WARNING, event_level=logging.WARNING
+    )
 
     sentry_sdk.init(
         dsn=SENTRY_DSN,


### PR DESCRIPTION
my best guess on why we didn't catch some of django 500 error that might have been logged instead of thrown. 
Closes https://bluesquare.atlassian.net/browse/HEXA-1369