### PR TITLE
fix: Bring back Django auto reload for local development

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -31,6 +31,7 @@ DJANGO_SETTINGS_MODULE=config.settings.base
 # Django debugging settings
 DEBUG_LOGGING=true
 DEBUG_TOOLBAR=false
+DJANGO_HOT_RELOAD=false
 
 # Self-registration (allow users to sign up without an invitation)
 ALLOW_SELF_REGISTRATION=false

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -36,7 +36,7 @@ case "$command" in
   ;;
 "start")
   wait-for-it ${DATABASE_HOST:-db}:${DATABASE_PORT:-5432}
-  gunicorn config.asgi:application -k config.workers.UvicornWorkerNoLifespan --bind 0:8000 --workers=3
+  gunicorn config.asgi:application -k config.workers.UvicornWorkerNoLifespan --bind 0:8000 --workers=3 $arguments
   ;;
 "makemigrations")
   wait-for-it ${DATABASE_HOST:-db}:${DATABASE_PORT:-5432}

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -36,7 +36,11 @@ case "$command" in
   ;;
 "start")
   wait-for-it ${DATABASE_HOST:-db}:${DATABASE_PORT:-5432}
-  gunicorn config.asgi:application -k config.workers.UvicornWorkerNoLifespan --bind 0:8000 --workers=3 $arguments
+  if [[ "${DJANGO_HOT_RELOAD:-false}" == "true" ]]; then
+    uvicorn config.asgi:application --host 0.0.0.0 --port 8000 --reload
+  else
+    gunicorn config.asgi:application -k config.workers.UvicornWorkerNoLifespan --bind 0:8000 --workers=3 $arguments
+  fi
   ;;
 "makemigrations")
   wait-for-it ${DATABASE_HOST:-db}:${DATABASE_PORT:-5432}

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -39,7 +39,7 @@ case "$command" in
   if [[ "${DJANGO_HOT_RELOAD:-false}" == "true" ]]; then
     uvicorn config.asgi:application --host 0.0.0.0 --port 8000 --reload
   else
-    gunicorn config.asgi:application -k config.workers.UvicornWorkerNoLifespan --bind 0:8000 --workers=3 $arguments
+    gunicorn config.asgi:application -k config.workers.UvicornWorkerNoLifespan --bind 0:8000 --workers=3
   fi
   ;;
 "makemigrations")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
   app:
     # Inherit from the block defined on top and override some fields
     <<: *common
-    command: "start --reload"
+    command: "start"
     restart: unless-stopped
     image: blsq/openhexa-app
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
   app:
     # Inherit from the block defined on top and override some fields
     <<: *common
-    command: "start"
+    command: "start --reload"
     restart: unless-stopped
     image: blsq/openhexa-app
     ports:


### PR DESCRIPTION
Seems like it got lost somewhere when we changed the `gunicorn` settings.