### PR TITLE
chore: Up the max_token limit

### DIFF
--- a/backend/hexa/assistant/agents/base.py
+++ b/backend/hexa/assistant/agents/base.py
@@ -74,7 +74,7 @@ def _parse_conversation_title(text: str) -> str:
 class BaseAgent:
     instruction_set = InstructionSet.GENERAL
     tools: list = []
-    max_tokens: int = 4096
+    max_tokens: int = 32768
 
     def __init__(
         self, conversation: Conversation, built_model: BuiltModel | None = None

--- a/backend/hexa/assistant/agents/create_pipeline_agent.py
+++ b/backend/hexa/assistant/agents/create_pipeline_agent.py
@@ -8,4 +8,4 @@ class CreatePipelineAgent(BaseAgent):
     # TODO: Add reading pipeline / pipeline templates tools
     instruction_set = InstructionSet.CREATE_PIPELINE
     tools = [get_help_or_doc, create_pipeline]
-    max_tokens = 8192
+    max_tokens = 32768


### PR DESCRIPTION
Making sure we don't break pipeline creation/edit by setting the `max_token` to a high default.

Note: I tried removing the limit, but disabling by setting to `None` or 0 does not work.
Removing the setting would cause a fallback to the default of 4096.
