### PR TITLE
feat: add secret parameter type for pipeline parameters

### DIFF
--- a/backend/hexa/pipelines/graphql/schema.graphql
+++ b/backend/hexa/pipelines/graphql/schema.graphql
@@ -67,6 +67,7 @@ enum ParameterType {
   gcs
   custom
   file
+  secret
 }
 
 """

--- a/frontend/schema.generated.graphql
+++ b/frontend/schema.generated.graphql
@@ -3242,6 +3242,7 @@ enum ParameterType {
   int
   postgresql
   s3
+  secret
   str
 }
 

--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -3852,6 +3852,7 @@ export enum ParameterType {
   Int = 'int',
   Postgresql = 'postgresql',
   S3 = 's3',
+  Secret = 'secret',
   Str = 'str'
 }
 

--- a/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/[runId].tsx
+++ b/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/[runId].tsx
@@ -127,6 +127,9 @@ const WorkspacePipelineRunPage: NextPageWithLayout = (props: Props) => {
     if (entry.type === "file" && entry.value) {
       return entry.value;
     }
+    if (entry.type === "secret" && entry.value) {
+      return "••••••";
+    }
 
     return "-";
   };

--- a/frontend/src/pipelines/features/PipelineVersionParametersTable/PipelineVersionParametersTable.tsx
+++ b/frontend/src/pipelines/features/PipelineVersionParametersTable/PipelineVersionParametersTable.tsx
@@ -49,8 +49,11 @@ const PipelineVersionParametersTable = ({
               {parameter.multiple ? t("Yes") : t("No")}
             </TableCell>
             <TableCell className="py-1">
-              {(version.config && version.config[parameter.code]?.toString()) ||
-                "-"}
+              {parameter.type === "secret" &&
+              version.config?.[parameter.code] != null
+                ? "••••••"
+                : (version.config && version.config[parameter.code]?.toString()) ||
+                  "-"}
             </TableCell>
           </TableRow>
         ))}

--- a/frontend/src/workspaces/features/RunPipelineDialog/ParameterField.tsx
+++ b/frontend/src/workspaces/features/RunPipelineDialog/ParameterField.tsx
@@ -170,6 +170,19 @@ const ParameterField = (props: ParameterFieldProps) => {
           data-testid={`${parameter.code}-input`}
         />
       );
+    case "secret":
+      return (
+        <Input
+          type="password"
+          fullWidth
+          aria-label={parameter.code}
+          name={parameter.code}
+          required={Boolean(parameter.required)}
+          onChange={(event) => handleChange(event.target.value)}
+          value={value ?? ""}
+          data-testid={`${parameter.code}-input`}
+        />
+      );
   }
   return null;
 };


### PR DESCRIPTION
Add secret parameter type to mask sensitive pipeline parameters in the UI


## Changes


- Added secret to the ParameterType enum in the GraphQL schema so the backend accepts and returns it as a valid type.
- Masked secret parameter values in the run form (password input) and run detail page (••••••).

## How/what to test

Create a pipeline that has Secret type on the CLI and on the app we will have •••••• as that parameter

## Screenshots / screencast

<img width="969" height="532" alt="image" src="https://github.com/user-attachments/assets/f63564d1-7ad9-4c82-8573-0a558780d507" />
<img width="1600" height="931" alt="image" src="https://github.com/user-attachments/assets/bbca74db-f0e4-446a-bda0-a348814b585b" />
