### PR TITLE
fix: Object of type UUID is not JSON serializable for mixpanel events on organization emails

### DIFF
--- a/backend/hexa/user_management/utils.py
+++ b/backend/hexa/user_management/utils.py
@@ -58,7 +58,7 @@ def send_organization_invite(invitation):
             event="emails.organization_invite_sent",
             properties={
                 "timestamp": datetime.now(timezone.utc).isoformat(),
-                "organization": invitation.organization.id,
+                "organization": invitation.organization.name,
                 "invitee_email": invitation.email,
                 "invitee_role": invitation.role,
                 "status": invitation.status,
@@ -96,7 +96,7 @@ def send_organization_add_user_email(
             event="emails.organization_add_user_sent",
             properties={
                 "timestamp": datetime.now(timezone.utc).isoformat(),
-                "organization": organization.id,
+                "organization": organization.name,
                 "invitee_email": invitee.email,
                 "invitee_role": role,
             },


### PR DESCRIPTION
Fix https://bluesquareorg.sentry.io/issues/6822493320/?alert_rule_id=7767430&alert_type=issue&notification_uuid=59beafb9-e367-453d-900c-f6f14babad06&project=5893042&referrer=slack


The other tracking events of organization action are tracking the name and not the id, so we can take this opportunity to also use the name and solve the type issue