### PR TITLE
fix: Long Runs parameters not breaking layout (HEXA-1656)

### DIFF
--- a/frontend/src/core/components/DataCard/__tests__/__snapshots__/DataCard.test.tsx.snap
+++ b/frontend/src/core/components/DataCard/__tests__/__snapshots__/DataCard.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DataCard renders 1`] = `
 <div>
@@ -38,7 +38,7 @@ exports[`DataCard renders 1`] = `
                   class="flex text-sm font-medium text-gray-500 col-span-1 items-center"
                 >
                   <span
-                    class="inline"
+                    class="w-full break-all"
                   >
                     Name
                   </span>

--- a/frontend/src/core/components/DescriptionList/DescriptionList.tsx
+++ b/frontend/src/core/components/DescriptionList/DescriptionList.tsx
@@ -78,7 +78,7 @@ DescriptionList.Item = function Item({
           titleClassName,
         )}
       >
-        <span className="inline">{label}</span>
+        <span className="w-full break-all">{label}</span>
         {help && (
           <Tooltip
             placement="top"

--- a/frontend/src/core/components/DescriptionList/__snapshots__/DescriptionList.test.tsx.snap
+++ b/frontend/src/core/components/DescriptionList/__snapshots__/DescriptionList.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DescriptionList renders a list with one item 1`] = `
 <div>
@@ -12,7 +12,7 @@ exports[`DescriptionList renders a list with one item 1`] = `
         class="flex text-sm font-medium text-gray-500 col-span-1 items-center"
       >
         <span
-          class="inline"
+          class="w-full break-all"
         >
           label
         </span>
@@ -39,7 +39,7 @@ exports[`DescriptionList renders the list on multiple columns 1`] = `
         class="flex text-sm font-medium text-gray-500 col-span-1 items-center"
       >
         <span
-          class="inline"
+          class="w-full break-all"
         >
           label 1
         </span>
@@ -57,7 +57,7 @@ exports[`DescriptionList renders the list on multiple columns 1`] = `
         class="flex text-sm font-medium text-gray-500 col-span-1 items-center"
       >
         <span
-          class="inline"
+          class="w-full break-all"
         >
           label 2
         </span>
@@ -84,7 +84,7 @@ exports[`DescriptionList renders the list with the label above the value 1`] = `
         class="flex text-sm font-medium text-gray-500 col-span-5"
       >
         <span
-          class="inline"
+          class="w-full break-all"
         >
           label 1
         </span>
@@ -102,7 +102,7 @@ exports[`DescriptionList renders the list with the label above the value 1`] = `
         class="flex text-sm font-medium text-gray-500 col-span-5"
       >
         <span
-          class="inline"
+          class="w-full break-all"
         >
           label 2
         </span>

--- a/frontend/src/core/components/TruncatedText.tsx
+++ b/frontend/src/core/components/TruncatedText.tsx
@@ -45,6 +45,7 @@ const TruncatedText = ({ children, lines = 3, className, tooltip = false }: Prop
   return (
     <Tooltip
       label={isTruncated ? children : null}
+      delayShow={300}
       renderTrigger={(tooltipRef) => (
         <span
           ref={(el) => {

--- a/frontend/src/core/components/TruncatedText.tsx
+++ b/frontend/src/core/components/TruncatedText.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import Tooltip from "core/components/Tooltip";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "next-i18next";
 
 const LINE_CLAMP_CLASSES: Record<number, string> = {
   1: "line-clamp-1",
@@ -16,23 +17,56 @@ type Props = {
   lines?: number;
   className?: string;
   tooltip?: boolean;
+  expandable?: boolean;
 };
 
-const TruncatedText = ({ children, lines = 3, className, tooltip = false }: Props) => {
+const TruncatedText = ({
+  children,
+  lines = 3,
+  className,
+  tooltip = false,
+  expandable = false,
+}: Props) => {
+  const { t } = useTranslation();
   const ref = useRef<HTMLSpanElement | null>(null);
   const [isTruncated, setIsTruncated] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   const spanClass = clsx(
     "min-w-0 whitespace-normal break-words",
-    LINE_CLAMP_CLASSES[lines] ?? "line-clamp-3",
+    !isExpanded && (LINE_CLAMP_CLASSES[lines] ?? "line-clamp-3"),
     className,
   );
+
+  useEffect(() => {
+    if (expandable && ref.current) {
+      setIsTruncated(ref.current.scrollHeight > ref.current.clientHeight);
+    }
+  }, [children, expandable]);
 
   const checkTruncation = () => {
     if (ref.current) {
       setIsTruncated(ref.current.scrollHeight > ref.current.clientHeight);
     }
   };
+
+  if (expandable) {
+    return (
+      <div>
+        <span ref={ref} className={spanClass}>
+          {children}
+        </span>
+        {(isTruncated || isExpanded) && (
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="cursor-pointer text-xs text-blue-600 hover:text-blue-800 hover:underline"
+          >
+            {isExpanded ? t("Show less") : t("Show more")}
+          </button>
+        )}
+      </div>
+    );
+  }
 
   if (!tooltip) {
     return (

--- a/frontend/src/core/components/TruncatedText.tsx
+++ b/frontend/src/core/components/TruncatedText.tsx
@@ -1,0 +1,64 @@
+import clsx from "clsx";
+import Tooltip from "core/components/Tooltip";
+import { useRef, useState } from "react";
+
+const LINE_CLAMP_CLASSES: Record<number, string> = {
+  1: "line-clamp-1",
+  2: "line-clamp-2",
+  3: "line-clamp-3",
+  4: "line-clamp-4",
+  5: "line-clamp-5",
+  6: "line-clamp-6",
+};
+
+type Props = {
+  children: string;
+  lines?: number;
+  className?: string;
+  tooltip?: boolean;
+};
+
+const TruncatedText = ({ children, lines = 3, className, tooltip = false }: Props) => {
+  const ref = useRef<HTMLSpanElement | null>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  const spanClass = clsx(
+    "min-w-0 whitespace-normal break-words",
+    LINE_CLAMP_CLASSES[lines] ?? "line-clamp-3",
+    className,
+  );
+
+  const checkTruncation = () => {
+    if (ref.current) {
+      setIsTruncated(ref.current.scrollHeight > ref.current.clientHeight);
+    }
+  };
+
+  if (!tooltip) {
+    return (
+      <span ref={ref} className={spanClass}>
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <Tooltip
+      label={isTruncated ? children : null}
+      renderTrigger={(tooltipRef) => (
+        <span
+          ref={(el) => {
+            ref.current = el;
+            if (typeof tooltipRef === "function") tooltipRef(el);
+          }}
+          className={spanClass}
+          onMouseEnter={checkTruncation}
+        >
+          {children}
+        </span>
+      )}
+    />
+  );
+};
+
+export default TruncatedText;

--- a/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/[runId].tsx
+++ b/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/[runId].tsx
@@ -348,7 +348,7 @@ const WorkspacePipelineRunPage: NextPageWithLayout = (props: Props) => {
                   displayMode={DescriptionListDisplayMode.LABEL_ABOVE}
                 >
                   {config.map((entry) => (
-                    <DescriptionList.Item key={entry.name} label={entry.name} titleClassName="break-words">
+                    <DescriptionList.Item key={entry.name} label={entry.name}>
                       {renderParameterValue(entry)}
                     </DescriptionList.Item>
                   ))}

--- a/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/[runId].tsx
+++ b/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/[runId].tsx
@@ -1,6 +1,7 @@
 import { ArrowPathIcon } from "@heroicons/react/24/outline";
 import { StopIcon } from "@heroicons/react/24/solid";
 import Badge from "core/components/Badge";
+import TruncatedText from "core/components/TruncatedText";
 import Block from "core/components/Block";
 import Breadcrumbs from "core/components/Breadcrumbs";
 import Button from "core/components/Button";
@@ -110,7 +111,8 @@ const WorkspacePipelineRunPage: NextPageWithLayout = (props: Props) => {
 
   const renderParameterValue = (entry: PipelineParameter & { value: any }) => {
     if (entry.type === "str" && entry.value) {
-      return entry.multiple ? entry.value.join(", ") : entry.value;
+      const text = entry.multiple ? entry.value.join(", ") : entry.value;
+      return <TruncatedText lines={6} expandable>{text}</TruncatedText>;
     }
     if (entry.type === "bool") {
       return <Switch checked={entry.value} disabled />;
@@ -119,10 +121,11 @@ const WorkspacePipelineRunPage: NextPageWithLayout = (props: Props) => {
       (entry.type === "int" || entry.type === "float") &&
       !isNil(entry.value)
     ) {
-      return entry.multiple ? entry.value.join(", ") : entry.value;
+      const text = entry.multiple ? entry.value.join(", ") : String(entry.value);
+      return <TruncatedText lines={6} expandable>{text}</TruncatedText>;
     }
     if (isConnectionParameter(entry.type) && entry.value) {
-      return entry.value;
+      return <TruncatedText lines={6} expandable>{entry.value}</TruncatedText>;
     }
     if (entry.type === "dataset") {
       return (
@@ -136,7 +139,7 @@ const WorkspacePipelineRunPage: NextPageWithLayout = (props: Props) => {
       );
     }
     if (entry.type === "file" && entry.value) {
-      return entry.value;
+      return <TruncatedText lines={6} expandable>{entry.value}</TruncatedText>;
     }
     if (entry.type === "secret" && entry.value) {
       return "••••••";
@@ -345,7 +348,7 @@ const WorkspacePipelineRunPage: NextPageWithLayout = (props: Props) => {
                   displayMode={DescriptionListDisplayMode.LABEL_ABOVE}
                 >
                   {config.map((entry) => (
-                    <DescriptionList.Item key={entry.name} label={entry.name}>
+                    <DescriptionList.Item key={entry.name} label={entry.name} titleClassName="break-words">
                       {renderParameterValue(entry)}
                     </DescriptionList.Item>
                   ))}

--- a/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/index.tsx
+++ b/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/index.tsx
@@ -47,11 +47,13 @@ function RunParametersCell({
   const remainingCount = params.length - MAX_VISIBLE_PARAMS;
 
   return (
-    <div className="w-72 whitespace-normal space-y-0.5 text-xs text-gray-600">
+    <div className="max-w-md whitespace-normal space-y-0.5 text-xs text-gray-600">
       {visibleParams.map((p) => (
-        <div key={p.code} className="flex min-w-0 gap-1">
-          <span className="shrink-0 text-gray-400">{p.name}:</span>
-          <TruncatedText lines={3} tooltip>{formatParamValue(p)}</TruncatedText>
+        <div key={p.code} className="flex min-w-0 items-baseline gap-1">
+          <TruncatedText lines={1} tooltip className="shrink-0 max-w-[45%] text-gray-400">
+            {`${p.name}:`}
+          </TruncatedText>
+          <TruncatedText lines={3} tooltip className="flex-1">{formatParamValue(p)}</TruncatedText>
         </div>
       ))}
       {shouldShowToggle && !isExpanded && (

--- a/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/index.tsx
+++ b/frontend/src/pages/workspaces/[workspaceSlug]/pipelines/[pipelineCode]/runs/index.tsx
@@ -11,6 +11,7 @@ import { PipelineParameter, PipelineRunStatus, PipelineRunTrigger, PipelineType 
 import { useTranslation } from "next-i18next";
 import router from "next/router";
 import { useState } from "react";
+import TruncatedText from "core/components/TruncatedText";
 import { formatParamValue } from "pipelines/helpers/format";
 import PipelineRunStatusBadge from "pipelines/features/PipelineRunStatusBadge";
 import usePipelineRunPoller from "pipelines/hooks/usePipelineRunPoller";
@@ -46,11 +47,11 @@ function RunParametersCell({
   const remainingCount = params.length - MAX_VISIBLE_PARAMS;
 
   return (
-    <div className="w-52 space-y-0.5 text-xs text-gray-600">
+    <div className="w-72 whitespace-normal space-y-0.5 text-xs text-gray-600">
       {visibleParams.map((p) => (
         <div key={p.code} className="flex min-w-0 gap-1">
           <span className="shrink-0 text-gray-400">{p.name}:</span>
-          <span className="break-words">{formatParamValue(p)}</span>
+          <TruncatedText lines={3} tooltip>{formatParamValue(p)}</TruncatedText>
         </div>
       ))}
       {shouldShowToggle && !isExpanded && (


### PR DESCRIPTION
Pipeline Run parameters that are very long (such as the DHIS2 Connection) break the layout of the pipeline runs page. This PR solves that by truncating the parameters text and, if hidden, showing the information on a tooltip.

## Changes

- Added a component that truncates text
- Used the component to truncate run parameters

## How/what to test

Run a pipeline with really long parameters. DHIS2 connections is an example of parameters being really long.

## Screenshots / screencast

<img width="806" height="562" alt="image" src="https://github.com/user-attachments/assets/21aa67ea-a305-4473-bc97-d7e5b9a7f5a6" />



Old Run page:
<img width="1521" height="244" alt="image" src="https://github.com/user-attachments/assets/13dbb415-ba34-43a4-bc91-f02cf3b7620c" />



Fixed Run page:
<img width="1478" height="530" alt="image" src="https://github.com/user-attachments/assets/a41214cb-026d-4dca-91f3-0fe1986880c8" />

