### PR TITLE
fix:auto update pipeline run status on list page

### DIFF
--- a/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/[runId].tsx
+++ b/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/[runId].tsx
@@ -28,7 +28,7 @@ import RunLogs from "pipelines/features/RunLogs";
 import RunMessages from "pipelines/features/RunMessages";
 import usePipelineRunMessages from "pipelines/hooks/usePipelineRunMessages/usePipelineRunMessages";
 import usePipelineRunPoller from "pipelines/hooks/usePipelineRunPoller";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import RunOutputsTable from "workspaces/features/RunOutputsTable";
 import RunPipelineDialog from "workspaces/features/RunPipelineDialog";
 import StopPipelineDialog from "workspaces/features/StopPipelineDialog";
@@ -76,6 +76,12 @@ const WorkspacePipelineRunPage: NextPageWithLayout = (props: Props) => {
     { id: runId_, status: runStatus ?? PipelineRunStatus.Queued },
     !isTerminal && !!data?.pipelineRun,
   );
+
+  useEffect(() => {
+    if (isTerminal) {
+      refetch();
+    }
+  }, [isTerminal]);
 
   const { messages: sseMessages, isStreaming, streamError } = usePipelineRunMessages(runId_, isTerminal, refetch);
 

--- a/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/index.tsx
+++ b/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/index.tsx
@@ -7,12 +7,13 @@ import Time from "core/components/Time";
 import { createGetServerSideProps } from "core/helpers/page";
 import { formatDuration } from "core/helpers/time";
 import { NextPageWithLayout } from "core/helpers/types";
-import { PipelineParameter, PipelineRunTrigger, PipelineType } from "graphql/types";
+import { PipelineParameter, PipelineRunStatus, PipelineRunTrigger, PipelineType } from "graphql/types";
 import { useTranslation } from "next-i18next";
 import router from "next/router";
 import { useState } from "react";
 import { formatParamValue } from "pipelines/helpers/format";
 import PipelineRunStatusBadge from "pipelines/features/PipelineRunStatusBadge";
+import usePipelineRunPoller from "pipelines/hooks/usePipelineRunPoller";
 import {
   useWorkspacePipelineRunsPageQuery,
   WorkspacePipelineRunsPageDocument,
@@ -23,6 +24,11 @@ import { getPipelineRunConfig } from "workspaces/helpers/pipelines";
 import PipelineLayout from "workspaces/layouts/PipelineLayout";
 
 const MAX_VISIBLE_PARAMS = 3;
+
+function RunPoller({ run }: { run: { id: string; status: PipelineRunStatus } }) {
+  usePipelineRunPoller(run);
+  return null;
+}
 
 function RunParametersCell({
   run,
@@ -100,6 +106,9 @@ const WorkspacePipelineRunsPage: NextPageWithLayout = (props: Props) => {
 
   return (
     <Page title={pipeline.name ?? t("Pipeline runs")}>
+      {pipeline.runs.items.map((run) => (
+        <RunPoller key={run.id} run={run} />
+      ))}
       <PipelineLayout
         workspace={workspace}
         pipeline={pipeline}


### PR DESCRIPTION
Active runs on the list page now poll for status updates using usePipelineRunPoller.

Also the PR fixes a race condition  that was introduced on the detail page where the poller could set isTerminal before the SSE done event arrived, causing run messages to disappear.