### PR TITLE
docs: fix incorrect Connection import path in toolbox docs

### DIFF
--- a/docs/en/toolbox.md
+++ b/docs/en/toolbox.md
@@ -35,7 +35,7 @@ Outside an OpenHEXA workspace, a connection can be manually created using the SD
 
 
 ``` python
->>> from openhexa.sdk.workspaces.connections import DHIS2Connection
+>>> from openhexa.sdk.workspaces.connection import DHIS2Connection
 >>> from openhexa.toolbox.dhis2 import DHIS2
 
 >>> # initialize a new connection outside an OpenHEXA workspace

--- a/docs/fr/toolbox.md
+++ b/docs/fr/toolbox.md
@@ -36,7 +36,7 @@ En dehors d'un espace de travail OpenHEXA, une connexion peut être créée manu
 
 
 ``` python
->>> from openhexa.sdk.workspaces.connections import DHIS2Connection
+>>> from openhexa.sdk.workspaces.connection import DHIS2Connection
 >>> from openhexa.toolbox.dhis2 import DHIS2
 
 >>> # initialiser une nouvelle connexion en dehors d'un espace de travail OpenHEXA


### PR DESCRIPTION
## Summary

The DHIS2 toolbox examples in both the English and French docs imported `DHIS2Connection` from a module path that does not exist:

```python
from openhexa.sdk.workspaces.connections import DHIS2Connection 
```
The actual SDK module is singular — `openhexa.sdk.workspaces.connection` — as defined in [openhexa-sdk-python/openhexa/sdk/workspaces/connection.py](https://github.com/BLSQ/openhexa-sdk-python/blob/main/openhexa/sdk/workspaces/connection.py). 