### PR TITLE
fix: Web app subdomain validation + logfire environment setting

### DIFF
--- a/backend/hexa/assistant/apps.py
+++ b/backend/hexa/assistant/apps.py
@@ -12,5 +12,5 @@ class AssistantConfig(CoreAppConfig):
     def ready(self):
         super().ready()
         if os.environ.get("LOGFIRE_SEND_TO_LOGFIRE", "false").lower() == "true":
-            logfire.configure()
+            logfire.configure(environment=os.environ.get("SENTRY_ENVIRONMENT"))
             logfire.instrument_pydantic_ai()

--- a/backend/hexa/webapps/models.py
+++ b/backend/hexa/webapps/models.py
@@ -3,7 +3,7 @@ import secrets
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.validators import DomainNameValidator, URLValidator, validate_slug
 from django.db import models, transaction
 from django.db.models import Q
@@ -35,13 +35,20 @@ def create_webapp_slug(name: str, workspace: Workspace):
 
 
 def create_webapp_subdomain(slug: str, workspace: Workspace, max_tries=10):
+    def is_valid_and_available(candidate):
+        try:
+            validate_subdomain(candidate)
+        except ValidationError:
+            return False
+        return not Webapp.all_objects.filter(subdomain=candidate).exists()
+
     candidates = [slug, f"{workspace.slug}-{slug}"]
     for candidate in candidates:
-        if not Webapp.all_objects.filter(subdomain=candidate).exists():
+        if is_valid_and_available(candidate):
             return candidate
     for _ in range(max_tries):
         candidate = f"{workspace.slug}-{slug}-{secrets.token_hex(3)}"
-        if not Webapp.all_objects.filter(subdomain=candidate).exists():
+        if is_valid_and_available(candidate):
             return candidate
     raise ValueError(
         f"Could not generate a unique subdomain after {max_tries} attempts"
@@ -82,7 +89,9 @@ class WebappManager(
         if "slug" not in kwargs:
             kwargs["slug"] = create_webapp_slug(kwargs["name"], ws)
 
-        if "subdomain" not in kwargs:
+        if "subdomain" in kwargs:
+            validate_subdomain(kwargs["subdomain"])
+        else:
             kwargs["subdomain"] = create_webapp_subdomain(kwargs["slug"], ws)
 
         kwargs["workspace"] = ws

--- a/backend/hexa/webapps/tests/test_models.py
+++ b/backend/hexa/webapps/tests/test_models.py
@@ -317,9 +317,7 @@ class WebappModelTest(TestCase):
                 url="https://example.com",
                 subdomain="api",
             )
-        self.assertFalse(
-            Webapp.all_objects.filter(name="Reserved Subdomain").exists()
-        )
+        self.assertFalse(Webapp.all_objects.filter(name="Reserved Subdomain").exists())
 
     def test_unique_constraint(self):
         with self.assertRaises(IntegrityError):

--- a/backend/hexa/webapps/tests/test_models.py
+++ b/backend/hexa/webapps/tests/test_models.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import IntegrityError
 
 from hexa.core.test import TestCase
@@ -277,6 +277,49 @@ class WebappModelTest(TestCase):
             url="https://example.com",
         )
         self.assertEqual(webapp2.subdomain, f"{workspace2.slug}-{webapp2.slug}")
+
+    def test_assign_subdomain_skips_reserved_slug(self):
+        workspace = Workspace.objects.create_if_has_perm(
+            self.user_admin,
+            name="Reserved Slug Workspace",
+            description="",
+            countries=[{"code": "FR"}],
+        )
+        webapp = Webapp.objects.create_if_has_perm(
+            self.user_admin,
+            workspace,
+            name="staging",
+            created_by=self.user_admin,
+            url="https://example.com",
+        )
+        self.assertEqual(webapp.slug, "staging")
+        self.assertNotEqual(webapp.subdomain, "staging")
+        self.assertEqual(webapp.subdomain, f"{workspace.slug}-staging")
+
+    def test_create_with_explicit_valid_subdomain(self):
+        webapp = Webapp.objects.create_if_has_perm(
+            self.user_admin,
+            self.workspace,
+            name="Explicit Subdomain",
+            created_by=self.user_admin,
+            url="https://example.com",
+            subdomain="my-custom-subdomain",
+        )
+        self.assertEqual(webapp.subdomain, "my-custom-subdomain")
+
+    def test_create_with_explicit_invalid_subdomain_raises(self):
+        with self.assertRaises(ValidationError):
+            Webapp.objects.create_if_has_perm(
+                self.user_admin,
+                self.workspace,
+                name="Reserved Subdomain",
+                created_by=self.user_admin,
+                url="https://example.com",
+                subdomain="api",
+            )
+        self.assertFalse(
+            Webapp.all_objects.filter(name="Reserved Subdomain").exists()
+        )
 
     def test_unique_constraint(self):
         with self.assertRaises(IntegrityError):


### PR DESCRIPTION
- fix: Validate the webapp subdomain on creation: the path of "create subdomain based on slug" didn't do the actual
validation. This means that if you create a new web app with name "Staging", you end up with subdomain "staging" which is a reserved field.
- chore: Add environment for logfire: for convenience, we'll reuse the Sentry variable, we'll always want to
keep those aligned anyways.