### PR TITLE
fix: disable lifespan for Uvicorn (HEXA-1590)

### DIFF
--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -36,7 +36,7 @@ case "$command" in
   ;;
 "start")
   wait-for-it ${DATABASE_HOST:-db}:${DATABASE_PORT:-5432}
-  gunicorn config.asgi:application -k uvicorn.workers.UvicornWorker --bind 0:8000 --workers=3
+  UVICORN_LIFESPAN=off gunicorn config.asgi:application -k uvicorn.workers.UvicornWorker --bind 0:8000 --workers=3
   ;;
 "makemigrations")
   wait-for-it ${DATABASE_HOST:-db}:${DATABASE_PORT:-5432}


### PR DESCRIPTION
Lifespan is not supported by Django

https://bluesquareorg.sentry.io/issues/7401494100/?project=5893042&query=is%3Aunresolved&referrer=issue-stream