### PR TITLE
fix: group webapp icon name

### DIFF
--- a/frontend/src/pages/workspaces/[workspaceSlug]/webapps/index.tsx
+++ b/frontend/src/pages/workspaces/[workspaceSlug]/webapps/index.tsx
@@ -122,27 +122,29 @@ const WebappsPage = (props: Props) => {
                 maxWidth={350}
               >
                 {(item) => (
-                  <div className="flex items-center">
+                  <div className="flex items-center gap-2">
                     <div className="flex items-center space-x-1 shrink-0">
                       <FavoriteWebappButton webapp={item} />
                       <ShortcutWebappButton webapp={item} />
+                    </div>
+                    <div className="flex items-center gap-1.5 min-w-0">
                       <img
                         src={item.icon}
                         className={clsx(
-                          "h-4 w-4 rounded",
+                          "h-4 w-4 rounded shrink-0",
                           !item.icon && "invisible",
                         )}
                         alt={"Icon"}
                       />
+                      <Link
+                        href={{
+                          pathname: `/workspaces/${encodeURIComponent(workspace.slug)}/webapps/${item.slug}`,
+                        }}
+                        className="truncate"
+                      >
+                        {item.name}
+                      </Link>
                     </div>
-                    <Link
-                      href={{
-                        pathname: `/workspaces/${encodeURIComponent(workspace.slug)}/webapps/${item.slug}`,
-                      }}
-                      className="truncate"
-                    >
-                      {item.name}
-                    </Link>
                   </div>
                 )}
               </BaseColumn>


### PR DESCRIPTION
## Changes

- Group icon with name
- spacing between actions and name


## Screenshots / screencast
<img width="2342" height="120" alt="image" src="https://github.com/user-attachments/assets/48c8790a-3c11-4c9b-a2c7-9da0fc9a9da9" />
