### PR TITLE
fix: webapps preview origin check (HEXA-1629)

### DIFF
--- a/backend/hexa/webapps/graphql_proxy.py
+++ b/backend/hexa/webapps/graphql_proxy.py
@@ -66,12 +66,12 @@ def extract_top_level_fields(query_string: str) -> set[str]:
 _graphql_view = GraphQLView.as_view(schema=schema)
 
 
-def _check_origin(request: HttpRequest, webapp: Webapp) -> bool:
+def _check_origin(request: HttpRequest) -> bool:
     origin = request.META.get("HTTP_ORIGIN", "")
     if not origin:
         return True
-    expected = f"{settings.SCHEME}://{webapp.subdomain}.{settings.WEBAPPS_DOMAIN}"
-    return origin.rstrip("/") == expected.rstrip("/")
+    request_origin = f"{settings.SCHEME}://{request.get_host()}"
+    return origin.rstrip("/") == request_origin.rstrip("/")
 
 
 def handle_graphql_proxy(request: HttpRequest, webapp: Webapp):
@@ -81,7 +81,7 @@ def handle_graphql_proxy(request: HttpRequest, webapp: Webapp):
             status=405,
         )
 
-    if not _check_origin(request, webapp):
+    if not _check_origin(request):
         return JsonResponse(
             {"errors": [{"message": "Origin not allowed"}]},
             status=403,

--- a/backend/hexa/webapps/tests/test_graphql_proxy.py
+++ b/backend/hexa/webapps/tests/test_graphql_proxy.py
@@ -231,6 +231,35 @@ class GraphQLProxyMiddlewareTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_preview_session_key_host_origin_succeeds(self):
+        # Preview URLs serve the webapp from a session-key subdomain rather
+        # than the webapp's own subdomain — same-origin queries must still pass.
+        session = self._create_webapp_session(self.WEBAPP_PRIVATE, self.USER)
+        preview_host = f"{session.session_key}.{WEBAPPS_DOMAIN}"
+        self.client.cookies[WEBAPP_SESSION_COOKIE] = session.session_key
+        response = self.client.post(
+            "/graphql/",
+            data=json.dumps({"query": "query { me { user { email } } }"}),
+            content_type="application/json",
+            HTTP_HOST=preview_host,
+            HTTP_ORIGIN=f"http://{preview_host}",
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_custom_domain_host_origin_succeeds(self):
+        self.WEBAPP_PRIVATE.custom_domain = "my-custom-domain.example.com"
+        self.WEBAPP_PRIVATE.save()
+        session = self._create_webapp_session(self.WEBAPP_PRIVATE, self.USER)
+        self.client.cookies[WEBAPP_SESSION_COOKIE] = session.session_key
+        response = self.client.post(
+            "/graphql/",
+            data=json.dumps({"query": "query { me { user { email } } }"}),
+            content_type="application/json",
+            HTTP_HOST="my-custom-domain.example.com",
+            HTTP_ORIGIN="http://my-custom-domain.example.com",
+        )
+        self.assertEqual(response.status_code, 200)
+
     def test_empty_allowed_operations_blocks_everything(self):
         webapp = Webapp.objects.create(
             name="No Ops App",


### PR DESCRIPTION
Preview of webapps are now on a different domain, we need to adapt the graphql origin check