### PR TITLE
fix: Web apps image files are corrupted upon upload

### DIFF
--- a/backend/hexa/git/forgejo.py
+++ b/backend/hexa/git/forgejo.py
@@ -148,10 +148,8 @@ class ForgejoClient(GitClient):
             path = file["path"]
             is_update = path in existing_tree
             content = file["content"]
-            if isinstance(content, str):
-                content = base64.b64encode(content.encode()).decode()
-            elif isinstance(content, bytes):
-                content = base64.b64encode(content).decode()
+            if isinstance(content, bytes):
+                content = base64.b64encode(content).decode("ascii")
             op = {
                 "operation": "update" if is_update else "create",
                 "path": path,
@@ -184,7 +182,7 @@ class ForgejoClient(GitClient):
         *,
         org_slug: str | None = None,
     ) -> list[dict]:
-        """Fetch the full file tree and return a flat list with path, type, and content."""
+        """Fetch the full file tree and return a flat list with path, type, and base64 content."""
         tree = self.get_files_tree(repo_name, ref, org_slug=org_slug)
         nodes: list[dict] = []
 
@@ -196,7 +194,7 @@ class ForgejoClient(GitClient):
                 nodes.append({"path": path, "type": "directory", "content": None})
             elif entry_type == "blob":
                 raw = self.get_file(repo_name, path, ref, org_slug=org_slug)
-                content = raw.decode("utf-8", errors="replace")
+                content = base64.b64encode(raw).decode("ascii")
                 nodes.append({"path": path, "type": "file", "content": content})
 
         return nodes

--- a/backend/hexa/webapps/models.py
+++ b/backend/hexa/webapps/models.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import secrets
 
@@ -268,6 +269,13 @@ class GitWebapp(Webapp, GitRepoMixin):
             parent = "/".join(path.split("/")[:-1]) or None
             extension = os.path.splitext(path)[1].lower()
 
+            language = self.LANGUAGE_MAP.get(extension) if content else None
+            line_count = (
+                base64.b64decode(content).decode("utf-8").count("\n") + 1
+                if content and language
+                else None
+            )
+
             nodes.append(
                 {
                     "id": path,
@@ -277,8 +285,8 @@ class GitWebapp(Webapp, GitRepoMixin):
                     "content": content,
                     "parent_id": parent,
                     "auto_select": path == "index.html",
-                    "language": self.LANGUAGE_MAP.get(extension) if content else None,
-                    "line_count": content.count("\n") + 1 if content else None,
+                    "language": language,
+                    "line_count": line_count,
                 }
             )
         return nodes

--- a/backend/hexa/webapps/tests/test_schema/test_git_webapps.py
+++ b/backend/hexa/webapps/tests/test_schema/test_git_webapps.py
@@ -1,3 +1,4 @@
+import base64
 from unittest.mock import MagicMock, patch
 from urllib.parse import urlparse
 
@@ -582,8 +583,16 @@ class GitWebappQueryTest(GraphQLTestCase):
         mock_client = MagicMock()
         mock_client.get_commits.return_value = []
         mock_client.get_repository_files.return_value = [
-            {"path": "index.html", "type": "file", "content": "<h1>Hello</h1>"},
-            {"path": "style.css", "type": "file", "content": "body { color: red; }"},
+            {
+                "path": "index.html",
+                "type": "file",
+                "content": base64.b64encode(b"<h1>Hello</h1>").decode("ascii"),
+            },
+            {
+                "path": "style.css",
+                "type": "file",
+                "content": base64.b64encode(b"body { color: red; }").decode("ascii"),
+            },
         ]
         mock_get_client.return_value = mock_client
 
@@ -607,7 +616,10 @@ class GitWebappQueryTest(GraphQLTestCase):
         index_file = next(f for f in files if f["path"] == "index.html")
         self.assertEqual(index_file["name"], "index.html")
         self.assertEqual(index_file["type"], "file")
-        self.assertEqual(index_file["content"], "<h1>Hello</h1>")
+        self.assertEqual(
+            base64.b64decode(index_file["content"]).decode("utf-8"),
+            "<h1>Hello</h1>",
+        )
         self.assertTrue(index_file["autoSelect"])
         self.assertEqual(index_file["language"], "html")
 
@@ -621,12 +633,20 @@ class GitWebappQueryTest(GraphQLTestCase):
         mock_client.get_commits.return_value = []
         mock_client.get_repository_files.return_value = [
             {"path": "assets", "type": "directory", "content": None},
-            {"path": "index.html", "type": "file", "content": "<html></html>"},
-            {"path": "assets/style.css", "type": "file", "content": "body {}"},
+            {
+                "path": "index.html",
+                "type": "file",
+                "content": base64.b64encode(b"<html></html>").decode("ascii"),
+            },
+            {
+                "path": "assets/style.css",
+                "type": "file",
+                "content": base64.b64encode(b"body {}").decode("ascii"),
+            },
             {
                 "path": "assets/script.js",
                 "type": "file",
-                "content": "console.log('hi');",
+                "content": base64.b64encode(b"console.log('hi');").decode("ascii"),
             },
         ]
         mock_get_client.return_value = mock_client

--- a/frontend/src/core/helpers/base64.ts
+++ b/frontend/src/core/helpers/base64.ts
@@ -16,19 +16,10 @@ export const base64ToString = (value: string): string =>
 export const fileToBase64 = (file: Blob): Promise<string> =>
   new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onerror = () => reject(reader.error ?? new Error("read failed"));
+    reader.onerror = () => reject(reader.error);
     reader.onload = () => {
-      const result = reader.result;
-      if (typeof result !== "string") {
-        reject(new Error("Unexpected FileReader result"));
-        return;
-      }
-      const comma = result.indexOf(",");
-      if (comma < 0) {
-        reject(new Error("Malformed data URL"));
-        return;
-      }
-      resolve(result.slice(comma + 1));
+      const result = reader.result as string;
+      resolve(result.slice(result.indexOf(",") + 1));
     };
     reader.readAsDataURL(file);
   });

--- a/frontend/src/core/helpers/base64.ts
+++ b/frontend/src/core/helpers/base64.ts
@@ -1,3 +1,6 @@
+export const base64ToBytes = (value: string) =>
+  Uint8Array.from(atob(value), (c) => c.charCodeAt(0));
+
 export const stringToBase64 = (value: string): string => {
   const bytes = new TextEncoder().encode(value);
   let binary = "";
@@ -7,14 +10,8 @@ export const stringToBase64 = (value: string): string => {
   return btoa(binary);
 };
 
-export const base64ToString = (value: string): string => {
-  const binary = atob(value);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
-};
+export const base64ToString = (value: string): string =>
+  new TextDecoder().decode(base64ToBytes(value));
 
 export const fileToBase64 = (file: Blob): Promise<string> =>
   new Promise((resolve, reject) => {

--- a/frontend/src/pipelines/helpers/pipeline.ts
+++ b/frontend/src/pipelines/helpers/pipeline.ts
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client";
 import { getApolloClient } from "core/helpers/apollo";
+import { base64ToBytes } from "core/helpers/base64";
 import { RunDagError } from "graphql/types";
 import {
   GetPipelineVersionQuery,
@@ -65,9 +66,7 @@ export async function downloadPipelineVersion(versionId: string) {
     throw new Error(`No version found for ${versionId}`);
   }
   const { zipfile, pipeline } = data.pipelineVersion;
-  const binaryString = atob(zipfile);
-  const bytes = Uint8Array.from(binaryString, (c) => c.charCodeAt(0));
-  const blob = new Blob([bytes], {
+  const blob = new Blob([base64ToBytes(zipfile)], {
     type: "application/zip",
   });
   const url = window.URL.createObjectURL(blob);

--- a/frontend/src/webapps/features/WebappFilesEditor/WebappFilesEditor.tsx
+++ b/frontend/src/webapps/features/WebappFilesEditor/WebappFilesEditor.tsx
@@ -9,7 +9,7 @@ import {
   base64ToString,
   fileToBase64,
   stringToBase64,
-} from "webapps/helpers/base64";
+} from "core/helpers/base64";
 import Spinner from "core/components/Spinner";
 import { ArrowUpTrayIcon, FolderPlusIcon } from "@heroicons/react/24/outline";
 

--- a/frontend/src/webapps/features/WebappFilesEditor/WebappFilesEditor.tsx
+++ b/frontend/src/webapps/features/WebappFilesEditor/WebappFilesEditor.tsx
@@ -5,6 +5,11 @@ import { FilesEditor } from "workspaces/features/FilesEditor/FilesEditor";
 import { FilesEditor_FileFragment } from "workspaces/features/FilesEditor/FilesEditor.generated";
 import { useUpdateWebappMutation } from "webapps/graphql/mutations.generated";
 import { useWebappFilesLazyQuery } from "webapps/graphql/queries.generated";
+import {
+  base64ToString,
+  fileToBase64,
+  stringToBase64,
+} from "webapps/helpers/base64";
 import Spinner from "core/components/Spinner";
 import { ArrowUpTrayIcon, FolderPlusIcon } from "@heroicons/react/24/outline";
 
@@ -48,7 +53,12 @@ const WebappFilesEditor = ({
       variables: { workspaceSlug, webappSlug, ref: versionRef },
     }).then(({ data }) => {
       if (!cancelled) {
-        setFiles(data?.webapp?.files ?? []);
+        const decodedFiles = (data?.webapp?.files ?? []).map((file) => ({
+          ...file,
+          content:
+            file.content != null ? base64ToString(file.content) : file.content,
+        }));
+        setFiles(decodedFiles);
         setIsLoading(false);
       }
     });
@@ -65,7 +75,7 @@ const WebappFilesEditor = ({
         const uploadedFiles = await Promise.all(
           Array.from(fileList).map(async (file) => ({
             path: file.webkitRelativePath || file.name,
-            content: await file.text(),
+            content: await fileToBase64(file),
           })),
         );
         const { data } = await updateWebapp({
@@ -103,7 +113,7 @@ const WebappFilesEditor = ({
         const file = allFiles.find((f) => f.id === fileId);
         return {
           path: file?.path ?? fileId,
-          content,
+          content: stringToBase64(content),
         };
       },
     );

--- a/frontend/src/webapps/features/WebappForm/WebappForm.tsx
+++ b/frontend/src/webapps/features/WebappForm/WebappForm.tsx
@@ -36,6 +36,7 @@ import {
 import { useDataCardSection } from "core/components/DataCard/context";
 import { getWebappTypeLabel } from "webapps/helpers";
 import { DEFAULT_HTML_TEMPLATE } from "webapps/helpers/templates";
+import { stringToBase64 } from "webapps/helpers/base64";
 
 const ALL_SCOPES = Object.values(WebappOperationScope);
 
@@ -162,7 +163,7 @@ const DEFAULT_BLUESQUARE_SUPERSET_URL = "https://superset.bluesquare.org";
 
 const getDefaultSourceFiles = (type: WebappType): WebappFileInput[] =>
   type === WebappType.Static
-    ? [{ path: "index.html", content: DEFAULT_HTML_TEMPLATE }]
+    ? [{ path: "index.html", content: stringToBase64(DEFAULT_HTML_TEMPLATE) }]
     : [];
 
 const buildSource: Record<WebappType, (values: any) => any> = {

--- a/frontend/src/webapps/features/WebappForm/WebappForm.tsx
+++ b/frontend/src/webapps/features/WebappForm/WebappForm.tsx
@@ -36,7 +36,7 @@ import {
 import { useDataCardSection } from "core/components/DataCard/context";
 import { getWebappTypeLabel } from "webapps/helpers";
 import { DEFAULT_HTML_TEMPLATE } from "webapps/helpers/templates";
-import { stringToBase64 } from "webapps/helpers/base64";
+import { stringToBase64 } from "core/helpers/base64";
 
 const ALL_SCOPES = Object.values(WebappOperationScope);
 

--- a/frontend/src/webapps/features/WebappSourceEditor/WebappSourceEditor.tsx
+++ b/frontend/src/webapps/features/WebappSourceEditor/WebappSourceEditor.tsx
@@ -5,7 +5,7 @@ import Tabs from "core/components/Tabs";
 import CodeEditor from "core/components/CodeEditor";
 import Dropzone from "core/components/Dropzone";
 import { WebappFileInput } from "graphql/types";
-import { fileToBase64, stringToBase64 } from "webapps/helpers/base64";
+import { fileToBase64, stringToBase64 } from "core/helpers/base64";
 
 type WebappSourceEditorProps = {
   initialTemplate: string;

--- a/frontend/src/webapps/features/WebappSourceEditor/WebappSourceEditor.tsx
+++ b/frontend/src/webapps/features/WebappSourceEditor/WebappSourceEditor.tsx
@@ -5,6 +5,7 @@ import Tabs from "core/components/Tabs";
 import CodeEditor from "core/components/CodeEditor";
 import Dropzone from "core/components/Dropzone";
 import { WebappFileInput } from "graphql/types";
+import { fileToBase64, stringToBase64 } from "webapps/helpers/base64";
 
 type WebappSourceEditorProps = {
   initialTemplate: string;
@@ -21,7 +22,7 @@ const WebappSourceEditor = ({
   const handleTemplateChange = useCallback(
     (value: string) => {
       setTemplateContent(value);
-      onChange([{ path: "index.html", content: value }]);
+      onChange([{ path: "index.html", content: stringToBase64(value) }]);
     },
     [onChange],
   );
@@ -32,7 +33,7 @@ const WebappSourceEditor = ({
         await Promise.all(
           acceptedFiles.map(async (file) => ({
             path: (file.path || file.webkitRelativePath || file.name).replace(/^\//, ""),
-            content: await file.text(),
+            content: await fileToBase64(file),
           })),
         ),
       );

--- a/frontend/src/webapps/helpers/base64.ts
+++ b/frontend/src/webapps/helpers/base64.ts
@@ -1,0 +1,37 @@
+export const stringToBase64 = (value: string): string => {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+};
+
+export const base64ToString = (value: string): string => {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+};
+
+export const fileToBase64 = (file: Blob): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error ?? new Error("read failed"));
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== "string") {
+        reject(new Error("Unexpected FileReader result"));
+        return;
+      }
+      const comma = result.indexOf(",");
+      if (comma < 0) {
+        reject(new Error("Malformed data URL"));
+        return;
+      }
+      resolve(result.slice(comma + 1));
+    };
+    reader.readAsDataURL(file);
+  });

--- a/frontend/src/workspaces/helpers/templates.ts
+++ b/frontend/src/workspaces/helpers/templates.ts
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client";
 import { getApolloClient } from "core/helpers/apollo";
+import { base64ToBytes } from "core/helpers/base64";
 import "cronstrue/locales/en";
 import "cronstrue/locales/fr";
 import {
@@ -97,9 +98,7 @@ export async function downloadTemplateVersion(versionId: string) {
   }
   const { zipfile } = data.pipelineTemplateVersion.sourcePipelineVersion;
   const { template, versionNumber } = data.pipelineTemplateVersion;
-  const binaryString = atob(zipfile);
-  const bytes = Uint8Array.from(binaryString, (c) => c.charCodeAt(0));
-  const blob = new Blob([bytes], {
+  const blob = new Blob([base64ToBytes(zipfile)], {
     type: "application/zip",
   });
   const url = window.URL.createObjectURL(blob);


### PR DESCRIPTION
Webapp file content was sent over GraphQL as UTF-8 strings, which silently corrupted binary files (images, fonts, etc.). Switch the encoding to base64 end-to-end so binary assets round-trip cleanly between the editor and Forgejo.
 
## Changes

- Backend now returns webapp file content as base64 over GraphQL.
- Frontend encodes uploads/edits to base64 before sending, and decodes for display in the editor.
- Only compute `line_count` for recognized text files

## How to test

- Upload images into a webapp and verify they render correctly when the webapp runs.
- Edit and save a text file in the editor, check if that's still working.

**Note:** Images uploaded under the old code are corrupted in storage and cannot be recovered, users will need to re-upload.

## Screenshot

After re-upload:
<img width="4001" height="1921" alt="image" src="https://github.com/user-attachments/assets/97815a7f-bf11-45b6-865f-7bbe60e1c4b7" />

