### PR TITLE
fix: folder cant be deleted (HEXA-1622)

### DIFF
--- a/backend/hexa/files/backends/gcp.py
+++ b/backend/hexa/files/backends/gcp.py
@@ -380,13 +380,19 @@ class GoogleCloudStorage(Storage):
     def delete_object(self, bucket_name: str, file_name: str):
         bucket = self.client.get_bucket(bucket_name)
         blob = bucket.get_blob(file_name)
-        if blob is None:
-            raise self.exceptions.NotFound("Object not found")
-        if _is_dir(blob):
-            blobs = list(bucket.list_blobs(prefix=file_name))
-            bucket.delete_blobs(blobs)
-        else:
+        if blob is not None and not _is_dir(blob):
             bucket.delete_blob(file_name)
+            return
+
+        # Folder case (explicit zero-byte marker) and implicit-folder case
+        # (no marker, just a shared prefix among other objects, e.g. when a
+        # pipeline writes "foo/bar.csv" without first creating "foo/") are
+        # both handled by listing and bulk-deleting under the prefix.
+        dir_prefix = file_name if file_name.endswith("/") else file_name + "/"
+        blobs = list(bucket.list_blobs(prefix=dir_prefix))
+        if not blobs:
+            raise self.exceptions.NotFound("Object not found")
+        bucket.delete_blobs(blobs)
 
     def load_bucket_sample_data(self, bucket_name: str):
         return load_bucket_sample_data_with(bucket_name, self)

--- a/backend/hexa/files/tests/backends/test_gcp.py
+++ b/backend/hexa/files/tests/backends/test_gcp.py
@@ -84,6 +84,24 @@ class GoogleCloudStorageTest(StorageTestMixin, TestCase):
             [item.name for item in result.items if item.name], ["folder_k"]
         )
 
+    def test_delete_object_implicit_directory(self):
+        """Deleting a folder that has no explicit zero-byte marker must succeed.
+
+        GCS folders may exist solely as a shared prefix among other objects
+        (e.g. when a pipeline writes "foo/bar.csv" without first creating
+        "foo/"). Such folders show up in listings but bucket.get_blob returns
+        None for the prefix itself — the delete path must fall back to a
+        prefix listing.
+        """
+        bucket_name = self.storage.create_bucket("my-bucket")
+        bucket = self.storage_client.get_bucket(bucket_name)
+        bucket.blob("parent/file1.txt").upload_from_string(b"a")
+        bucket.blob("parent/file2.txt").upload_from_string(b"b")
+
+        self.storage.delete_object("my-bucket", "parent/")
+
+        self.assertEqual(self.storage.list_bucket_objects("my-bucket").items, [])
+
     def test_list_bucket_objects_late_prefix_not_dropped(self):
         """A folder that sorts after many files still appears prefix-first.
 

--- a/backend/hexa/files/tests/mocks/bucket.py
+++ b/backend/hexa/files/tests/mocks/bucket.py
@@ -43,9 +43,7 @@ class MockBucket:
         return self.client.list_blobs(self, *args, **kwargs)
 
     def get_blob(self, name: str, *args, **kwargs):
-        if name not in self._blobs:
-            raise NotFound(f"Blob {name} not found")
-        return self._blobs[name]
+        return self._blobs.get(name)
 
     def blob(self, blob_name: str, *args, **kwargs):
         if blob_name in self._blobs:

--- a/backend/hexa/files/tests/mocks/client.py
+++ b/backend/hexa/files/tests/mocks/client.py
@@ -84,9 +84,12 @@ class MockHTTPIterator:
                 there are no pages left.
         """
         if self._has_next_page():
-            page_items = self.items[
-                self.num_results : self.num_results + self._page_size
-            ]
+            if self._page_size is None:
+                page_items = self.items[self.num_results :]
+            else:
+                page_items = self.items[
+                    self.num_results : self.num_results + self._page_size
+                ]
             for item in page_items:
                 if item.name.endswith("/"):
                     self._prefixes.add(item.name)


### PR DESCRIPTION
Deleting folders from the UI that were created without creating an empty marker file is failing because the empty marker file cant be found. Instead, list blobs and delete them

Integration to be tested in demo