### PR TITLE
fix: AI agent streaming URL fallback

### DIFF
--- a/frontend/src/assistant/features/ChatPane/index.tsx
+++ b/frontend/src/assistant/features/ChatPane/index.tsx
@@ -40,7 +40,7 @@ type Props = {
 
 function getStreamUrl(conversationId: string): string {
   const apiBasePath =
-    process.env.NEXT_PUBLIC_API_BASE_PATH ?? getPublicEnv().OPENHEXA_BACKEND_URL;
+    process.env.NEXT_PUBLIC_API_BASE_PATH || getPublicEnv().OPENHEXA_BACKEND_URL;
   return `${apiBasePath}/assistant/conversations/${conversationId}/stream/`;
 }
 

--- a/frontend/src/workspaces/features/CreatePipelineDialog/CreatePipelineUsingAI/useAIForm.ts
+++ b/frontend/src/workspaces/features/CreatePipelineDialog/CreatePipelineUsingAI/useAIForm.ts
@@ -31,7 +31,7 @@ export type AIFormInstance = {
 
 function getStreamUrl(conversationId: string): string {
   const apiBasePath =
-    process.env.NEXT_PUBLIC_API_BASE_PATH ?? getPublicEnv().OPENHEXA_BACKEND_URL;
+    process.env.NEXT_PUBLIC_API_BASE_PATH || getPublicEnv().OPENHEXA_BACKEND_URL;
   return `${apiBasePath}/assistant/conversations/${conversationId}/stream/`;
 }
 


### PR DESCRIPTION
It should fallback on empty string. Not using express proxy because of SSE