### PR TITLE
refactor: add principal/workspace/organization accessors to UserInterface (HEXA-1619)

### DIFF
--- a/backend/hexa/core/tests/test_pipeline_user_filtering.py
+++ b/backend/hexa/core/tests/test_pipeline_user_filtering.py
@@ -4,8 +4,17 @@ from django.test import TestCase
 
 from hexa.pipelines.authentication import PipelineRunUser
 from hexa.pipelines.models import Pipeline, PipelineRun
-from hexa.user_management.models import User
-from hexa.workspaces.models import Workspace
+from hexa.user_management.models import (
+    Organization,
+    OrganizationMembership,
+    OrganizationMembershipRole,
+    User,
+)
+from hexa.workspaces.models import (
+    Workspace,
+    WorkspaceMembership,
+    WorkspaceMembershipRole,
+)
 
 
 class TestPipelineRunUserFiltering(TestCase):
@@ -143,3 +152,111 @@ class TestPipelineRunUserFiltering(TestCase):
             self.pipeline_user
         )
         self.assertEqual(filtered_templates.count(), 2)  # Expect all templates
+
+
+class TestPrincipalAccessors(TestCase):
+    def setUp(self):
+        self.superuser = User.objects.create_user(
+            "root@bluesquarehub.com", "standardpassword", is_superuser=True
+        )
+        self.member = User.objects.create_user(
+            "member@bluesquarehub.com", "standardpassword"
+        )
+        self.outsider = User.objects.create_user(
+            "outsider@bluesquarehub.com", "standardpassword"
+        )
+        self.workspace1 = Workspace.objects.create_if_has_perm(
+            self.superuser, name="WS1", description="Workspace 1"
+        )
+        self.workspace2 = Workspace.objects.create_if_has_perm(
+            self.superuser, name="WS2", description="Workspace 2"
+        )
+        WorkspaceMembership.objects.create(
+            user=self.member,
+            workspace=self.workspace1,
+            role=WorkspaceMembershipRole.EDITOR,
+        )
+        self.pipeline_run = MagicMock(PipelineRun)
+        self.pipeline_run.pipeline = MagicMock(Pipeline)
+        self.pipeline_run.pipeline.workspace = self.workspace1
+        self.pipeline_run.pipeline.workspace_id = self.workspace1.id
+        self.pipeline_user = PipelineRunUser(self.pipeline_run)
+
+    def test_user_accessible_workspaces_returns_memberships(self):
+        accessible = self.member.accessible_workspaces()
+        self.assertEqual(list(accessible), [self.workspace1])
+
+    def test_user_accessible_workspaces_empty_for_outsider(self):
+        self.assertEqual(self.outsider.accessible_workspaces().count(), 0)
+
+    def test_user_accessible_workspaces_returns_all_for_superuser(self):
+        self.assertEqual(
+            set(self.superuser.accessible_workspaces()),
+            {self.workspace1, self.workspace2},
+        )
+
+    def test_pipeline_user_accessible_workspaces_returns_pipeline_workspace(self):
+        accessible = self.pipeline_user.accessible_workspaces()
+        self.assertEqual(list(accessible), [self.workspace1])
+
+    def test_user_accessible_workspaces_includes_org_admin_workspaces(self):
+        # An organization admin/owner sees every workspace in the org,
+        # including ones they have no direct WorkspaceMembership for.
+        org_admin = User.objects.create_user(
+            "org-admin@bluesquarehub.com", "standardpassword"
+        )
+        org = Organization.objects.create(
+            name="Org", short_name="org", organization_type="CORPORATE"
+        )
+        OrganizationMembership.objects.create(
+            user=org_admin,
+            organization=org,
+            role=OrganizationMembershipRole.ADMIN,
+        )
+        self.workspace1.organization = org
+        self.workspace1.save()
+
+        accessible = org_admin.accessible_workspaces()
+        self.assertIn(self.workspace1, accessible)
+        self.assertNotIn(self.workspace2, accessible)
+
+    def test_user_accessible_workspaces_excludes_org_for_regular_members(self):
+        # A REGULAR (non-admin/owner) organization member should NOT see
+        # workspaces just because they share an org — only direct
+        # WorkspaceMembership grants access.
+        org_member = User.objects.create_user(
+            "org-member@bluesquarehub.com", "standardpassword"
+        )
+        org = Organization.objects.create(
+            name="Org", short_name="org", organization_type="CORPORATE"
+        )
+        OrganizationMembership.objects.create(
+            user=org_member,
+            organization=org,
+            role=OrganizationMembershipRole.MEMBER,
+        )
+        self.workspace1.organization = org
+        self.workspace1.save()
+
+        self.assertEqual(org_member.accessible_workspaces().count(), 0)
+
+    def test_user_accessible_organizations_includes_via_workspace(self):
+        org = Organization.objects.create(
+            name="Org", short_name="org", organization_type="CORPORATE"
+        )
+        self.workspace1.organization = org
+        self.workspace1.save()
+        self.assertEqual(list(self.member.accessible_organizations()), [org])
+
+    def test_pipeline_user_accessible_organizations(self):
+        org = Organization.objects.create(
+            name="Org", short_name="org", organization_type="CORPORATE"
+        )
+        self.workspace1.organization = org
+        self.workspace1.save()
+        self.assertEqual(list(self.pipeline_user.accessible_organizations()), [org])
+
+    def test_is_service_principal_flags(self):
+        self.assertFalse(self.member.is_service_principal)
+        self.assertFalse(self.superuser.is_service_principal)
+        self.assertTrue(self.pipeline_user.is_service_principal)

--- a/backend/hexa/pipelines/authentication.py
+++ b/backend/hexa/pipelines/authentication.py
@@ -1,5 +1,8 @@
+from django.db.models import QuerySet
+
 from hexa.pipelines.models import PipelineRun
-from hexa.user_management.models import UserInterface
+from hexa.user_management.models import Organization, UserInterface
+from hexa.workspaces.models import Workspace
 
 
 class PipelineRunUser(UserInterface):
@@ -9,6 +12,7 @@ class PipelineRunUser(UserInterface):
 
     is_active = True
     is_authenticated = True
+    is_service_principal = True
 
     def get_username(self):
         return f"pipeline_{self.pipeline_run.id}"
@@ -21,3 +25,11 @@ class PipelineRunUser(UserInterface):
 
     def has_feature_flag(self, *args, **kwargs):
         return False
+
+    def accessible_workspaces(self) -> QuerySet:
+        return Workspace.objects.filter(id=self.pipeline_run.pipeline.workspace_id)
+
+    def accessible_organizations(self) -> QuerySet:
+        return Organization.objects.filter(
+            workspaces=self.pipeline_run.pipeline.workspace
+        )

--- a/backend/hexa/user_management/models.py
+++ b/backend/hexa/user_management/models.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import UserManager as BaseUserManager
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import models
-from django.db.models import EmailField, Q
+from django.db.models import EmailField, Q, QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django_countries.fields import CountryField
@@ -75,6 +75,7 @@ class UserInterface:
     is_active = False
     is_superuser = False
     is_anonymous = True
+    is_service_principal = False
 
     def has_perm(self, perm, obj=None):
         raise NotImplementedError
@@ -85,6 +86,12 @@ class UserInterface:
     @property
     def is_authenticated(self):
         return False
+
+    def accessible_workspaces(self) -> QuerySet:
+        raise NotImplementedError
+
+    def accessible_organizations(self) -> QuerySet:
+        raise NotImplementedError
 
 
 class User(AbstractUser, UserInterface):
@@ -164,6 +171,37 @@ class User(AbstractUser, UserInterface):
                 role=OrganizationMembershipRole.OWNER,
             ).exists()
         )
+
+    def accessible_workspaces(self) -> QuerySet:
+        from hexa.workspaces.models import Workspace
+
+        if not self.is_authenticated:
+            return Workspace.objects.none()
+        if self.is_superuser:
+            return Workspace.objects.all()
+
+        organization_access = Q(
+            organization__organizationmembership__user=self,
+            organization__organizationmembership__role__in=[
+                OrganizationMembershipRole.OWNER,
+                OrganizationMembershipRole.ADMIN,
+            ],
+        )
+        workspace_access = Q(workspacemembership__user=self)
+        return Workspace.objects.filter(
+            organization_access | workspace_access
+        ).distinct()
+
+    def accessible_organizations(self) -> QuerySet:
+        if not self.is_authenticated:
+            return Organization.objects.none()
+        if self.is_superuser or self.has_perm(
+            "user_management.manage_all_organizations"
+        ):
+            return Organization.objects.all()
+        return Organization.objects.filter(
+            Q(organizationmembership__user=self) | Q(workspaces__members=self)
+        ).distinct()
 
     def __str__(self):
         if self.first_name or self.last_name:


### PR DESCRIPTION
Add `is_service_principal` flag and `accessible_workspaces()` / `accessible_organizations()` accessors to UserInterface, implemented on User and PipelineRunUser.