### PR TITLE
fix: ensure SSE pipeline messages point to API URL

### DIFF
--- a/frontend/src/pipelines/hooks/usePipelineRunMessages/usePipelineRunMessages.ts
+++ b/frontend/src/pipelines/hooks/usePipelineRunMessages/usePipelineRunMessages.ts
@@ -33,7 +33,7 @@ function usePipelineRunMessages(
   const url = useMemo(() => {
     if (isTerminal) return null;
     const apiBasePath =
-      process.env.NEXT_PUBLIC_API_BASE_PATH ??
+      process.env.NEXT_PUBLIC_API_BASE_PATH ||
       getPublicEnv().OPENHEXA_BACKEND_URL;
     return `${apiBasePath}/pipelines/runs/${runId}/messages/stream/`;
   }, [runId, isTerminal]);


### PR DESCRIPTION
The issue was `process.env.NEXT_PUBLIC_API_BASE_PATH` being `""`. Since the `??` operator is more strict in its falsey interpretation, this means we'd hit the frontend to get the messages stream, instead of the API endpoint.

E.g.

```
https://app.demo.openhexa.org/pipelines/runs/f851241e-11be-4071-a8ae-5362f32ebc18/messages/stream/

# but should be
https://api.demo.openhexa.org/pipelines/runs/f851241e-11be-4071-a8ae-5362f32ebc18/messages/stream/
```
