### PR TITLE
fix: Clarify the cron schedule to avoid user confusing

### DIFF
--- a/frontend/public/locales/en/messages.json
+++ b/frontend/public/locales/en/messages.json
@@ -490,6 +490,7 @@
   "New Template '{{name}}' created successfully.": "New Template '{{name}}' created successfully.",
   "New Template Version for '{{templateName}}' created successfully.": "New Template Version for '{{templateName}}' created successfully.",
   "Next": "Next",
+  "Next run: {{date}} ({{timeZone}})": "Next run: {{date}} ({{timeZone}})",
   "No": "No",
   "No attributes found": "No attributes found",
   "No commits yet. Edit files and save to get started.": "No commits yet. Edit files and save to get started.",

--- a/frontend/public/locales/fr/messages.json
+++ b/frontend/public/locales/fr/messages.json
@@ -499,6 +499,7 @@
   "New Template '{{name}}' created successfully.": "Nouveau modèle '{{name}}' créé avec succès.",
   "New Template Version for '{{templateName}}' created successfully.": "Nouvelle version de modèle pour '{{templateName}}' créée avec succès.",
   "Next": "Suivant",
+  "Next run: {{date}} ({{timeZone}})": "Prochaine exécution : {{date}} ({{timeZone}})",
   "No": "Non",
   "No attributes found": "Aucun attribut trouvé",
   "No commits yet. Edit files and save to get started.": "Aucun commit pour le moment. Modifiez les fichiers et enregistrez pour commencer.",

--- a/frontend/src/workspaces/features/CronProperty/CronProperty.tsx
+++ b/frontend/src/workspaces/features/CronProperty/CronProperty.tsx
@@ -7,6 +7,7 @@ import Link from "core/components/Link";
 import { ExclamationCircleIcon } from "@heroicons/react/24/outline";
 import {
   getCronExpressionDescription,
+  getCronExpressionNextRun,
   validateCronExpression,
 } from "workspaces/helpers/pipelines";
 
@@ -31,6 +32,8 @@ const CronProperty = (props: CronPropertyProps) => {
   });
 
   if (section.isEdited && !property.readonly) {
+    const description = getCronExpressionDescription(property.formValue);
+    const nextRun = getCronExpressionNextRun(property.formValue);
     return (
       <DataCard.Property property={property}>
         <div className="flex items-center gap-2">
@@ -44,9 +47,20 @@ const CronProperty = (props: CronPropertyProps) => {
             fullWidth={false}
           />
           <span className="grow-0 text-gray-500 italic">
-            ({getCronExpressionDescription(property.formValue) ?? t("Invalid")})
+            {description ? `${description} (UTC)` : t("Invalid")}
           </span>
         </div>
+        {nextRun && (
+          <div
+            className="text-xs text-gray-500 mt-1"
+            suppressHydrationWarning={true}
+          >
+            {t("Next run: {{date}} ({{timeZone}})", {
+              date: nextRun.formatted,
+              timeZone: nextRun.timeZone,
+            })}
+          </div>
+        )}
         <Trans>
           <div className="text-xs text-gray-500 mt-1">
             Use{" "}
@@ -73,13 +87,30 @@ const CronProperty = (props: CronPropertyProps) => {
       </DataCard.Property>
     );
   } else {
+    const description = property.displayValue
+      ? getCronExpressionDescription(property.displayValue)
+      : null;
+    const nextRun = property.displayValue
+      ? getCronExpressionNextRun(property.displayValue)
+      : null;
     return (
       <DataCard.Property property={property}>
         <div className={className}>
           {property.displayValue
-            ? getCronExpressionDescription(property.displayValue)
+            ? description && `${description} (UTC)`
             : property.defaultValue}
         </div>
+        {nextRun && (
+          <div
+            className="text-xs text-gray-500 mt-1"
+            suppressHydrationWarning={true}
+          >
+            {t("Next run: {{date}} ({{timeZone}})", {
+              date: nextRun.formatted,
+              timeZone: nextRun.timeZone,
+            })}
+          </div>
+        )}
       </DataCard.Property>
     );
   }

--- a/frontend/src/workspaces/helpers/pipelines.ts
+++ b/frontend/src/workspaces/helpers/pipelines.ts
@@ -2,6 +2,7 @@ import { gql } from "@apollo/client";
 import { getApolloClient } from "core/helpers/apollo";
 import cronstrue from "cronstrue";
 import CronParser from "cron-parser";
+import { DateTime } from "luxon";
 import "cronstrue/locales/en";
 import "cronstrue/locales/fr";
 import {
@@ -104,7 +105,7 @@ export async function updatePipeline(
 
 export function validateCronExpression(cronExpression: string) {
   try {
-    validateFiveFieldCron(cronExpression)
+    validateFiveFieldCron(cronExpression);
     CronParser.parse(cronExpression);
     return true;
   } catch (err) {
@@ -116,7 +117,7 @@ function validateFiveFieldCron(cronExpression: string): void {
   const fields = cronExpression.trim().split(/\s+/);
   if (fields.length !== 5) {
     throw new Error(
-      `Invalid cron expression: expected 5 fields, got ${fields.length}`
+      `Invalid cron expression: expected 5 fields, got ${fields.length}`,
     );
   }
 }
@@ -171,6 +172,30 @@ export function getCronExpressionDescription(
   }
   try {
     return cronstrue.toString(cronExpression, { locale });
+  } catch (err) {
+    return null;
+  }
+}
+
+// Schedules are interpreted in UTC by the backend scheduler. This computes the
+// next occurrence as an absolute instant and renders it in the viewer's local
+// zone/locale via Luxon (Settings.defaultZone/defaultLocale are set globally in
+// _app.tsx), so it stays correct across DST and day-shifts.
+export function getCronExpressionNextRun(
+  cronExpression: string,
+): { formatted: string; timeZone: string } | null {
+  if (!validateCronExpression(cronExpression)) {
+    return null;
+  }
+  try {
+    const next = CronParser.parse(cronExpression, { tz: "UTC" })
+      .next()
+      .toDate();
+    const dt = DateTime.fromJSDate(next);
+    return {
+      formatted: dt.toLocaleString(DateTime.DATETIME_MED_WITH_WEEKDAY),
+      timeZone: dt.zoneName ?? "",
+    };
   } catch (err) {
     return null;
   }
@@ -319,8 +344,11 @@ export async function deletePipelineVersion(versionId: string) {
  * @param hasSourceTemplate - Whether the pipeline was created from a template
  * @returns User-friendly display name for the pipeline's technical format
  */
-export function formatPipelineSource(pipelineType: PipelineType, hasSourceTemplate?: boolean): string {
-  if (hasSourceTemplate){
+export function formatPipelineSource(
+  pipelineType: PipelineType,
+  hasSourceTemplate?: boolean,
+): string {
+  if (hasSourceTemplate) {
     return i18n!.t("Template");
   }
 
@@ -344,7 +372,9 @@ export function formatPipelineSource(pipelineType: PipelineType, hasSourceTempla
  * formatPipelineFunctionalType(PipelineFunctionalType.Extraction) // "Extraction"
  * formatPipelineFunctionalType(PipelineFunctionalType.Transformation) // "Transformation"
  */
-export function formatPipelineFunctionalType(functionalType: PipelineFunctionalType): string {
+export function formatPipelineFunctionalType(
+  functionalType: PipelineFunctionalType,
+): string {
   switch (functionalType) {
     case PipelineFunctionalType.Extraction:
       return i18n!.t("Extraction");
@@ -363,16 +393,22 @@ export function formatPipelineFunctionalType(functionalType: PipelineFunctionalT
  * @param functionalType - The functional type to describe
  * @returns Detailed description of the functional type's purpose
  */
-export function getFunctionalTypeDescription(functionalType: PipelineFunctionalType): string {
+export function getFunctionalTypeDescription(
+  functionalType: PipelineFunctionalType,
+): string {
   switch (functionalType) {
     case PipelineFunctionalType.Extraction:
-      return i18n!.t("Ingests data from external sources like APIs, databases, or files");
+      return i18n!.t(
+        "Ingests data from external sources like APIs, databases, or files",
+      );
     case PipelineFunctionalType.Transformation:
       return i18n!.t("Processes, cleans, validates, or enriches data");
     case PipelineFunctionalType.Loading:
       return i18n!.t("Outputs data to warehouses, databases, or files");
     case PipelineFunctionalType.Computation:
-      return i18n!.t("Performs analytics, machine learning, or statistical analysis");
+      return i18n!.t(
+        "Performs analytics, machine learning, or statistical analysis",
+      );
   }
 }
 


### PR DESCRIPTION
Based on some direct support requests from the DS team:

- Cron schedules are entered in UTC
- Then runs are displayed in local time

This confuses users. To help against that, add a little description to the schedule that clarifies that the time is in UTC + show the "next run" in localized time.

## Screenshots / screencast

### Display (FR/EN)

<img width="1024" height="271" alt="Screenshot 2026-05-29 at 09 21 18" src="https://github.com/user-attachments/assets/9907e767-491a-41ff-b63c-b46c23dd8900" />
<img width="673" height="283" alt="Screenshot 2026-05-29 at 09 23 42" src="https://github.com/user-attachments/assets/974221d1-c6e8-4a5f-9271-95d49891f5ca" />

### Edit (FR/EN)

<img width="1302" height="402" alt="Screenshot 2026-05-29 at 09 21 57" src="https://github.com/user-attachments/assets/fcc89efb-5208-496d-b6b9-d2446d6b3946" />
<img width="1286" height="395" alt="Screenshot 2026-05-29 at 09 23 25" src="https://github.com/user-attachments/assets/ec28b835-5bd8-4bd4-aa8b-48e27073ad68" />
