### PR TITLE
fix: instrument internal ai agent and mcp clients with documentation (HEXA-1631)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -98,6 +98,8 @@ jobs:
         with:
           push: ${{ github.event_name != 'pull_request' }}
           context: backend
+          build-contexts: |
+            docs=docs
           target: app
           file: backend/Dockerfile
           cache-from: type=registry,ref=blsq/openhexa-app:buildcache

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -75,6 +75,8 @@ jobs:
         with:
           push: true
           context: backend
+          build-contexts: |
+            docs=docs
           file: backend/Dockerfile
           tags: |
             blsq/openhexa-app:${{ steps.version.outputs.number }}
@@ -87,6 +89,8 @@ jobs:
         with:
           push: true
           context: backend
+          build-contexts: |
+            docs=docs
           file: backend/Dockerfile
           tags: |
             blsq/openhexa-app:main

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,6 +27,9 @@ RUN --mount=type=cache,target=/root/.cache \
 # Copy the rest of the application
 COPY . /code/
 
+# Bundle only the English markdown docs consumed by hexa.mcp.docs
+COPY --from=docs en/*.md /code/docs/en/
+
 # Rootless
 ARG UID=1000
 ARG GID=1000

--- a/backend/hexa/assistant/agents/create_pipeline_agent.py
+++ b/backend/hexa/assistant/agents/create_pipeline_agent.py
@@ -1,10 +1,11 @@
 from hexa.assistant.agents.base import BaseAgent
 from hexa.assistant.instructions import InstructionSet
+from hexa.mcp.tools.help import get_help_or_doc
 from hexa.mcp.tools.pipelines import create_pipeline
 
 
 class CreatePipelineAgent(BaseAgent):
     # TODO: Add reading pipeline / pipeline templates tools
     instruction_set = InstructionSet.CREATE_PIPELINE
-    tools = [create_pipeline]
+    tools = [get_help_or_doc, create_pipeline]
     max_tokens = 8192

--- a/backend/hexa/assistant/agents/edit_pipeline_agent.py
+++ b/backend/hexa/assistant/agents/edit_pipeline_agent.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from hexa.assistant.agents.base import BaseAgent
 from hexa.assistant.instructions import InstructionSet
+from hexa.mcp.tools.help import get_help_or_doc
 from hexa.pipelines.models import Pipeline
 
 
@@ -52,7 +53,7 @@ def propose_pipeline_version(
 
 class EditPipelineAgent(BaseAgent):
     instruction_set = InstructionSet.EDIT_PIPELINE
-    tools = [propose_pipeline_version]
+    tools = [get_help_or_doc, propose_pipeline_version]
 
     @property
     def _context(self) -> dict:

--- a/backend/hexa/assistant/instructions.py
+++ b/backend/hexa/assistant/instructions.py
@@ -11,7 +11,9 @@ class InstructionSet(TextChoices):
 _BASE = """\
 You are OpenHEXA Assistant, an AI helper embedded in the OpenHEXA data platform. \
 You help data professionals work with pipelines, datasets, workspaces, and data \
-infrastructure. Be concise, accurate, and practical.\
+infrastructure. Be concise, accurate, and practical. \
+When you need orientation or domain knowledge, call get_help_or_doc — its description \
+lists the available topics.\
 """
 
 _CREATE_PIPELINE = """\
@@ -21,7 +23,9 @@ of what the pipeline does. \
 Use the create_pipeline tool to create the pipeline record, passing both pipeline name, description \
 and source code: write a minimal openhexa.sdk pipeline \
 skeleton in Python with @pipeline and @task decorators that reflects what the user described, \
-and pass it as source_code.\
+and pass it as source_code. \
+The create_pipeline tool description includes a cheat-sheet of OpenHEXA SDK conventions — \
+follow it. If you need deeper reference, call get_help_or_doc(topic="writing-pipelines").\
 """
 
 _EDIT_PIPELINE = """\
@@ -32,7 +36,8 @@ propose_pipeline_version tool — pass only the files you modified or created in
 and list any files to delete in deleted_files. Unchanged files are preserved automatically. \
 Before calling the tool, don't send any message. \
 After using the tool, briefly explain what you changed and why: \
-keep it short but structured, only the 2 or 3 most relevant key points.\
+keep it short but structured, only the 2 or 3 most relevant key points. \
+If you need a refresher on OpenHEXA SDK conventions, call get_help_or_doc(topic="writing-pipelines").\
 """
 
 _WEBAPPS = """\

--- a/backend/hexa/assistant/instructions.py
+++ b/backend/hexa/assistant/instructions.py
@@ -11,9 +11,7 @@ class InstructionSet(TextChoices):
 _BASE = """\
 You are OpenHEXA Assistant, an AI helper embedded in the OpenHEXA data platform. \
 You help data professionals work with pipelines, datasets, workspaces, and data \
-infrastructure. Be concise, accurate, and practical. \
-When you need orientation or domain knowledge, call get_help_or_doc — its description \
-lists the available topics.\
+infrastructure. Be concise, accurate, and practical.\
 """
 
 _CREATE_PIPELINE = """\

--- a/backend/hexa/assistant/instructions.py
+++ b/backend/hexa/assistant/instructions.py
@@ -1,11 +1,18 @@
 from django.db.models import TextChoices
 
+from hexa.mcp.docs import read_doc
+
 
 class InstructionSet(TextChoices):
     GENERAL = "general", "General"
     CREATE_PIPELINE = "create_pipeline", "Create Pipeline"
     EDIT_PIPELINE = "edit_pipeline", "Edit Pipeline"
     CREATE_WEBAPPS = "create_webapps", "Create Web Apps"
+
+
+PIPELINE_DOC_TOPICS = ("writing-pipelines", "sdk")
+
+_PIPELINE_DOCS = "\n\n".join(read_doc(name)["content"] for name in PIPELINE_DOC_TOPICS)
 
 
 _BASE = """\
@@ -21,9 +28,7 @@ of what the pipeline does. \
 Use the create_pipeline tool to create the pipeline record, passing both pipeline name, description \
 and source code: write a minimal openhexa.sdk pipeline \
 skeleton in Python with @pipeline and @task decorators that reflects what the user described, \
-and pass it as source_code. \
-The create_pipeline tool description includes a cheat-sheet of OpenHEXA SDK conventions — \
-follow it. If you need deeper reference, call get_help_or_doc(topic="writing-pipelines").\
+and pass it as source_code.
 """
 
 _EDIT_PIPELINE = """\
@@ -34,8 +39,7 @@ propose_pipeline_version tool — pass only the files you modified or created in
 and list any files to delete in deleted_files. Unchanged files are preserved automatically. \
 Before calling the tool, don't send any message. \
 After using the tool, briefly explain what you changed and why: \
-keep it short but structured, only the 2 or 3 most relevant key points. \
-If you need a refresher on OpenHEXA SDK conventions, call get_help_or_doc(topic="writing-pipelines").\
+keep it short but structured, only the 2 or 3 most relevant key points.
 """
 
 _WEBAPPS = """\
@@ -44,8 +48,8 @@ You are in charge of creating a new web app for the user.\
 
 _INSTRUCTION_SETS: dict[InstructionSet | tuple[str, str], str] = {
     InstructionSet.GENERAL: _BASE,
-    InstructionSet.CREATE_PIPELINE: _BASE + _CREATE_PIPELINE,
-    InstructionSet.EDIT_PIPELINE: _BASE + _EDIT_PIPELINE,
+    InstructionSet.CREATE_PIPELINE: _BASE + _CREATE_PIPELINE + _PIPELINE_DOCS,
+    InstructionSet.EDIT_PIPELINE: _BASE + _EDIT_PIPELINE + _PIPELINE_DOCS,
     InstructionSet.CREATE_WEBAPPS: _BASE + _WEBAPPS,
 }
 

--- a/backend/hexa/assistant/tests/test_instructions.py
+++ b/backend/hexa/assistant/tests/test_instructions.py
@@ -1,0 +1,26 @@
+from hexa.assistant.instructions import (
+    _PIPELINE_DOCS,
+    PIPELINE_DOC_TOPICS,
+    InstructionSet,
+    get_instructions,
+)
+from hexa.core.test import TestCase
+from hexa.mcp.docs import read_doc
+
+
+class PipelineDocsInstructionsTest(TestCase):
+    def test_required_topics_resolve_to_content(self):
+        for name in PIPELINE_DOC_TOPICS:
+            doc = read_doc(name)
+            self.assertIsNotNone(doc, f"missing doc topic '{name}'")
+            self.assertTrue(doc["content"].strip(), f"doc topic '{name}' is empty")
+
+    def test_pipeline_docs_block_includes_each_topic(self):
+        for name in PIPELINE_DOC_TOPICS:
+            self.assertIn(read_doc(name)["content"], _PIPELINE_DOCS)
+
+    def test_create_pipeline_instructions_include_docs(self):
+        self.assertIn(_PIPELINE_DOCS, get_instructions(InstructionSet.CREATE_PIPELINE))
+
+    def test_edit_pipeline_instructions_include_docs(self):
+        self.assertIn(_PIPELINE_DOCS, get_instructions(InstructionSet.EDIT_PIPELINE))

--- a/backend/hexa/mcp/docs.py
+++ b/backend/hexa/mcp/docs.py
@@ -1,0 +1,108 @@
+import os
+import re
+from functools import lru_cache
+from pathlib import Path
+
+
+def _resolve_docs_dir() -> Path:
+    override = os.environ.get("OPENHEXA_DOCS_DIR")
+    if override:
+        return Path(override)
+    here = Path(__file__).resolve()
+    candidates = (
+        here.parents[2] / "docs" / "en",  # docker image: /code/docs/en
+        here.parents[3] / "docs" / "en",  # local dev: <repo>/docs/en
+    )
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+    return candidates[0]
+
+
+DOCS_DIR = _resolve_docs_dir()
+
+_ALLOWED_SLUGS = frozenset(
+    {
+        "writing-pipelines",
+        "cli",
+        "sdk",
+        "toolbox",
+        "notebooks-advanced",
+    }
+)
+
+_HERO_H1_RE = re.compile(r"<h1[^>]*>(.*?)</h1>", re.DOTALL)
+_MD_H1_RE = re.compile(r"^#\s+(.+)$", re.MULTILINE)
+_TAG_RE = re.compile(r"<[^>]+>")
+_HERO_BLOCK_RE = re.compile(r'<div\s+class="hero-section".*?</div>\s*</div>', re.DOTALL)
+
+
+def _strip_tags(text: str) -> str:
+    return _TAG_RE.sub("", text).strip()
+
+
+def _extract_title(text: str, fallback: str) -> str:
+    m = _HERO_H1_RE.search(text)
+    if m:
+        title = _strip_tags(m.group(1))
+        if title:
+            return title
+    m = _MD_H1_RE.search(text)
+    if m:
+        return m.group(1).strip()
+    return fallback
+
+
+def _extract_summary(text: str) -> str:
+    body = _HERO_BLOCK_RE.sub("", text, count=1)
+    skip_prefixes = ("#", "<", "!", "```", "- ", "* ", "|", "    ")
+    for line in body.splitlines():
+        s = line.strip()
+        if not s or s.startswith(skip_prefixes):
+            continue
+        if re.match(r"^\d+\.\s", s):
+            continue
+        cleaned = _strip_tags(s)
+        cleaned = re.sub(r"\s+", " ", cleaned)
+        if cleaned:
+            return cleaned[:240]
+    return ""
+
+
+@lru_cache
+def _load() -> dict[str, dict]:
+    docs: dict[str, dict] = {}
+    if not DOCS_DIR.is_dir():
+        return docs
+    for path in sorted(DOCS_DIR.glob("*.md")):
+        slug = path.stem
+        if slug not in _ALLOWED_SLUGS:
+            continue
+        text = path.read_text(encoding="utf-8")
+        docs[slug] = {
+            "name": slug,
+            "title": _extract_title(text, slug),
+            "summary": _extract_summary(text),
+            "content": text,
+        }
+    return docs
+
+
+def get_index() -> list[dict]:
+    """Return [{name, title, summary}, ...] for every available doc."""
+    return [
+        {"name": d["name"], "title": d["title"], "summary": d["summary"]}
+        for d in _load().values()
+    ]
+
+
+def read_doc(name: str) -> dict | None:
+    """Return {name, title, content} for the given doc, or None if unknown."""
+    doc = _load().get(name)
+    if doc is None:
+        return None
+    return {"name": doc["name"], "title": doc["title"], "content": doc["content"]}
+
+
+def available_doc_names() -> list[str]:
+    return list(_load().keys())

--- a/backend/hexa/mcp/tests/test_help.py
+++ b/backend/hexa/mcp/tests/test_help.py
@@ -28,6 +28,16 @@ class GetHelpOrDocTest(MCPTestCase):
             {"cli", "notebooks-advanced", "sdk", "toolbox", "writing-pipelines"},
         )
 
+    def test_known_topic_returns_full_md_content(self):
+        result = get_help_or_doc(user=self.USER_ADMIN, topic="writing-pipelines")
+        self.assertEqual(result["name"], "writing-pipelines")
+        self.assertEqual(result["title"], "Writing OpenHEXA Pipelines")
+        self.assertIn(
+            "OpenHEXA data pipelines provide a way to help you automate data processing",
+            result["content"],
+        )
+        self.assertIn("## Quickstart", result["content"])
+
     def test_docstring_lists_curated_topics(self):
         expected = (
             "Call this tool when you are stuck, unsure what to do next, or need guidance on OpenHEXA."

--- a/backend/hexa/mcp/tests/test_help.py
+++ b/backend/hexa/mcp/tests/test_help.py
@@ -40,13 +40,13 @@ class GetHelpOrDocTest(MCPTestCase):
 
     def test_docstring_lists_curated_topics(self):
         expected = (
-            "Call this tool when you are stuck, unsure what to do next, or need guidance on OpenHEXA."
-            " Provide a reason describing why you need help (e.g. 'unsure which tool to use',"
-            " 'pipeline failed', 'cannot find dataset').\n"
+            "Call this tool when you are stuck, unsure what to do next, or need guidance on OpenHEXA.\n"
             "\n"
-            "Leave topic empty for an overview (orientation, common workflows, tips)."
-            " Pass a topic name to get guidance on a specific subject.\n"
-            "\n"
+            "    - Leave topic empty for an overview (orientation, common workflows, tips). Pass a reason\n"
+            "      describing what you are stuck on (e.g. 'unsure which tool to use', 'pipeline failed',\n"
+            "      'cannot find dataset').\n"
+            "    - Pass a topic name to fetch that doc page in full. Reason is optional here.\n"
+            "    \n"
             "\n"
             "    Available topics: cli, notebooks-advanced, sdk, toolbox, writing-pipelines."
         )

--- a/backend/hexa/mcp/tests/test_help.py
+++ b/backend/hexa/mcp/tests/test_help.py
@@ -42,11 +42,11 @@ class GetHelpOrDocTest(MCPTestCase):
         expected = (
             "Call this tool when you are stuck, unsure what to do next, or need guidance on OpenHEXA.\n"
             "\n"
-            "    - Leave topic empty for an overview (orientation, common workflows, tips). Pass a reason\n"
-            "      describing what you are stuck on (e.g. 'unsure which tool to use', 'pipeline failed',\n"
-            "      'cannot find dataset').\n"
-            "    - Pass a topic name to fetch that doc page in full. Reason is optional here.\n"
-            "    \n"
+            "- Leave topic empty for an overview (orientation, common workflows, tips). Pass a reason\n"
+            "  describing what you are stuck on (e.g. 'unsure which tool to use', 'pipeline failed',\n"
+            "  'cannot find dataset').\n"
+            "- Pass a topic name to fetch that doc page in full. Reason is optional here.\n"
+            "\n"
             "\n"
             "    Available topics: cli, notebooks-advanced, sdk, toolbox, writing-pipelines."
         )

--- a/backend/hexa/mcp/tests/test_help.py
+++ b/backend/hexa/mcp/tests/test_help.py
@@ -1,18 +1,43 @@
-from hexa.mcp.tools.help import get_help
+from hexa.mcp.tools.help import get_help_or_doc
 
 from .testutils import MCPTestCase
 
 
-class GetHelpTest(MCPTestCase):
-    def test_get_help(self):
-        result = get_help(user=self.USER_ADMIN)
+class GetHelpOrDocTest(MCPTestCase):
+    def test_overview_when_no_topic(self):
+        result = get_help_or_doc(user=self.USER_ADMIN)
         self.assertIn("about", result)
         self.assertIn("common_workflows", result)
         self.assertIn("tips", result)
         self.assertGreater(len(result["tips"]), 0)
+        self.assertIn("docs", result)
+        self.assertIsInstance(result["docs"], list)
 
-    def test_get_help_with_reason(self):
-        result = get_help(user=self.USER_ADMIN, reason="unsure which tool to use")
+    def test_overview_with_reason(self):
+        result = get_help_or_doc(
+            user=self.USER_ADMIN, reason="unsure which tool to use"
+        )
         self.assertIn("about", result)
-        self.assertIn("common_workflows", result)
-        self.assertIn("tips", result)
+        self.assertIn("docs", result)
+
+    def test_unknown_topic_returns_error_with_available_topics(self):
+        result = get_help_or_doc(user=self.USER_ADMIN, topic="does-not-exist")
+        self.assertEqual(result["error"], "Unknown topic 'does-not-exist'.")
+        self.assertEqual(
+            set(result["available_topics"]),
+            {"cli", "notebooks-advanced", "sdk", "toolbox", "writing-pipelines"},
+        )
+
+    def test_docstring_lists_curated_topics(self):
+        expected = (
+            "Call this tool when you are stuck, unsure what to do next, or need guidance on OpenHEXA."
+            " Provide a reason describing why you need help (e.g. 'unsure which tool to use',"
+            " 'pipeline failed', 'cannot find dataset').\n"
+            "\n"
+            "Leave topic empty for an overview (orientation, common workflows, tips)."
+            " Pass a topic name to get guidance on a specific subject.\n"
+            "\n"
+            "\n"
+            "    Available topics: cli, notebooks-advanced, sdk, toolbox, writing-pipelines."
+        )
+        self.assertEqual(get_help_or_doc.__doc__, expected)

--- a/backend/hexa/mcp/tools/help.py
+++ b/backend/hexa/mcp/tools/help.py
@@ -27,9 +27,12 @@ _OVERVIEW = {
 
 @tool
 def get_help_or_doc(user, topic: str = "", reason: str = "") -> dict:
-    """Call this tool when you are stuck, unsure what to do next, or need guidance on OpenHEXA. Provide a reason describing why you need help (e.g. 'unsure which tool to use', 'pipeline failed', 'cannot find dataset').
+    """Call this tool when you are stuck, unsure what to do next, or need guidance on OpenHEXA.
 
-    Leave topic empty for an overview (orientation, common workflows, tips). Pass a topic name to get guidance on a specific subject.
+    - Leave topic empty for an overview (orientation, common workflows, tips). Pass a reason
+      describing what you are stuck on (e.g. 'unsure which tool to use', 'pipeline failed',
+      'cannot find dataset').
+    - Pass a topic name to fetch that doc page in full. Reason is optional here.
     """
     if topic:
         doc = read_doc(topic)

--- a/backend/hexa/mcp/tools/help.py
+++ b/backend/hexa/mcp/tools/help.py
@@ -1,27 +1,52 @@
+from hexa.mcp.docs import available_doc_names, get_index, read_doc
 from hexa.mcp.protocol import tool
+
+_OVERVIEW = {
+    "about": (
+        "OpenHEXA is a data integration platform. Users organize work in workspaces, "
+        "which contain pipelines (automated data workflows), datasets (versioned data collections), "
+        "files (in a workspace bucket), connections (external data sources like S3, PostgreSQL, DHIS2), "
+        "and static web apps."
+    ),
+    "common_workflows": [
+        "Explore: list_workspaces -> list_pipelines / list_datasets / list_files",
+        "Run a pipeline: get_pipeline (check parameters) -> run_pipeline -> get_pipeline_run (check results)",
+        "Inspect data: list_datasets -> get_dataset -> preview_dataset_file",
+        "Use a template: list_pipeline_templates -> get_pipeline_template -> create_pipeline_from_template",
+        "Create a web app: create_static_webapp with HTML/CSS/JS files",
+    ],
+    "tips": [
+        "Start with list_workspaces to discover available workspaces",
+        "Most resources are identified by workspace_slug + resource_slug or UUID",
+        "When running pipelines, always check parameters first with get_pipeline",
+        "Connection slugs from list_connections are used as pipeline parameter values",
+        "For deeper guidance on a topic, call this tool again with topic=<doc-name>",
+    ],
+}
 
 
 @tool
-def get_help(user, reason: str = "") -> dict:
-    """Call this tool when you are stuck, unsure what to do next, or need guidance on OpenHEXA. Provide a reason describing why you need help (e.g. 'unsure which tool to use', 'pipeline failed', 'cannot find dataset')."""
-    return {
-        "about": (
-            "OpenHEXA is a data integration platform. Users organize work in workspaces, "
-            "which contain pipelines (automated data workflows), datasets (versioned data collections), "
-            "files (in a workspace bucket), connections (external data sources like S3, PostgreSQL, DHIS2), "
-            "and static web apps."
-        ),
-        "common_workflows": [
-            "Explore: list_workspaces -> list_pipelines / list_datasets / list_files",
-            "Run a pipeline: get_pipeline (check parameters) -> run_pipeline -> get_pipeline_run (check results)",
-            "Inspect data: list_datasets -> get_dataset -> preview_dataset_file",
-            "Use a template: list_pipeline_templates -> get_pipeline_template -> create_pipeline_from_template",
-            "Create a web app: create_static_webapp with HTML/CSS/JS files",
-        ],
-        "tips": [
-            "Start with list_workspaces to discover available workspaces",
-            "Most resources are identified by workspace_slug + resource_slug or UUID",
-            "When running pipelines, always check parameters first with get_pipeline",
-            "Connection slugs from list_connections are used as pipeline parameter values",
-        ],
-    }
+def get_help_or_doc(user, topic: str = "", reason: str = "") -> dict:
+    """Call this tool when you are stuck, unsure what to do next, or need guidance on OpenHEXA. Provide a reason describing why you need help (e.g. 'unsure which tool to use', 'pipeline failed', 'cannot find dataset').
+
+    Leave topic empty for an overview (orientation, common workflows, tips). Pass a topic name to get guidance on a specific subject.
+    """
+    if topic:
+        doc = read_doc(topic)
+        if doc is None:
+            return {
+                "error": f"Unknown topic '{topic}'.",
+                "available_topics": [d["name"] for d in get_index()],
+            }
+        return doc
+    return {**_OVERVIEW, "docs": get_index()}
+
+
+_topic_names = available_doc_names()
+if _topic_names:
+    get_help_or_doc.__doc__ = (
+        (get_help_or_doc.__doc__ or "")
+        + "\n\n    Available topics: "
+        + ", ".join(_topic_names)
+        + "."
+    )

--- a/backend/hexa/mcp/tools/pipelines.py
+++ b/backend/hexa/mcp/tools/pipelines.py
@@ -113,7 +113,6 @@ def _build_zipfile_b64(source_code: str) -> str:
 
 
 # TODO : refine cheat sheet
-# TODO : test reading docs
 
 _PIPELINE_AUTHORING_CHEAT_SHEET = """
 OpenHEXA pipeline authoring cheat-sheet

--- a/backend/hexa/mcp/tools/pipelines.py
+++ b/backend/hexa/mcp/tools/pipelines.py
@@ -112,6 +112,81 @@ def _build_zipfile_b64(source_code: str) -> str:
     return base64.b64encode(buf.getvalue()).decode("ascii")
 
 
+_PIPELINE_AUTHORING_CHEAT_SHEET = """
+OpenHEXA pipeline authoring cheat-sheet
+---------------------------------------
+
+Imports come from `openhexa.sdk`:
+
+    from openhexa.sdk import current_run, pipeline, parameter, workspace
+
+Structure:
+- The pipeline function uses `@pipeline("code")` and ONLY orchestrates tasks (no data work in it).
+- Tasks use `@<pipeline_name>.task` and contain the actual work.
+- Task return values can be passed as args to other tasks — that defines the DAG and
+  enables parallel execution of independent tasks.
+- Task return values must be picklable. Pass each value as its own argument
+  (no list/dict wrapping of return values).
+- You CANNOT use task return values inside the @pipeline-decorated function — they are proxies
+  resolved only when consumed by another task.
+
+Logging (surfaces in the run UI):
+    current_run.log_debug / log_info / log_warning / log_error / log_critical
+
+Workspace files (read/write under `workspace.files_path`):
+    with open(f"{workspace.files_path}/data.csv") as f: ...
+    current_run.add_file_output(output_path)            # register file output
+
+Workspace database:
+    from sqlalchemy import create_engine
+    engine = create_engine(workspace.database_url)
+    df.to_sql("transformed", con=engine, if_exists="replace")
+    current_run.add_database_output("transformed")      # register table output
+
+Pipeline parameters (declared with `@parameter` decorators stacked above `@pipeline`):
+- First positional arg `code` becomes the function argument name.
+- `type` is one of: `int`, `float`, `str`, `bool`,
+  a connection class (`DHIS2Connection`, `PostgreSQLConnection`, `IASOConnection`, ...),
+  `Dataset`, `File`, or `Secret` (for tokens/passwords).
+- Optional kwargs: `name`, `help`, `choices`, `default`, `required` (default True),
+  `multiple` (default False), `widget`, `connection`.
+
+Connections: declare via `@parameter("conn", type=DHIS2Connection)` — the connection instance
+is passed to the pipeline function automatically.
+
+Timeouts: pass `timeout=<seconds>` to `@pipeline(...)` if the default 4h is not enough
+(max is instance-configured, typically 12h).
+
+Minimal valid skeleton:
+
+    from openhexa.sdk import current_run, pipeline
+
+
+    @pipeline("simple-etl")
+    def simple_etl():
+        count = task_1()
+        task_2(count)
+
+
+    @simple_etl.task
+    def task_1():
+        current_run.log_info("In task 1...")
+        return 42
+
+
+    @simple_etl.task
+    def task_2(count):
+        current_run.log_info(f"In task 2... count is {count}")
+
+
+    if __name__ == "__main__":
+        simple_etl()
+
+For the full reference (file IO recipes, scheduling, widgets, secrets, datasets, debugging),
+call get_help_or_doc(topic="writing-pipelines"). For SDK details, use topic="sdk".
+"""
+
+
 @tool
 def create_pipeline(
     user,
@@ -128,31 +203,6 @@ def create_pipeline(
     Only name, description, and functional_type are supported at creation time.
 
     If source_code is omitted, the pipeline is created without any version.
-
-    The source_code must follow this structure:
-
-        from openhexa.sdk import current_run, pipeline
-
-
-        @pipeline("Simple ETL")
-        def simple_etl():
-            count = task_1()
-            task_2(count)
-
-
-        @simple_etl.task
-        def task_1():
-            current_run.log_info("In task 1...")
-            return 42
-
-
-        @simple_etl.task
-        def task_2(count):
-            current_run.log_info(f"In task 2... count is {count}")
-
-
-        if __name__ == "__main__":
-            simple_etl()
     """
     zipfile_b64 = _build_zipfile_b64(source_code) if source_code else None
 
@@ -210,3 +260,11 @@ def create_pipeline_version(
     if "errors" in data:
         return data
     return data.get("uploadPipeline", {})
+
+
+create_pipeline.__doc__ = (
+    create_pipeline.__doc__ or ""
+) + _PIPELINE_AUTHORING_CHEAT_SHEET
+create_pipeline_version.__doc__ = (
+    create_pipeline_version.__doc__ or ""
+) + _PIPELINE_AUTHORING_CHEAT_SHEET

--- a/backend/hexa/mcp/tools/pipelines.py
+++ b/backend/hexa/mcp/tools/pipelines.py
@@ -112,8 +112,6 @@ def _build_zipfile_b64(source_code: str) -> str:
     return base64.b64encode(buf.getvalue()).decode("ascii")
 
 
-# TODO : refine cheat sheet
-
 _PIPELINE_AUTHORING_CHEAT_SHEET = """
 OpenHEXA pipeline authoring cheat-sheet
 ---------------------------------------
@@ -184,7 +182,58 @@ Minimal valid skeleton:
     if __name__ == "__main__":
         simple_etl()
 
-For the full reference (file IO recipes, scheduling, widgets, secrets, datasets, debugging),
+Advanced example (parameters, connection, parallel tasks, file + database outputs):
+
+    import pandas as pd
+    from sqlalchemy import create_engine
+    from openhexa.sdk import (
+        current_run, pipeline, parameter, workspace, DHIS2Connection,
+    )
+
+
+    @parameter("dhis2", type=DHIS2Connection, name="DHIS2 instance")
+    @parameter("org_unit", type=str, name="Org unit ID", required=True)
+    @parameter("year", type=int, default=2024)
+    @pipeline("dhis2-monthly-report", timeout=3600)
+    def dhis2_monthly_report(dhis2, org_unit, year):
+        raw = extract(dhis2, org_unit, year)
+        cleaned = transform(raw)
+        # Independent tasks — run in parallel because they only depend on `cleaned`:
+        save_file(cleaned)
+        save_table(cleaned)
+
+
+    @dhis2_monthly_report.task
+    def extract(dhis2, org_unit, year):
+        current_run.log_info(f"Fetching data for {org_unit} ({year})")
+        # dhis2 is a ready-to-use openhexa.toolbox.dhis2 client
+        return dhis2.analytics.get(org_unit=org_unit, period=str(year))
+
+
+    @dhis2_monthly_report.task
+    def transform(raw):
+        df = pd.DataFrame(raw)
+        return df.dropna()
+
+
+    @dhis2_monthly_report.task
+    def save_file(df):
+        path = f"{workspace.files_path}/reports/monthly.csv"
+        df.to_csv(path, index=False)
+        current_run.add_file_output(path)
+
+
+    @dhis2_monthly_report.task
+    def save_table(df):
+        engine = create_engine(workspace.database_url)
+        df.to_sql("monthly_report", con=engine, if_exists="replace", index=False)
+        current_run.add_database_output("monthly_report")
+
+
+    if __name__ == "__main__":
+        dhis2_monthly_report()
+
+For the full reference (scheduling, widgets, secrets, datasets, debugging),
 call get_help_or_doc(topic="writing-pipelines"). For SDK details, use topic="sdk".
 """
 

--- a/backend/hexa/mcp/tools/pipelines.py
+++ b/backend/hexa/mcp/tools/pipelines.py
@@ -112,6 +112,9 @@ def _build_zipfile_b64(source_code: str) -> str:
     return base64.b64encode(buf.getvalue()).decode("ascii")
 
 
+# TODO : refine cheat sheet
+# TODO : test reading docs
+
 _PIPELINE_AUTHORING_CHEAT_SHEET = """
 OpenHEXA pipeline authoring cheat-sheet
 ---------------------------------------

--- a/backend/hexa/oauth/views.py
+++ b/backend/hexa/oauth/views.py
@@ -143,22 +143,6 @@ def dynamic_client_registration(request: HttpRequest) -> JsonResponse:
     return JsonResponse(response_data, status=201)
 
 
-def _short_description(description: str) -> str:
-    """Return the first paragraph of a tool description.
-
-    Tool docstrings can carry long reference material (e.g. authoring cheat-sheets) that the LLM
-    needs but that would clutter the OAuth consent screen. We display the leading paragraph only.
-    """
-    return (description or "").strip().split("\n\n", 1)[0].strip()
-
-
-def _consent_tools() -> list[dict]:
-    return [
-        {"name": t["name"], "description": _short_description(t.get("description", ""))}
-        for t in get_tools_list()
-    ]
-
-
 class OAuthAuthorizeView(AuthorizationView):
     login_url = "/login"
 
@@ -166,12 +150,19 @@ class OAuthAuthorizeView(AuthorizationView):
         context = super().get_context_data(**kwargs)
         scopes = self.request.GET.get("scope", "")
         if "openhexa:mcp" in scopes.split():
-            context["tools"] = _consent_tools()
+            context["tools"] = [
+                {"name": t["name"], "description": t.get("description", "")}
+                for t in get_tools_list()
+            ]
         return context
 
     def redirect(self, redirect_to, application):
+        tools = [
+            {"name": t["name"], "description": t.get("description", "")}
+            for t in get_tools_list()
+        ]
         html = render_to_string(
             "oauth2_provider/authorized.html",
-            {"redirect_uri": redirect_to, "tools": _consent_tools()},
+            {"redirect_uri": redirect_to, "tools": tools},
         )
         return HttpResponse(html)

--- a/backend/hexa/oauth/views.py
+++ b/backend/hexa/oauth/views.py
@@ -143,6 +143,22 @@ def dynamic_client_registration(request: HttpRequest) -> JsonResponse:
     return JsonResponse(response_data, status=201)
 
 
+def _short_description(description: str) -> str:
+    """Return the first paragraph of a tool description.
+
+    Tool docstrings can carry long reference material (e.g. authoring cheat-sheets) that the LLM
+    needs but that would clutter the OAuth consent screen. We display the leading paragraph only.
+    """
+    return (description or "").strip().split("\n\n", 1)[0].strip()
+
+
+def _consent_tools() -> list[dict]:
+    return [
+        {"name": t["name"], "description": _short_description(t.get("description", ""))}
+        for t in get_tools_list()
+    ]
+
+
 class OAuthAuthorizeView(AuthorizationView):
     login_url = "/login"
 
@@ -150,19 +166,12 @@ class OAuthAuthorizeView(AuthorizationView):
         context = super().get_context_data(**kwargs)
         scopes = self.request.GET.get("scope", "")
         if "openhexa:mcp" in scopes.split():
-            context["tools"] = [
-                {"name": t["name"], "description": t.get("description", "")}
-                for t in get_tools_list()
-            ]
+            context["tools"] = _consent_tools()
         return context
 
     def redirect(self, redirect_to, application):
-        tools = [
-            {"name": t["name"], "description": t.get("description", "")}
-            for t in get_tools_list()
-        ]
         html = render_to_string(
             "oauth2_provider/authorized.html",
-            {"redirect_uri": redirect_to, "tools": tools},
+            {"redirect_uri": redirect_to, "tools": _consent_tools()},
         )
         return HttpResponse(html)

--- a/backend/hexa/templates/oauth2_provider/authorize.html
+++ b/backend/hexa/templates/oauth2_provider/authorize.html
@@ -23,7 +23,15 @@
                             <svg fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                             </svg>
-                            <span><span class="tool-name">{{ tool.name }}</span>{% if tool.description %} <span class="tool-desc">— {{ tool.description }}</span>{% endif %}</span>
+                            <div class="tool-content">
+                                <span class="tool-name">{{ tool.name }}</span>
+                                {% if tool.description %}
+                                    <details class="tool-details">
+                                        <summary><span class="tool-desc">— {{ tool.description|truncatechars:140 }}</span><span class="tool-arrow" aria-hidden="true">▸</span></summary>
+                                        <div class="tool-full">{{ tool.description }}</div>
+                                    </details>
+                                {% endif %}
+                            </div>
                         </li>
                     {% endfor %}
                 </ul>

--- a/backend/hexa/templates/oauth2_provider/authorized.html
+++ b/backend/hexa/templates/oauth2_provider/authorized.html
@@ -29,7 +29,15 @@
                         <svg fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                         </svg>
-                        <span><span class="tool-name">{{ tool.name }}</span>{% if tool.description %} <span class="tool-desc">— {{ tool.description }}</span>{% endif %}</span>
+                        <div class="tool-content">
+                            <span class="tool-name">{{ tool.name }}</span>
+                            {% if tool.description %}
+                                <details class="tool-details">
+                                    <summary><span class="tool-desc">— {{ tool.description|truncatechars:140 }}</span><span class="tool-arrow" aria-hidden="true">▸</span></summary>
+                                    <div class="tool-full">{{ tool.description }}</div>
+                                </details>
+                            {% endif %}
+                        </div>
                     </li>
                 {% endfor %}
             </ul>

--- a/backend/hexa/templates/oauth2_provider/base.html
+++ b/backend/hexa/templates/oauth2_provider/base.html
@@ -18,10 +18,18 @@
         .scopes { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 0.5rem; padding: 1rem 1.25rem; }
         .scopes h3 { font-size: 0.875rem; font-weight: 500; color: #374151; margin-bottom: 0.75rem; }
         .scopes ul { list-style: none; display: flex; flex-direction: column; gap: 0.5rem; }
-        .scopes li { display: flex; align-items: baseline; font-size: 0.875rem; line-height: 1.4; }
-        .scopes li svg { width: 1rem; height: 1rem; margin-right: 0.5rem; flex-shrink: 0; position: relative; top: 0.15rem; }
-        .tool-name { font-weight: 600; font-family: 'SF Mono', SFMono-Regular, ui-monospace, Menlo, monospace; font-size: 0.8125rem; white-space: nowrap; }
+        .scopes li { display: flex; align-items: flex-start; font-size: 0.875rem; line-height: 1.4; }
+        .scopes li svg { width: 1rem; height: 1rem; margin-right: 0.5rem; flex-shrink: 0; position: relative; top: 0.2rem; }
+        .tool-content { flex: 1; min-width: 0; }
+        .tool-name { font-weight: 600; font-family: 'SF Mono', SFMono-Regular, ui-monospace, Menlo, monospace; font-size: 0.8125rem; }
         .tool-desc { color: #6b7280; }
+        .tool-details { display: inline; }
+        .tool-details > summary { display: inline; cursor: pointer; list-style: none; color: #6b7280; }
+        .tool-details > summary::-webkit-details-marker { display: none; }
+        .tool-arrow { display: inline-block; margin-left: 0.25rem; color: #9ca3af; transition: transform 0.15s ease; font-size: 0.75rem; }
+        .tool-details[open] .tool-arrow { transform: rotate(90deg); color: #6b7280; }
+        .tool-details[open] .tool-desc { display: none; }
+        .tool-full { display: block; margin-top: 0.25rem; color: #6b7280; font-size: 0.875rem; line-height: 1.4; white-space: pre-wrap; overflow-wrap: anywhere; }
         .error-box { background: #fef2f2; border: 1px solid #fecaca; border-radius: 0.5rem; padding: 1rem; }
         .error-box h3 { font-size: 0.875rem; font-weight: 500; color: #991b1b; }
         .error-box p { font-size: 0.875rem; color: #b91c1c; margin-top: 0.25rem; }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,8 @@ x-app: &common
       context: ./backend
       dockerfile: Dockerfile
       target: app
+      additional_contexts:
+        docs: ./docs
       args:
         - DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE}
         - WORKSPACE_STORAGE_LOCATION=${WORKSPACE_STORAGE_LOCATION}
@@ -22,6 +24,7 @@ x-app: &common
       - openhexa
     volumes:  # only used for Github Codespaces
       - "${LOCAL_WORKSPACE_FOLDER:-./backend}:/code"
+      - "./docs:/code/docs:ro"
       - "${WORKSPACE_STORAGE_LOCATION:-/data/openhexa}:/data"
 
 services:
@@ -69,6 +72,8 @@ services:
       context: ./backend
       dockerfile: Dockerfile
       target: pipelines
+      additional_contexts:
+        docs: ./docs
       args:
         - DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE}
         - WORKSPACE_STORAGE_LOCATION=${WORKSPACE_STORAGE_LOCATION}
@@ -82,6 +87,7 @@ services:
       - IS_LOCAL_DEV=true
     volumes:  # only used for Github Codespaces
       - "${LOCAL_WORKSPACE_FOLDER:-./backend}:/code"
+      - "./docs:/code/docs:ro"
       - /var/run/docker.sock:/var/run/docker.sock
       - ${HOME}/.kube:/root/.kube:ro
 
@@ -91,6 +97,8 @@ services:
       context: ./backend
       dockerfile: Dockerfile
       target: pipelines
+      additional_contexts:
+        docs: ./docs
       args:
         - DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE}
         - WORKSPACE_STORAGE_LOCATION=${WORKSPACE_STORAGE_LOCATION}
@@ -100,6 +108,7 @@ services:
       - "pipelines"
     volumes:  # only used for Github Codespaces
       - "${LOCAL_WORKSPACE_FOLDER:-./backend}:/code"
+      - "./docs:/code/docs:ro"
     depends_on:
       - db
 


### PR DESCRIPTION
Internal agent and agents using MCP lack the context to write great pipelines.

We previously migrated documentation into this project. We can now expose this doc through a tool to those agents

Strategy : 

- Include the en markdown docs in the build
- Modify the `get_help` tool to provide documentation with dynamic indexed topics as a docstring
- Instruction contain a hint to use this tool
- Create and edit pipelines tools now contain a cheat sheet to write great pipelines and are instructed to get_help for more depth

<img width="2154" height="884" alt="Screenshot 2026-05-07 at 10 37 06" src="https://github.com/user-attachments/assets/426b0ae3-151f-4c94-bb68-92b998e4a9e0" />
<img width="1982" height="399" alt="Screenshot 2026-05-07 at 10 47 34" src="https://github.com/user-attachments/assets/0920dcc4-201a-4d1c-a042-edcb9c1a7b30" />

