### PR TITLE
chore: Harden ourselves against supply chain attacks

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,2 @@
+# Only install package versions _older_ than 7 days to mitigate supply chain attacks
+min-release-age=7

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "minimumReleaseAge": "7 days",
   "automerge": false,
   "automergeStrategy": "squash",
   "patch": {


### PR DESCRIPTION
By setting the min release age to 1 week for both npm and renovate.

By not installing versions created in the last 7 days, we lower the possibility of getting hit by a supply chain attack.

This feels like a reasonable trade-off against slower security updates.

Sources:
- https://gajus.com/blog/3-pnpm-settings-to-protect-yourself-from-supply-chain-attacks
- https://docs.renovatebot.com/key-concepts/minimum-release-age/#minimum-release-age
