### PR TITLE
fix: docker pipeline runner is restarting all running pipelines on restart (HEXA-1660)

### DIFF
--- a/backend/hexa/pipelines/management/commands/pipelines_runner.py
+++ b/backend/hexa/pipelines/management/commands/pipelines_runner.py
@@ -340,7 +340,7 @@ def _get_docker_client():
 def create_container_docker(run: PipelineRun, image: str, env_vars: dict):
     del env_vars[
         "HEXA_PIPELINE_NAME"
-    ]  # If there are spaces in the pipeline name, it would break the command
+    ]  # If there are spaces in the pipeline name, it will break the command
 
     cmd = (
         'pipeline cloudrun --config="'

--- a/backend/hexa/pipelines/management/commands/pipelines_runner.py
+++ b/backend/hexa/pipelines/management/commands/pipelines_runner.py
@@ -8,7 +8,9 @@ from enum import Enum
 from logging import getLogger
 from time import sleep
 
+import docker
 import requests
+import urllib3
 from django import db
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -325,25 +327,27 @@ def monitor_pod_kube(run: PipelineRun, pod):
     return success, stdout
 
 
-def run_pipeline_docker(run: PipelineRun, image: str, env_vars: dict):
-    import docker
-    import urllib3
-
-    del env_vars[
-        "HEXA_PIPELINE_NAME"
-    ]  # If there are spaces in the pipeline name, it will break the command
-
-    cmd = (
-        'pipeline cloudrun --config="'
-        + base64.b64encode(json.dumps(run.config).encode("utf-8")).decode("utf-8")
-        + '"'
-    )
+def _get_docker_client():
     try:
         docker_client = docker.DockerClient(base_url="unix://var/run/docker.sock")
         docker_client.ping()
     except:
         logger.exception("Docker client error", exc_info=True)
         raise
+    return docker_client
+
+
+def create_container_docker(run: PipelineRun, image: str, env_vars: dict):
+    del env_vars[
+        "HEXA_PIPELINE_NAME"
+    ]  # If there are spaces in the pipeline name, it would break the command
+
+    cmd = (
+        'pipeline cloudrun --config="'
+        + base64.b64encode(json.dumps(run.config).encode("utf-8")).decode("utf-8")
+        + '"'
+    )
+    docker_client = _get_docker_client()
 
     env_vars.update(
         {
@@ -363,9 +367,12 @@ def run_pipeline_docker(run: PipelineRun, image: str, env_vars: dict):
                 "mode": "rw",
             }
         }
+    container_name = generate_pipeline_container_name(run)
     container = docker_client.containers.run(
         image=image,
         command=cmd,
+        name=container_name,
+        labels={"hexa-run-id": str(run.id)},
         privileged=True,
         network="openhexa",
         platform="linux/amd64",
@@ -374,7 +381,29 @@ def run_pipeline_docker(run: PipelineRun, image: str, env_vars: dict):
         detach=True,
     )
     logger.debug("Container %s started", container.id)
+    return container
 
+
+def attach_to_container_docker(run: PipelineRun):
+    """Find an existing Docker container for a previously-running pipeline run.
+
+    Allows the runner to re-attach (rather than spawn a duplicate container)
+    when it restarts while pipelines are still in RUNNING state.
+    """
+    docker_client = _get_docker_client()
+    container_name = generate_pipeline_container_name(run)
+
+    try:
+        container = docker_client.containers.get(container_name)
+    except docker.errors.NotFound:
+        logger.info("No container found for run %s, exiting attachment process", run.id)
+        sys.exit(0)
+
+    logger.info("Re-attached to container %s for run %s", container.id, run.id)
+    return container
+
+
+def monitor_container_docker(run: PipelineRun, container):
     while True:
         run.refresh_from_db()
         run.last_heartbeat = timezone.now()
@@ -441,7 +470,12 @@ def run_pipeline(run: PipelineRun, create_container: bool = True):
 
     try:
         if spawner == "docker":
-            success, container_logs = run_pipeline_docker(run, image, env_vars)
+            container = (
+                create_container_docker(run, image, env_vars)
+                if create_container
+                else attach_to_container_docker(run)
+            )
+            success, container_logs = monitor_container_docker(run, container)
         elif spawner == "kubernetes":
             pod = (
                 create_pod_kube(run, image, env_vars)

--- a/backend/hexa/pipelines/tests/test_pipelines_runner.py
+++ b/backend/hexa/pipelines/tests/test_pipelines_runner.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from kubernetes.client import ApiException
 
 from hexa.pipelines.management.commands.pipelines_runner import (
+    attach_to_container_docker,
     attach_to_pod_kube,
     create_pod_kube,
     monitor_pod_kube,
@@ -31,9 +32,14 @@ class TestRunPipeline(TestCase):
         DEFAULT_WORKSPACE_IMAGE="default_workspace_image",
         PIPELINE_SCHEDULER_SPAWNER="docker",
     )
-    @patch("hexa.pipelines.management.commands.pipelines_runner.run_pipeline_docker")
+    @patch(
+        "hexa.pipelines.management.commands.pipelines_runner.monitor_container_docker"
+    )
+    @patch(
+        "hexa.pipelines.management.commands.pipelines_runner.create_container_docker"
+    )
     @patch("os.fork", return_value=0)
-    def test_env_vars(self, _, mock_run_pipeline_docker):
+    def test_env_vars(self, _, mock_create_container, mock_monitor_container):
         mock_run = MagicMock(spec=PipelineRun)
         mock_run.id = 123
         mock_run.access_token = "someAccessToken"
@@ -46,7 +52,7 @@ class TestRunPipeline(TestCase):
         mock_run.pipeline.code = "pipeline_code"
         mock_run.send_mail_notifications = False
 
-        mock_run_pipeline_docker.return_value = (True, "SomeLogs")
+        mock_monitor_container.return_value = (True, "SomeLogs")
 
         with self.assertRaises(SystemExit):
             run_pipeline(mock_run)
@@ -62,9 +68,63 @@ class TestRunPipeline(TestCase):
             "HEXA_LOG_LEVEL": str(PipelineRunLogLevel.DEBUG),
             "HEXA_NOTEBOOK_PATH": "/path/to/notebook",
         }
-        mock_run_pipeline_docker.assert_called_once_with(
+        mock_create_container.assert_called_once_with(
             mock_run, "docker_image", expected_env_vars
         )
+
+    @override_settings(
+        INTERNAL_BASE_URL="http://testserver",
+        DEFAULT_WORKSPACE_IMAGE="default_workspace_image",
+        PIPELINE_SCHEDULER_SPAWNER="docker",
+    )
+    @patch(
+        "hexa.pipelines.management.commands.pipelines_runner.monitor_container_docker"
+    )
+    @patch(
+        "hexa.pipelines.management.commands.pipelines_runner.attach_to_container_docker"
+    )
+    @patch(
+        "hexa.pipelines.management.commands.pipelines_runner.create_container_docker"
+    )
+    @patch("os.fork", return_value=0)
+    def test_docker_reattach_does_not_create_new_container(
+        self, _, mock_create_container, mock_attach_container, mock_monitor_container
+    ):
+        mock_run = MagicMock(spec=PipelineRun)
+        mock_run.id = 123
+        mock_run.access_token = "someAccessToken"
+        mock_run.log_level = PipelineRunLogLevel.DEBUG
+        mock_run.pipeline.workspace.slug = "test_workspace"
+        mock_run.pipeline.workspace.docker_image = "docker_image"
+        mock_run.pipeline.name = "test_pipeline"
+        mock_run.pipeline.type = PipelineType.ZIPFILE
+        mock_run.pipeline.code = "pipeline_code"
+        mock_run.send_mail_notifications = False
+
+        mock_monitor_container.return_value = (True, "SomeLogs")
+
+        with self.assertRaises(SystemExit):
+            run_pipeline(mock_run, create_container=False)
+
+        mock_attach_container.assert_called_once_with(mock_run)
+        mock_create_container.assert_not_called()
+
+    @patch("hexa.pipelines.management.commands.pipelines_runner.docker")
+    def test_attach_to_container_docker_exits_when_missing(self, mock_docker):
+        mock_client = Mock()
+        mock_docker.DockerClient.return_value = mock_client
+        mock_docker.errors.NotFound = Exception
+        mock_client.containers.get.side_effect = mock_docker.errors.NotFound("missing")
+
+        mock_run = MagicMock(spec=PipelineRun)
+        mock_run.id = 123
+        mock_run.pipeline.workspace.slug = "test_workspace"
+        mock_run.pipeline.code = "pipeline_code"
+
+        with self.assertRaises(SystemExit) as cm:
+            attach_to_container_docker(mock_run)
+
+        self.assertEqual(cm.exception.code, 0)
 
 
 class TestKubernetesPipelineIntegration(TestCase):


### PR DESCRIPTION
We previously reworked the pipeline runner to be stateless (it can be restarted without effect on running pipelines) but we left out the docker path.

Fix it for docker.

Tested locally : 
- Started a long-running pipeline; confirmed a single container named `pipeline-<workspace>-<code>-<runid>` with label `hexa-run-id=<uuid>`.
- `docker compose restart pipelines_runner`
- After restart, docker ps still showed the same single container.
- Runner logs confirmed the re-attach path:
```
  Found 1 orphaned RUNNING pipeline(s) to re-attach gradually
  Re-attaching to orphaned run: 5af14409-...
  Re-attached to container 1bd804599dc7... for run 5af14409-...
```