### PR TITLE
chore: Change `prepare` command to ask for superuser password

### DIFF
--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -71,10 +71,10 @@ case "$command" in
 "fixtures")
   wait-for-it ${DATABASE_HOST:-db}:${DATABASE_PORT:-5432}
   export DJANGO_SUPERUSER_USERNAME=root@openhexa.org
-  export DJANGO_SUPERUSER_PASSWORD=root
   export DJANGO_SUPERUSER_EMAIL=root@openhexa.org
   python manage.py migrate
-  python manage.py createsuperuser --no-input || true
+  echo "Creating initial superuser root@openhexa.org. Please choose a password."
+  python manage.py createsuperuser --email ${DJANGO_SUPERUSER_EMAIL}
   python manage.py loaddata base.json
   python manage.py loaddata demo.json
   python manage.py loaddata live.json


### PR DESCRIPTION
The default setting of password `root` presents a risk for local setups. The easy fix is to not set a default password and instead request the user's input.

Example run where I set pw `root`:

<img width="2119" height="818" alt="image" src="https://github.com/user-attachments/assets/1192e07a-e55b-450c-9555-85d4a4b3fab3" />

See also: https://github.com/BLSQ/openhexa-app/pull/1396
