### PR TITLE
fix: hide MCP connection field values (HEXA-1612)

### DIFF
--- a/backend/hexa/mcp/graphql/connections.graphql
+++ b/backend/hexa/mcp/graphql/connections.graphql
@@ -10,7 +10,6 @@ query ListConnections($slug: String!) {
       updatedAt
       fields {
         code
-        value
         secret
       }
     }

--- a/backend/hexa/mcp/tests/test_connections.py
+++ b/backend/hexa/mcp/tests/test_connections.py
@@ -30,20 +30,10 @@ class ListConnectionsTest(MCPTestCase):
         )
         self.assertEqual(len(result["connections"]), 1)
 
-    def test_list_connections_admin_sees_secret_values(self):
+    def test_list_connections_does_not_return_field_values(self):
         result = list_connections(
             user=self.USER_ADMIN, workspace_slug=self.WORKSPACE.slug
         )
         fields = {f["code"]: f for f in result["connections"][0]["fields"]}
-        self.assertEqual(fields["url"]["value"], "https://example.com")
-        self.assertFalse(fields["url"]["secret"])
-        self.assertEqual(fields["token"]["value"], "super-secret-token")
-        self.assertTrue(fields["token"]["secret"])
-
-    def test_list_connections_viewer_cannot_see_secret_values(self):
-        result = list_connections(
-            user=self.USER_VIEWER, workspace_slug=self.WORKSPACE.slug
-        )
-        fields = {f["code"]: f for f in result["connections"][0]["fields"]}
-        self.assertEqual(fields["url"]["value"], "https://example.com")
-        self.assertIsNone(fields["token"]["value"])
+        self.assertNotIn("value", fields["url"])
+        self.assertNotIn("value", fields["token"])

--- a/backend/hexa/mcp/tools/connections.py
+++ b/backend/hexa/mcp/tools/connections.py
@@ -5,7 +5,7 @@ from ._graphql import execute_graphql
 
 @tool
 def list_connections(user, workspace_slug: str) -> dict:
-    """List connections (external data sources) configured in a workspace. Returns connection name, slug, type (S3, GCS, POSTGRESQL, DHIS2, IASO, CUSTOM), and their fields with values. Secret field values are only visible to workspace admins and editors. Connections are used as parameters when running pipelines — use the connection slug as the parameter value."""
+    """List connections (external data sources) configured in a workspace. Returns connection name, slug, type (S3, GCS, POSTGRESQL, DHIS2, IASO, CUSTOM), and their fields. Field values are not visible to not be tempted to use them directly. Connections are used as parameters when running pipelines — use the connection slug as the parameter value."""
     data = execute_graphql(user, "ListConnections", {"slug": workspace_slug})
     if "errors" in data:
         return data


### PR DESCRIPTION
Just remove the value for fields, to avoid the agent to use them directly. It can still read i in the execution of the pipeline to debug if needed