### PR TITLE
fix: OH logo is stretched in the email (HEXA-1571)

### DIFF
--- a/backend/hexa/pipelines/templates/pipelines/mails/run_report.mjml
+++ b/backend/hexa/pipelines/templates/pipelines/mails/run_report.mjml
@@ -16,7 +16,7 @@
   <mj-section padding="60px 0 0 0"></mj-section>
     <mj-section background-color="#2e2e2e" border-radius="18px 18px 0 0" padding="30px 0">
       <mj-column>
-        <mj-image align="center" height="100px" src="{% static_with_domain 'img/logo/logo_with_text_white.svg' %}" padding="10px 25px 10px 25px"></mj-image>
+        <mj-image align="center" width="200px" src="{% static_with_domain 'img/logo/logo_with_text_white.svg' %}" padding="10px 25px 10px 25px"></mj-image>
       </mj-column>
     </mj-section>
 


### PR DESCRIPTION
OH logo was stretched in the pipeline report email

## Changes

-  Setting only width lets the height scale proportionally


## How/what to test
- Configure smtp locally I've used [resend.com](resend.com)

- Trigger a pipeline run report email

## Screenshots / screencast

<img width="2342" height="1262" alt="image" src="https://github.com/user-attachments/assets/957c0947-907d-4267-aa2b-988ef01d7033" />
