### PR TITLE
fix: route Mixpanel events directly to EU endpoint

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -120,8 +120,8 @@ OPENHEXA_BACKEND_URL=http://app:8000
 ## MixPanel
 ##########
 
-# mixpanel analytics
 MIXPANEL_TOKEN=
+MIXPANEL_API_HOST=api-eu.mixpanel.com
 
 
 ## Pipelines

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -582,6 +582,9 @@ WORKSPACE_BUCKET_VERSIONING_ENABLED = False
 
 # MIXPANEL
 MIXPANEL_TOKEN = os.environ.get("MIXPANEL_TOKEN")
+# EU data residency: route directly to the EU ingestion endpoint instead of
+# relying on the deprecated US->EU forwarding (sunset July 2026).
+MIXPANEL_API_HOST = os.environ.get("MIXPANEL_API_HOST", "api-eu.mixpanel.com")
 
 #############
 # Legacy OH #

--- a/backend/hexa/analytics/api.py
+++ b/backend/hexa/analytics/api.py
@@ -16,7 +16,8 @@ if settings.MIXPANEL_TOKEN:
             # It’s a good practice to set connect timeouts to slightly larger than a multiple of 3, which is the default TCP packet retransmission window.
             # https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
             # request_timeout is an int, so using 4 seconds
-            request_timeout=4
+            request_timeout=4,
+            api_host=settings.MIXPANEL_API_HOST,
         ),
     )
 

--- a/backend/hexa/analytics/tests/test_analytics.py
+++ b/backend/hexa/analytics/tests/test_analytics.py
@@ -176,6 +176,16 @@ class AsyncMixpanelTest(TestCase):
     This test suite ensures, through sanity checks, that the open-source and community-maintained AsyncBufferedConsumer implementation works as expected.
     """
 
+    def test_consumer_uses_configured_api_host(self):
+        """The consumer must be constructed with MIXPANEL_API_HOST so events
+        bypass the deprecated US->EU forwarding (sunset July 2026)."""
+        consumer = AsyncBufferedConsumer(
+            request_timeout=4, api_host="api-eu.mixpanel.com"
+        )
+        endpoints = consumer._consumer._endpoints
+        self.assertEqual(endpoints["events"], "https://api-eu.mixpanel.com/track")
+        self.assertEqual(endpoints["people"], "https://api-eu.mixpanel.com/engage")
+
     @mock.patch("mixpanel_async.AsyncBufferedConsumer._sync_flush")
     def test_async_mixpanel_queues_events(self, mock_sync_flush):
         consumer = AsyncBufferedConsumer(request_timeout=4, flush_first=False)

--- a/backend/hexa/analytics/tests/test_analytics.py
+++ b/backend/hexa/analytics/tests/test_analytics.py
@@ -178,7 +178,8 @@ class AsyncMixpanelTest(TestCase):
 
     def test_consumer_uses_configured_api_host(self):
         """The consumer must be constructed with MIXPANEL_API_HOST so events
-        bypass the deprecated US->EU forwarding (sunset July 2026)."""
+        bypass the deprecated US->EU forwarding (sunset July 2026).
+        """
         consumer = AsyncBufferedConsumer(
             request_timeout=4, api_host="api-eu.mixpanel.com"
         )
@@ -214,7 +215,7 @@ class AsyncMixpanelTest(TestCase):
         mixpanel = Mixpanel(token="dummy_token", consumer=consumer)
 
         for i in range(3):
-            mixpanel.track("event", "event_name", {"prop": f"value{i+1}"})
+            mixpanel.track("event", "event_name", {"prop": f"value{i + 1}"})
 
         # Simulate a bit more than the flush_after time passing
         mock_datetime.now.return_value = (


### PR DESCRIPTION
HEXA-1677 

The Mixpanel SDK defaults to sending events to `api.mixpanel.com` (US). Both of our Mixpanel projects (OpenHEXA prod `3331032` and demo `3353437`) are EU-resident and currently rely on Mixpanel's automatic US→EU forwarding.

That forwarding [is being deprecated in July 2026](https://docs.mixpanel.com/changelogs/2026-02-20-eu-forwarding-deprecation). After the cutover, every event sent to the US endpoint will be discarded instead of reaching our EU project. 🇪🇺😱

This PR aims to route events directly to the EU ingestion endpoint (`api-eu.mixpanel.com`) by making the host configurable, defaulted to EU.

## Changes

- Add `MIXPANEL_API_HOST` setting in `config/settings/base.py`, defaulting to `api-eu.mixpanel.com`.
- Pass `api_host=settings.MIXPANEL_API_HOST` to `AsyncBufferedConsumer` in `hexa/analytics/api.py`.
- Document the new env var in `.env.dist`.
- Add a unit test asserting the consumer is constructed with the configured host. 

## How to test

Verified locally against a new `OpenHEXA (Dev)` Mixpanel project (`4028329`):

1. Set `MIXPANEL_API_HOST=api-eu.mixpanel.com` and a dev `MIXPANEL_TOKEN` in `.env`.
2. Restart the app
3. Trigger any tracked action (e.g. open a dataset → `datasets.dataset_open` fires).
4. In Mixpanel, inspect the event's `$mp_api_endpoint` property. It should now read `api-eu.mixpanel.com` (was `api.mixpanel.com`).
5. Confirm event properties all arrive intact.
