### PR TITLE
fix: Read-only user should not be able to create tables (HEXA-1630)

### DIFF
--- a/backend/hexa/databases/api.py
+++ b/backend/hexa/databases/api.py
@@ -120,6 +120,13 @@ def create_read_only_role(db_name: str, ro_pwd: str, cursor=None):
     """
     ro_role = f"{db_name}_ro"
     with get_cursor(db_name, cursor) as cur:
+        # template1.public ACL granted CREATE to PUBLIC (pre-PG15 default, and
+        # potentially retained across pg_upgrade). Without this REVOKE,
+        # the RO role inherits CREATE on the public schema via PUBLIC and can
+        # create tables. Run before any role-specific GRANTs so the RW role's
+        # explicit GRANT ALL is unaffected.
+        # Adding this to ensure the fix on all databases, also ones we don't manage.
+        cur.execute("REVOKE CREATE ON SCHEMA public FROM PUBLIC;")
         cur.execute(
             sql.SQL("CREATE ROLE {role_name} LOGIN PASSWORD {password};").format(
                 role_name=sql.Identifier(ro_role), password=sql.Literal(ro_pwd)

--- a/backend/hexa/databases/tests/test_api.py
+++ b/backend/hexa/databases/tests/test_api.py
@@ -1,4 +1,5 @@
 import psycopg2
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from psycopg2 import OperationalError, sql
 from psycopg2.errors import (
@@ -9,6 +10,8 @@ from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT, STATUS_READY
 from hexa.core.test import TestCase
 from hexa.databases.api import (
     create_database,
+    create_read_and_write_role,
+    create_read_only_role,
     delete_database,
     get_database_connection,
     get_db_server_credentials,
@@ -362,3 +365,58 @@ class DatabaseAPITest(TestCase):
                 user=ro_role,
                 password=self.RO_PWD_1,
             )
+
+    def test_read_only_role_cannot_create_table_when_public_grants_create_to_public(
+        self,
+    ):
+        """Mimic the template1 ACL where PUBLIC has CREATE on the public
+        schema, then verify the read-only role still cannot create tables after
+        create_read_only_role has been run on top.
+        """
+        db_name = "ro_create_grant_test"
+        pwd = "rw_pwd"
+        ro_pwd = "ro_pwd"
+        ro_role = f"{db_name}_ro"
+
+        credentials = get_db_server_credentials()
+        host = credentials["host"]
+        port = credentials["port"]
+
+        admin_conn = get_database_connection(settings.WORKSPACES_DATABASE_DEFAULT_DB)
+        admin_conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        try:
+            with admin_conn.cursor() as cursor:
+                cursor.execute(
+                    sql.SQL("CREATE DATABASE {db_name};").format(
+                        db_name=sql.Identifier(db_name),
+                    )
+                )
+        finally:
+            admin_conn.close()
+
+        try:
+            db_conn = get_database_connection(db_name)
+            db_conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+            try:
+                with db_conn.cursor() as cursor:
+                    cursor.execute("GRANT CREATE ON SCHEMA public TO PUBLIC;")
+                    create_read_and_write_role(db_name, pwd, cursor)
+                    create_read_only_role(db_name, ro_pwd, cursor)
+            finally:
+                db_conn.close()
+
+            ro_conn = psycopg2.connect(
+                host=host,
+                port=port,
+                dbname=db_name,
+                user=ro_role,
+                password=ro_pwd,
+            )
+            try:
+                cursor = ro_conn.cursor()
+                with self.assertRaises(InsufficientPrivilege):
+                    cursor.execute("CREATE TABLE should_fail (id serial PRIMARY KEY);")
+            finally:
+                ro_conn.close()
+        finally:
+            delete_database(db_name)

--- a/backend/hexa/databases/tests/test_api.py
+++ b/backend/hexa/databases/tests/test_api.py
@@ -405,12 +405,24 @@ class DatabaseAPITest(TestCase):
             finally:
                 db_conn.close()
 
+            # RW user can still create a table
+            rw_conn = psycopg2.connect(
+                host=host, port=port, dbname=db_name, user=db_name, password=pwd
+            )
+            try:
+                cursor = rw_conn.cursor()
+                cursor.execute("CREATE TABLE should_work (id serial PRIMARY KEY);")
+                cursor.execute(
+                    "SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema='public' AND table_name='should_work';"
+                )
+                self.assertIsNotNone(cursor.fetchone())
+            finally:
+                rw_conn.close()
+
+            # RO user cannot create a table
             ro_conn = psycopg2.connect(
-                host=host,
-                port=port,
-                dbname=db_name,
-                user=ro_role,
-                password=ro_pwd,
+                host=host, port=port, dbname=db_name, user=ro_role, password=ro_pwd
             )
             try:
                 cursor = ro_conn.cursor()

--- a/backend/hexa/workspaces/migrations/0058_revoke_create_on_public_from_public.py
+++ b/backend/hexa/workspaces/migrations/0058_revoke_create_on_public_from_public.py
@@ -1,0 +1,64 @@
+import psycopg2
+from django.conf import settings
+from django.db import migrations
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+
+def get_admin_connection(db_name):
+    """Get a connection to a specific database using the admin role."""
+    host = settings.WORKSPACES_DATABASE_HOST
+    port = settings.WORKSPACES_DATABASE_PORT
+    admin_role = settings.WORKSPACES_DATABASE_ROLE
+    admin_password = settings.WORKSPACES_DATABASE_PASSWORD
+
+    conn = psycopg2.connect(
+        host=host,
+        port=port,
+        dbname=db_name,
+        user=admin_role,
+        password=admin_password,
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    return conn
+
+
+def revoke_create_on_public_from_public(apps, schema_editor):
+    """
+    Strip the inherited `GRANT CREATE ON SCHEMA public TO PUBLIC` from every
+    existing workspace DB.
+
+    Cloud SQL's template1.public ACL retained the pre-PG15 default
+    (=UC/cloudsqlsuperuser) across pg_upgrade, so each workspace DB cloned from
+    template1 inherited CREATE-via-PUBLIC. That let the {db}_ro role create
+    tables despite create_read_only_role only granting USAGE + SELECT.
+
+    This is a no-op on DBs already in the modern state (e.g. dev). Per-workspace
+    failures (e.g. archived workspace whose DB was dropped) are logged and
+    skipped so a single bad workspace can't abort the migration.
+    """
+    Workspace = apps.get_model("workspaces", "Workspace")
+
+    for workspace in Workspace.objects.all():
+        db_name = workspace.db_name
+        try:
+            conn = get_admin_connection(db_name)
+            try:
+                with conn.cursor() as cur:
+                    cur.execute("REVOKE CREATE ON SCHEMA public FROM PUBLIC;")
+            finally:
+                conn.close()
+        except Exception as exc:
+            print(f"[0058] Skipping workspace {workspace.id} ({db_name}): {exc}")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workspaces", "0057_fix_readonly_role_grants"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            revoke_create_on_public_from_public,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/hexa/workspaces/migrations/0059_reassign_objects_owned_by_ro_role.py
+++ b/backend/hexa/workspaces/migrations/0059_reassign_objects_owned_by_ro_role.py
@@ -1,0 +1,81 @@
+import psycopg2
+from django.conf import settings
+from django.db import migrations
+from psycopg2 import sql
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+
+def get_admin_connection(db_name):
+    """Get a connection to a specific database using the admin role."""
+    host = settings.WORKSPACES_DATABASE_HOST
+    port = settings.WORKSPACES_DATABASE_PORT
+    admin_role = settings.WORKSPACES_DATABASE_ROLE
+    admin_password = settings.WORKSPACES_DATABASE_PASSWORD
+
+    conn = psycopg2.connect(
+        host=host,
+        port=port,
+        dbname=db_name,
+        user=admin_role,
+        password=admin_password,
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    return conn
+
+
+def reassign_objects_owned_by_ro_role(apps, schema_editor):
+    """
+    Move ownership of any objects owned by `{db_name}_ro` to `{db_name}` (the
+    workspace's RW role).
+
+    While the CREATE-via-PUBLIC leak (fixed with migration 0058) was active,
+    RO sessions could create tables.
+
+    Those tables ended up owned by the RO role, which made them invisible to the
+    OpenHEXA UI, resulting in confusion.
+
+    REASSIGN OWNED BY moves ownership of all such objects (tables,
+    sequences, indexes, views, …) from RO to RW within the current database.
+    Idempotent: a no-op if RO currently owns nothing.
+    """
+    Workspace = apps.get_model("workspaces", "Workspace")
+    admin_role = settings.WORKSPACES_DATABASE_ROLE
+
+    for workspace in Workspace.objects.all():
+        db_name = workspace.db_name
+        ro_role = f"{db_name}_ro"
+        try:
+            conn = get_admin_connection(db_name)
+            try:
+                with conn.cursor() as cur:
+                    # REASSIGN OWNED BY requires the executor to be a member of both the source
+                    # and target roles.
+                    cur.execute(
+                        sql.SQL("GRANT {ro_role} TO {admin_role}").format(
+                            ro_role=sql.Identifier(ro_role),
+                            admin_role=sql.Identifier(admin_role),
+                        )
+                    )
+                    cur.execute(
+                        sql.SQL("REASSIGN OWNED BY {ro_role} TO {rw_role}").format(
+                            ro_role=sql.Identifier(ro_role),
+                            rw_role=sql.Identifier(db_name),
+                        )
+                    )
+            finally:
+                conn.close()
+        except Exception as exc:
+            print(f"[0059] Skipping workspace {workspace.id} ({db_name}): {exc}")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workspaces", "0058_revoke_create_on_public_from_public"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            reassign_objects_owned_by_ro_role,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/hexa/workspaces/migrations/0059_reassign_objects_owned_by_ro_role.py
+++ b/backend/hexa/workspaces/migrations/0059_reassign_objects_owned_by_ro_role.py
@@ -62,6 +62,12 @@ def reassign_objects_owned_by_ro_role(apps, schema_editor):
                             rw_role=sql.Identifier(db_name),
                         )
                     )
+                    cur.execute(
+                        sql.SQL("REVOKE {ro_role} FROM {admin_role}").format(
+                            ro_role=sql.Identifier(ro_role),
+                            admin_role=sql.Identifier(admin_role),
+                        )
+                    )
             finally:
                 conn.close()
         except Exception as exc:


### PR DESCRIPTION
### Main changes

- Explicitly revoke the `CREATE` privilige for read-only roles (with a unit test that reproduces the issue we had on prod and shows how it's fixed)
- 2 migrations:
   1. Remove the `CREATE` privilige from the public role (this effectively removes it from RO role, RW is unaffected because it sets it explicitly)
   2. Change ownership of any tables that were created by RO roles.

### How to test

Difficult, since this issue only arises on production (not even on `demo`). So I propose a code-only review and good testing/verification on production.
Wrt to the test: I did make sure the test fails when the fix is absent.