### PR TITLE
fix: sentry issue no sample found for file xxx (HEXA-1672)

### DIFF
--- a/backend/hexa/datasets/models.py
+++ b/backend/hexa/datasets/models.py
@@ -450,14 +450,25 @@ class DatasetVersionFile(MetadataMixin, Base):
         return blob.size
 
     def generate_metadata(self):
-        from hexa.datasets.queue import dataset_file_metadata_queue
+        from hexa.datasets.queue import dataset_file_metadata_queue, is_file_supported
 
-        dataset_file_metadata_queue.enqueue(
-            "generate_file_metadata",
-            {
-                "file_id": str(self.id),
-            },
-        )
+        with transaction.atomic():
+            if is_file_supported(self.filename):
+                DatasetFileSample.objects.update_or_create(
+                    dataset_version_file=self,
+                    defaults={
+                        "sample": [],
+                        "status": DatasetFileSample.STATUS_PROCESSING,
+                        "status_reason": None,
+                    },
+                )
+
+            dataset_file_metadata_queue.enqueue(
+                "generate_file_metadata",
+                {
+                    "file_id": str(self.id),
+                },
+            )
 
     class Meta:
         ordering = ["uri"]

--- a/backend/hexa/datasets/queue.py
+++ b/backend/hexa/datasets/queue.py
@@ -249,6 +249,10 @@ def generate_file_metadata_task(file_id: str) -> None:
         logger.exception(
             f"Failed to load dataframe for file {version_file.id}", exc_info=e
         )
+        DatasetFileSample.objects.filter(dataset_version_file=version_file).update(
+            status=DatasetFileSample.STATUS_FAILED,
+            status_reason=str(e),
+        )
         return
     logger.info("Finished sample generation, calculating profiling")
     add_system_attributes(version_file, df)

--- a/backend/hexa/datasets/schema/types.py
+++ b/backend/hexa/datasets/schema/types.py
@@ -13,6 +13,7 @@ from hexa.datasets.models import (
     DatasetVersion,
     DatasetVersionFile,
 )
+from hexa.datasets.queue import is_file_supported
 from hexa.files import storage
 from hexa.workspaces.models import Workspace
 from hexa.workspaces.schema.types import workspace_object, workspace_permissions
@@ -237,7 +238,10 @@ def resolve_version_file_metadata(obj: DatasetVersionFile, info, **kwargs):
     try:
         return obj.sample_entry
     except DatasetFileSample.DoesNotExist:
-        logging.error(f"No sample found for file {obj.filename} with id {obj.id}")
+        if is_file_supported(obj.filename):
+            logging.warning(
+                f"No sample found for supported file {obj.filename} with id {obj.id}"
+            )
         return None
 
 

--- a/backend/hexa/datasets/tests/test_generate_sample.py
+++ b/backend/hexa/datasets/tests/test_generate_sample.py
@@ -269,6 +269,62 @@ class TestCreateDatasetFileSampleTask(TestCase, DatasetTestMixin):
             with self.assertRaises(EmptyDataError):
                 load_df(version_file)
 
+    def test_generate_metadata_pre_creates_processing_row_for_supported_file(self):
+        version_file = DatasetVersionFile.objects.create_if_has_perm(
+            self.USER_SERENA,
+            self.DATASET_VERSION,
+            uri="example.csv",
+            content_type="text/csv",
+        )
+
+        with patch(
+            "hexa.datasets.queue.dataset_file_metadata_queue.enqueue"
+        ) as mock_enqueue:
+            version_file.generate_metadata()
+
+        mock_enqueue.assert_called_once()
+        sample = DatasetFileSample.objects.get(dataset_version_file=version_file)
+        self.assertEqual(sample.status, DatasetFileSample.STATUS_PROCESSING)
+        self.assertEqual(sample.sample, [])
+        self.assertIsNone(sample.status_reason)
+
+    def test_generate_metadata_skips_row_for_unsupported_file(self):
+        version_file = DatasetVersionFile.objects.create_if_has_perm(
+            self.USER_SERENA,
+            self.DATASET_VERSION,
+            uri="report.txt",
+            content_type="text/plain",
+        )
+
+        with patch(
+            "hexa.datasets.queue.dataset_file_metadata_queue.enqueue"
+        ) as mock_enqueue:
+            version_file.generate_metadata()
+
+        mock_enqueue.assert_called_once()
+        self.assertFalse(
+            DatasetFileSample.objects.filter(dataset_version_file=version_file).exists()
+        )
+
+    def test_generate_metadata_is_atomic_when_enqueue_fails(self):
+        version_file = DatasetVersionFile.objects.create_if_has_perm(
+            self.USER_SERENA,
+            self.DATASET_VERSION,
+            uri="example.csv",
+            content_type="text/csv",
+        )
+
+        with patch(
+            "hexa.datasets.queue.dataset_file_metadata_queue.enqueue",
+            side_effect=RuntimeError("queue down"),
+        ):
+            with self.assertRaises(RuntimeError):
+                version_file.generate_metadata()
+
+        self.assertFalse(
+            DatasetFileSample.objects.filter(dataset_version_file=version_file).exists()
+        )
+
     def test_generate_profile(self):
         df = pd.DataFrame(
             {

--- a/backend/hexa/datasets/tests/test_schema.py
+++ b/backend/hexa/datasets/tests/test_schema.py
@@ -749,6 +749,81 @@ class DatasetVersionTest(GraphQLTestCase, DatasetTestMixin):
             r["data"],
         )
 
+    def test_get_file_sample_no_row_unsupported_file(self):
+        self.test_create_dataset_version()
+        superuser = User.objects.get(email="superuser@blsq.com")
+        dataset = Dataset.objects.get(name="Dataset")
+        self.client.force_login(superuser)
+        file = DatasetVersionFile.objects.create(
+            dataset_version=dataset.latest_version,
+            uri=dataset.latest_version.get_full_uri("report.txt"),
+            created_by=superuser,
+        )
+        with self.assertNoLogs("root", level="WARNING"):
+            r = self.run_query(
+                """
+                        query GetDatasetVersionFile($id: ID!) {
+                          datasetVersionFile(id: $id) {
+                            filename
+                            fileSample {
+                              status
+                            }
+                          }
+                        }
+            """,
+                {"id": str(file.id)},
+            )
+        self.assertEqual(
+            {
+                "datasetVersionFile": {
+                    "filename": file.filename,
+                    "fileSample": None,
+                }
+            },
+            r["data"],
+        )
+
+    def test_get_file_sample_no_row_supported_file_warns(self):
+        self.test_create_dataset_version()
+        superuser = User.objects.get(email="superuser@blsq.com")
+        dataset = Dataset.objects.get(name="Dataset")
+        self.client.force_login(superuser)
+        file = DatasetVersionFile.objects.create(
+            dataset_version=dataset.latest_version,
+            uri=dataset.latest_version.get_full_uri("file.csv"),
+            created_by=superuser,
+        )
+        with self.assertLogs(level="WARNING") as captured:
+            r = self.run_query(
+                """
+                        query GetDatasetVersionFile($id: ID!) {
+                          datasetVersionFile(id: $id) {
+                            filename
+                            fileSample {
+                              status
+                            }
+                          }
+                        }
+            """,
+                {"id": str(file.id)},
+            )
+        self.assertEqual(
+            {
+                "datasetVersionFile": {
+                    "filename": file.filename,
+                    "fileSample": None,
+                }
+            },
+            r["data"],
+        )
+        self.assertTrue(
+            any(
+                "No sample found for supported file file.csv" in message
+                for message in captured.output
+            ),
+            captured.output,
+        )
+
     def test_get_file_metadata_fail(self):
         self.test_create_dataset_version()
         superuser = User.objects.get(email="superuser@blsq.com")


### PR DESCRIPTION
The issue (https://bluesquareorg.sentry.io/issues/7398239096/?referrer=jira_integration) seems to come from two distinct cases : 

- Some files format are not supported
- When the sample is still queued for processing 


This PR is about removing warning for unsupported files (if we need to support a new format this might come as a feature request) and ensure we create a `PROCESSING` record in the database before actual execution to be handled correctly by the frontend