### PR TITLE
fix: iframe webapps should render the source url in an iframe and not through subdomain (HEXA-1639)

### DIFF
--- a/backend/hexa/webapps/models.py
+++ b/backend/hexa/webapps/models.py
@@ -174,6 +174,8 @@ class Webapp(Base, SoftDeletedModel, ShortcutableMixin):
 
     @property
     def serve_url(self):
+        if self.type == self.WebappType.IFRAME:
+            return f"{settings.NEW_FRONTEND_DOMAIN}/workspaces/{self.workspace.slug}/webapps/{self.slug}/play"
         return f"{settings.SCHEME}://{self.subdomain}.{settings.WEBAPPS_DOMAIN}/"
 
     def is_favorite(self, user: User):

--- a/backend/hexa/webapps/tests/test_models.py
+++ b/backend/hexa/webapps/tests/test_models.py
@@ -243,6 +243,39 @@ class WebappModelTest(TestCase):
         self.assertIn(webapp.subdomain, shortcut["url"])
         self.assertNotIn(str(webapp.id), shortcut["url"])
 
+    def test_serve_url_iframe_returns_play_page(self):
+        webapp = Webapp.objects.create(
+            name="Iframe App",
+            slug="iframe-app",
+            subdomain="iframe-app",
+            workspace=self.workspace,
+            created_by=self.user_admin,
+            url="https://example.com",
+            type=Webapp.WebappType.IFRAME,
+        )
+
+        self.assertEqual(
+            webapp.serve_url,
+            f"http://localhost:3000/workspaces/{self.workspace.slug}/webapps/iframe-app/play",
+        )
+        self.assertNotIn(webapp.subdomain, webapp.serve_url.split("/workspaces/")[0])
+
+    def test_serve_url_non_iframe_returns_subdomain(self):
+        for webapp_type in (Webapp.WebappType.STATIC, Webapp.WebappType.SUPERSET):
+            with self.subTest(type=webapp_type):
+                webapp = Webapp(
+                    name=f"{webapp_type} App",
+                    slug=f"{webapp_type}-app",
+                    subdomain=f"{webapp_type}-app",
+                    workspace=self.workspace,
+                    created_by=self.user_admin,
+                    url="https://example.com",
+                    type=webapp_type,
+                )
+                self.assertTrue(webapp.serve_url.startswith("http"))
+                self.assertIn(f"{webapp.subdomain}.", webapp.serve_url)
+                self.assertNotIn("/play", webapp.serve_url)
+
     def test_assign_subdomain_on_create(self):
         webapp = Webapp.objects.create_if_has_perm(
             self.user_admin,

--- a/frontend/src/pages/workspaces/[workspaceSlug]/webapps/[webappSlug]/play/index.tsx
+++ b/frontend/src/pages/workspaces/[workspaceSlug]/webapps/[webappSlug]/play/index.tsx
@@ -20,7 +20,11 @@ const WorkspaceWebappPlayPage: NextPageWithLayout = (props: Props) => {
   return (
     <Page title={webapp.name}>
       <WebappIframe
-        url={webapp.serveUrl ?? webapp.url}
+        url={
+          webapp.type === WebappType.Iframe
+            ? webapp.url
+            : (webapp.serveUrl ?? webapp.url)
+        }
         type={webapp.type}
         style={{ height: "100vh" }}
         showPoweredBy={

--- a/frontend/src/webapps/features/WebappForm/WebappForm.tsx
+++ b/frontend/src/webapps/features/WebappForm/WebappForm.tsx
@@ -420,7 +420,15 @@ const WebappForm = ({ workspace, webapp }: WebappFormProps) => {
             label={t("Dashboard URL")}
           />
         )}
-        {webapp && (
+        {webapp && selectedType === WebappType.Iframe && (
+          <LinkProperty
+            id="serveUrl"
+            accessor="serveUrl"
+            label={t("Published URL")}
+            help={t("The URL where this web app can be accessed")}
+          />
+        )}
+        {webapp && selectedType !== WebappType.Iframe && (
           <SubdomainProperty
             id="subdomain"
             accessor="subdomain"
@@ -440,7 +448,7 @@ const WebappForm = ({ workspace, webapp }: WebappFormProps) => {
           onChange={setIsPublic}
         />
 
-        {webapp && !isPublic && (
+        {webapp && !isPublic && selectedType === WebappType.Static && (
           <ApiAccessSection
             serveUrl={webapp.serveUrl}
             allowedOperations={allowedOperations}


### PR DESCRIPTION
- Change serve_url for iframe webapps
- Add backend unit test to cover this new logic for `serve_url`
- The FE play page is using the url for iframe webapps
- Hide API access section for non-static webapps