### PR TITLE
fix:prevent scroll glitch in response streaming in chatpanel

### DIFF
--- a/frontend/src/assistant/features/ChatPane/index.tsx
+++ b/frontend/src/assistant/features/ChatPane/index.tsx
@@ -367,17 +367,8 @@ export default function ChatPane({
           {(isStreaming || streamingText !== null || frozenAssistantMessage !== null) && (
             <div className="flex justify-start">
               <div className="max-w-2xl rounded-2xl bg-gray-100 px-4 py-3 text-sm text-gray-900">
-<<<<<<< HEAD
-                {streamingText ? (
-                  <MarkdownContent sm>{streamingText}</MarkdownContent>
-=======
                 {(streamingText || frozenAssistantMessage) ? (
-                  <div className="prose prose-sm prose-gray max-w-none">
-                    <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                      {streamingText ?? frozenAssistantMessage!}
-                    </ReactMarkdown>
-                  </div>
->>>>>>> a3b7d1d5 (fix:remove the flicker by freezing bubbles in refetch)
+                  <MarkdownContent sm>{streamingText ?? frozenAssistantMessage!}</MarkdownContent>
                 ) : (
                   <Spinner size="xs" className="text-gray-400" />
                 )}

--- a/frontend/src/assistant/features/ChatPane/index.tsx
+++ b/frontend/src/assistant/features/ChatPane/index.tsx
@@ -61,6 +61,7 @@ export default function ChatPane({
   );
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const isPinnedToBottom = useRef(true);
   const apolloClient = useApolloClient();
 
   useEffect(() => {
@@ -158,13 +159,14 @@ export default function ChatPane({
 
   useEffect(() => {
     if (!loadingMessages) {
+      isPinnedToBottom.current = true;
       bottomRef.current?.scrollIntoView({ behavior: "smooth" });
     }
   }, [loadingMessages, localConversationId]);
 
   useEffect(() => {
-    if (!loadingMore) {
-      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    if (!loadingMore && isPinnedToBottom.current) {
+      bottomRef.current?.scrollIntoView({ behavior: "instant" });
     }
   }, [messages.length, pendingUserMessage, streamingText]);
 
@@ -213,6 +215,8 @@ export default function ChatPane({
   const handleScroll = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
+    isPinnedToBottom.current =
+      container.scrollHeight - container.scrollTop - container.clientHeight < 50;
     if (container.scrollTop === 0 && hasMore && !loadingMore) {
       loadOlderMessages();
     }

--- a/frontend/src/assistant/features/ChatPane/index.tsx
+++ b/frontend/src/assistant/features/ChatPane/index.tsx
@@ -107,6 +107,7 @@ export default function ChatPane({
   }, [data?.assistantConversation?.name]);
 
   const [pendingUserMessage, setPendingUserMessage] = useState<string | null>(null);
+  const [frozenAssistantMessage, setFrozenAssistantMessage] = useState<string | null>(null);
   const [sendError, setSendError] = useState<string | null>(null);
 
   const localConversationIdRef = useRef(localConversationId);
@@ -114,13 +115,22 @@ export default function ChatPane({
     localConversationIdRef.current = localConversationId;
   }, [localConversationId]);
 
+  // Kept up-to-date so handleDrained can read the last drained text without a stale closure.
+  const lastStreamingTextRef = useRef<string | null>(null);
+
   const handleDrained = useCallback(() => {
-    setPendingUserMessage(null);
+    setFrozenAssistantMessage(lastStreamingTextRef.current);
     setCurrentPage(1);
     if (localConversationIdRef.current) {
-      apolloClient.refetchQueries({
-        include: [AssistantConversationMessagesDocument],
-      });
+      apolloClient
+        .refetchQueries({ include: [AssistantConversationMessagesDocument] })
+        .then(() => {
+          setPendingUserMessage(null);
+          setFrozenAssistantMessage(null);
+        });
+    } else {
+      setPendingUserMessage(null);
+      setFrozenAssistantMessage(null);
     }
   }, [apolloClient]);
 
@@ -128,6 +138,10 @@ export default function ChatPane({
     interval: 30,
     onDrained: handleDrained,
   });
+
+  if (streamingText !== null) {
+    lastStreamingTextRef.current = streamingText;
+  }
 
   const onToolResultRef = useRef(onToolResult);
   onToolResultRef.current = onToolResult;
@@ -350,11 +364,20 @@ export default function ChatPane({
             </div>
           )}
 
-          {(isStreaming || streamingText !== null) && (
+          {(isStreaming || streamingText !== null || frozenAssistantMessage !== null) && (
             <div className="flex justify-start">
               <div className="max-w-2xl rounded-2xl bg-gray-100 px-4 py-3 text-sm text-gray-900">
+<<<<<<< HEAD
                 {streamingText ? (
                   <MarkdownContent sm>{streamingText}</MarkdownContent>
+=======
+                {(streamingText || frozenAssistantMessage) ? (
+                  <div className="prose prose-sm prose-gray max-w-none">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                      {streamingText ?? frozenAssistantMessage!}
+                    </ReactMarkdown>
+                  </div>
+>>>>>>> a3b7d1d5 (fix:remove the flicker by freezing bubbles in refetch)
                 ) : (
                   <Spinner size="xs" className="text-gray-400" />
                 )}

--- a/frontend/src/assistant/features/ChatPane/index.tsx
+++ b/frontend/src/assistant/features/ChatPane/index.tsx
@@ -66,6 +66,7 @@ export default function ChatPane({
   );
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const isPinnedToBottom = useRef(true);
   const apolloClient = useApolloClient();
 
   useEffect(() => {
@@ -173,13 +174,14 @@ export default function ChatPane({
 
   useEffect(() => {
     if (!loadingMessages) {
+      isPinnedToBottom.current = true;
       bottomRef.current?.scrollIntoView({ behavior: "smooth" });
     }
   }, [loadingMessages, localConversationId]);
 
   useEffect(() => {
-    if (!loadingMore) {
-      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    if (!loadingMore && isPinnedToBottom.current) {
+      bottomRef.current?.scrollIntoView({ behavior: "instant" });
     }
   }, [messages.length, pendingUserMessage, streamingText]);
 
@@ -228,6 +230,8 @@ export default function ChatPane({
   const handleScroll = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
+    isPinnedToBottom.current =
+      container.scrollHeight - container.scrollTop - container.clientHeight < 50;
     if (container.scrollTop === 0 && hasMore && !loadingMore) {
       loadOlderMessages();
     }


### PR DESCRIPTION
We were having issue of glitch where the agent was trying to smoothly scroll after each word. I  replaced  the smooth scrolling with instant during streaming to prevent animating glitches, added a isPinnedToBottom ref to stop auto scroll when a user  goes up.