### PR TITLE
fix: Correctly set web apps domain in ALLOWED_HOSTS + CORS

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -82,11 +82,14 @@ ALLOWED_HOSTS = (
     else []
 )
 
-# Example: "webapps.openhexa.org"
+# Example: "webapps.openhexa.org" (or "webapps.localhost:8000" for local dev).
 # When not set, the webapps feature is disabled entirely.
 WEBAPPS_DOMAIN = os.environ.get("WEBAPPS_DOMAIN", None)
+# WEBAPPS_DOMAIN may include a port (e.g. for local dev), but the host-only form
+# is what's compared against Host headers and CORS origins.
+WEBAPPS_DOMAIN_HOST = WEBAPPS_DOMAIN.split(":")[0] if WEBAPPS_DOMAIN else None
 if WEBAPPS_DOMAIN:
-    ALLOWED_HOSTS += [f".{WEBAPPS_DOMAIN}"]
+    ALLOWED_HOSTS += [f".{WEBAPPS_DOMAIN_HOST}"]
 
 CORS_ALLOWED_ORIGINS = []
 CSRF_TRUSTED_ORIGINS = []
@@ -131,7 +134,9 @@ if "CORS_ALLOWED_ORIGINS" in os.environ:
 
 CORS_ALLOWED_ORIGIN_REGEXES = []
 if WEBAPPS_DOMAIN:
-    CORS_ALLOWED_ORIGIN_REGEXES.append(rf"^https?://[\w-]+\.{WEBAPPS_DOMAIN}(:\d+)?$")
+    CORS_ALLOWED_ORIGIN_REGEXES.append(
+        rf"^https?://[\w-]+\.{re.escape(WEBAPPS_DOMAIN_HOST)}(:\d+)?$"
+    )
 if "CORS_ALLOWED_ORIGIN_REGEXES" in os.environ:
     CORS_ALLOWED_ORIGIN_REGEXES += os.environ.get("CORS_ALLOWED_ORIGIN_REGEXES").split(
         ","


### PR DESCRIPTION
Noticed while testing the local hosting image:

If the domain contained a port, such as for local dev, the settings didn't really work. We just didn't notice because on our local docker container because the env is set with `ADDITIONAL_ALLOWED_HOSTS=*`, which gives a freepass.

This small fix strips the port if any and correctly sets `ALLOWED_HOSTS` and `CORS_ALLOWED_ORIGIN_REGEXES` (with a small regex escape just in case).

### How to test

Remove the `ADDITIONAL_ALLOWED_HOSTS=*` setting from `docker-compose.yaml`. Without the fix from this PR, you'll get this when loading a web app:

<img width="1657" height="706" alt="Screenshot 2026-05-13 at 13 31 28" src="https://github.com/user-attachments/assets/66bd48f9-f861-4c2a-a6e5-4ebcc5509ea8" />

