### PR TITLE
chore: Make model limits specific and up the limit for pipeline creation

### DIFF
--- a/backend/hexa/assistant/agents/base.py
+++ b/backend/hexa/assistant/agents/base.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncGenerator
 from decimal import Decimal
 
 import genai_prices
-from pydantic_ai import Agent, ModelRetry, RunUsage
+from pydantic_ai import Agent, ModelRetry, ModelSettings, RunUsage
 from pydantic_ai.messages import (
     FunctionToolCallEvent,
     FunctionToolResultEvent,
@@ -73,6 +73,7 @@ def _parse_conversation_title(text: str) -> str:
 class BaseAgent:
     instruction_set = InstructionSet.GENERAL
     tools: list = []
+    max_tokens: int = 4096
 
     def __init__(self, conversation: Conversation):
         self.conversation = conversation
@@ -91,6 +92,7 @@ class BaseAgent:
             instructions=instructions,
             tools=self._tools_with_context,
             end_strategy="exhaustive",
+            model_settings=ModelSettings(max_tokens=self.max_tokens),
         )
 
     def _extra_instructions(self) -> str:

--- a/backend/hexa/assistant/agents/create_pipeline_agent.py
+++ b/backend/hexa/assistant/agents/create_pipeline_agent.py
@@ -7,3 +7,4 @@ class CreatePipelineAgent(BaseAgent):
     # TODO: Add reading pipeline / pipeline templates tools
     instruction_set = InstructionSet.CREATE_PIPELINE
     tools = [create_pipeline]
+    max_tokens = 8192


### PR DESCRIPTION
A model hitting the limit will return a "cut-off" response, resulting in incorrect JSON for a tool call for example.

The default limit for Anthropic was 4096, but for the creation we can allow some more (set to double).

Example of requesting a complicated pipeline and hitting the 4096 limit, the resulting tool call is cut short:
<img width="2257" height="2090" alt="image" src="https://github.com/user-attachments/assets/eb9f0c60-ceda-4648-9ccf-b878ce21d4dc" />

**Note:** Follow-up ticket to improve this: https://bluesquare.atlassian.net/browse/HEXA-1635