### PR TITLE
feat: expose read only data exploration tools to agent (HEXA-1653)

### DIFF
--- a/backend/hexa/assistant/agents/base.py
+++ b/backend/hexa/assistant/agents/base.py
@@ -236,11 +236,12 @@ class BaseAgent:
                         call.tool_call_id,
                     )
                     raw_args = call.args
-                    tool_input = (
-                        json.loads(raw_args)
-                        if isinstance(raw_args, str)
-                        else json.loads(json.dumps(raw_args, default=str))
-                    )
+                    if isinstance(raw_args, str):
+                        tool_input = json.loads(raw_args) if raw_args else {}
+                    elif raw_args is None:
+                        tool_input = {}
+                    else:
+                        tool_input = json.loads(json.dumps(raw_args, default=str))
                     tool_invocations[call.tool_call_id] = ToolInvocation(
                         tool_call_id=call.tool_call_id,
                         tool_name=call.tool_name,

--- a/backend/hexa/assistant/agents/create_pipeline_agent.py
+++ b/backend/hexa/assistant/agents/create_pipeline_agent.py
@@ -3,6 +3,9 @@ from django.contrib.contenttypes.models import ContentType
 
 from hexa.assistant.agents.base import BaseAgent
 from hexa.assistant.instructions import InstructionSet
+from hexa.mcp.tools.connections import list_connections
+from hexa.mcp.tools.datasets import get_dataset, list_datasets, preview_dataset_file
+from hexa.mcp.tools.files import list_files, read_file
 from hexa.mcp.tools.help import get_help_or_doc
 from hexa.mcp.tools.pipelines import create_pipeline
 from hexa.pipelines.models import Pipeline
@@ -10,7 +13,16 @@ from hexa.pipelines.models import Pipeline
 
 class CreatePipelineAgent(BaseAgent):
     instruction_set = InstructionSet.CREATE_PIPELINE
-    tools = [get_help_or_doc, create_pipeline]
+    tools = [
+        get_help_or_doc,
+        list_datasets,
+        get_dataset,
+        preview_dataset_file,
+        list_connections,
+        list_files,
+        read_file,
+        create_pipeline,
+    ]
     max_tokens = 32768
 
     async def _on_tool_result(self, invocation) -> None:

--- a/backend/hexa/assistant/agents/edit_pipeline_agent.py
+++ b/backend/hexa/assistant/agents/edit_pipeline_agent.py
@@ -5,6 +5,9 @@ from pydantic import BaseModel
 
 from hexa.assistant.agents.base import BaseAgent
 from hexa.assistant.instructions import InstructionSet
+from hexa.mcp.tools.connections import list_connections
+from hexa.mcp.tools.datasets import get_dataset, list_datasets, preview_dataset_file
+from hexa.mcp.tools.files import list_files, read_file
 from hexa.mcp.tools.help import get_help_or_doc
 from hexa.pipelines.models import Pipeline
 
@@ -53,7 +56,16 @@ def propose_pipeline_version(
 
 class EditPipelineAgent(BaseAgent):
     instruction_set = InstructionSet.EDIT_PIPELINE
-    tools = [get_help_or_doc, propose_pipeline_version]
+    tools = [
+        get_help_or_doc,
+        list_datasets,
+        get_dataset,
+        preview_dataset_file,
+        list_connections,
+        list_files,
+        read_file,
+        propose_pipeline_version,
+    ]
 
     @property
     def _context(self) -> dict:


### PR DESCRIPTION
Add tools to the agent and handle empty tool calls.

Not to sure how to fully evaluate this. But I think we might need to start add evaluation checks on those agents. 

<img width="1197" height="569" alt="Screenshot 2026-05-21 at 13 47 18" src="https://github.com/user-attachments/assets/f6cc71d4-b06a-461d-9157-9f36367051bc" />
