### PR TITLE
fix: silence webapp GraphQL errors to warning in Sentry

### DIFF
--- a/backend/config/sentry.py
+++ b/backend/config/sentry.py
@@ -36,9 +36,9 @@ def setup_sentry(dsn):
         if _is_chained_exception(hint, AuthenticationError):
             return None
         # Webapp GraphQL errors are caused by external clients using outdated or incorrect API queries.
-        # We keep them for investigation but downgrade to warning so error-level alerts don't fire.
+        # They are expected and do not warrant a Sentry report.
         if event.get("tags", {}).get("webapp_graphql"):
-            event["level"] = "warning"
+            return None
         return event
 
     # Exclude /ready from sentry

--- a/backend/config/sentry.py
+++ b/backend/config/sentry.py
@@ -35,6 +35,10 @@ def setup_sentry(dsn):
         # Authentication errors are also expected user errors, and can be caused by various issues (expired token, misconfiguration, etc.)
         if _is_chained_exception(hint, AuthenticationError):
             return None
+        # Webapp GraphQL errors are caused by external clients using outdated or incorrect API queries.
+        # We keep them for investigation but downgrade to warning so error-level alerts don't fire.
+        if event.get("tags", {}).get("webapp_graphql"):
+            event["level"] = "warning"
         return event
 
     # Exclude /ready from sentry

--- a/backend/config/test_sentry.py
+++ b/backend/config/test_sentry.py
@@ -39,6 +39,13 @@ class SentryBeforeSendTest(TestCase):
         event = {"tags": {"connection_test": True}}
         self.assertIsNone(self.before_send(event, self._make_hint(exc)))
 
+    def test_downgrades_webapp_graphql_errors_to_warning(self):
+        exc = Exception("Unknown type 'PipelineRunOutputFile'")
+        event = {"tags": {"webapp_graphql": True}, "level": "error"}
+        result = self.before_send(event, self._make_hint(exc))
+        self.assertIsNotNone(result)
+        self.assertEqual(result["level"], "warning")
+
     def test_circular_exception_chain_does_not_loop(self):
         exc_a = ValueError("a")
         exc_b = ValueError("b")

--- a/backend/config/test_sentry.py
+++ b/backend/config/test_sentry.py
@@ -39,12 +39,10 @@ class SentryBeforeSendTest(TestCase):
         event = {"tags": {"connection_test": True}}
         self.assertIsNone(self.before_send(event, self._make_hint(exc)))
 
-    def test_downgrades_webapp_graphql_errors_to_warning(self):
+    def test_filters_webapp_graphql_errors(self):
         exc = Exception("Unknown type 'PipelineRunOutputFile'")
         event = {"tags": {"webapp_graphql": True}, "level": "error"}
-        result = self.before_send(event, self._make_hint(exc))
-        self.assertIsNotNone(result)
-        self.assertEqual(result["level"], "warning")
+        self.assertIsNone(self.before_send(event, self._make_hint(exc)))
 
     def test_circular_exception_chain_does_not_loop(self):
         exc_a = ValueError("a")

--- a/backend/hexa/webapps/graphql_proxy.py
+++ b/backend/hexa/webapps/graphql_proxy.py
@@ -1,5 +1,6 @@
 import json
 
+import sentry_sdk
 from ariadne_django.views import GraphQLView
 from django.conf import settings
 from django.http import HttpRequest, JsonResponse
@@ -150,4 +151,6 @@ def handle_graphql_proxy(request: HttpRequest, webapp: Webapp):
         )
 
     track(request, "webapp_graphql_query", {**event_properties, "status": "allowed"})
-    return _graphql_view(request)
+    with sentry_sdk.new_scope() as scope:
+        scope.set_tag("webapp_graphql", True)
+        return _graphql_view(request)


### PR DESCRIPTION
The aim is to tag Graphql errors that comes from web apps and then ignore them before send.