### PR TITLE
fix: MCP create pipeline version only takes a single file (HEXA-1648)

### DIFF
--- a/backend/hexa/mcp/graphql/pipelines.graphql
+++ b/backend/hexa/mcp/graphql/pipelines.graphql
@@ -161,6 +161,7 @@ mutation CreatePipeline($input: CreatePipelineInput!) {
   createPipeline(input: $input) {
     success
     errors
+    details
     pipeline {
       id
       code
@@ -177,6 +178,7 @@ mutation UploadPipeline($input: UploadPipelineInput!) {
   uploadPipeline(input: $input) {
     success
     errors
+    details
     pipelineVersion {
       id
       versionNumber

--- a/backend/hexa/mcp/tests/test_pipelines.py
+++ b/backend/hexa/mcp/tests/test_pipelines.py
@@ -1,3 +1,7 @@
+import io
+import json
+from zipfile import ZipFile
+
 from hexa.mcp.tools.pipelines import (
     create_pipeline_version,
     get_pipeline,
@@ -208,15 +212,21 @@ class UpdatePipelineTest(MCPTestCase):
         self.assertIn("NOT_FOUND", result["errors"])
 
 
+def _zip_contents(zipfile_bytes: bytes) -> dict[str, bytes]:
+    with ZipFile(io.BytesIO(zipfile_bytes)) as zf:
+        return {name: zf.read(name) for name in zf.namelist()}
+
+
 class CreatePipelineVersionTest(MCPTestCase):
-    SOURCE_CODE = 'from openhexa.sdk import pipeline\n\n@pipeline("test")\ndef test_pipeline():\n    pass'
+    PIPELINE_PY = 'from openhexa.sdk import pipeline\n\n@pipeline("test")\ndef test_pipeline():\n    pass'
+    FILES_JSON = json.dumps([{"path": "pipeline.py", "content": PIPELINE_PY}])
 
     def test_create_pipeline_version(self):
         result = create_pipeline_version(
             user=self.USER_ADMIN,
             workspace_slug=self.WORKSPACE.slug,
             pipeline_code="test-pipeline",
-            source_code=self.SOURCE_CODE,
+            files_json=self.FILES_JSON,
         )
         self.assertTrue(result["success"])
         self.assertEqual(result["pipelineVersion"]["versionNumber"], 2)
@@ -226,13 +236,17 @@ class CreatePipelineVersionTest(MCPTestCase):
         self.assertEqual(version.version_number, 2)
         self.assertEqual(version.user, self.USER_ADMIN)
         self.assertIsNotNone(version.zipfile)
+        self.assertEqual(
+            _zip_contents(version.zipfile),
+            {"pipeline.py": self.PIPELINE_PY.encode("utf-8")},
+        )
 
     def test_create_pipeline_version_with_name(self):
         result = create_pipeline_version(
             user=self.USER_ADMIN,
             workspace_slug=self.WORKSPACE.slug,
             pipeline_code="test-pipeline",
-            source_code=self.SOURCE_CODE,
+            files_json=self.FILES_JSON,
             name="My release",
             description="A new version",
         )
@@ -243,12 +257,65 @@ class CreatePipelineVersionTest(MCPTestCase):
         self.assertEqual(version.name, "My release")
         self.assertEqual(version.description, "A new version")
 
+    def test_create_pipeline_version_multiple_files(self):
+        files = [
+            {"path": "pipeline.py", "content": self.PIPELINE_PY},
+            {
+                "path": "helpers.py",
+                "content": "def clean(df):\n    return df.dropna()\n",
+            },
+            {"path": "requirements.txt", "content": "pandas\nrequests\n"},
+        ]
+        result = create_pipeline_version(
+            user=self.USER_ADMIN,
+            workspace_slug=self.WORKSPACE.slug,
+            pipeline_code="test-pipeline",
+            files_json=json.dumps(files),
+        )
+        self.assertTrue(result["success"], result)
+
+        version = PipelineVersion.objects.get(id=result["pipelineVersion"]["id"])
+        contents = _zip_contents(version.zipfile)
+        self.assertEqual(
+            set(contents), {"pipeline.py", "helpers.py", "requirements.txt"}
+        )
+        self.assertEqual(
+            contents["helpers.py"], b"def clean(df):\n    return df.dropna()\n"
+        )
+        self.assertEqual(contents["requirements.txt"], b"pandas\nrequests\n")
+
+    def test_create_pipeline_version_invalid_json(self):
+        result = create_pipeline_version(
+            user=self.USER_ADMIN,
+            workspace_slug=self.WORKSPACE.slug,
+            pipeline_code="test-pipeline",
+            files_json="not json",
+        )
+        self.assertEqual(result["errors"][0]["message"], "Invalid JSON in files_json")
+
+    def test_create_pipeline_version_invalid_files_surface_resolver_error(self):
+        result = create_pipeline_version(
+            user=self.USER_ADMIN,
+            workspace_slug=self.WORKSPACE.slug,
+            pipeline_code="test-pipeline",
+            files_json=json.dumps(
+                [
+                    {"path": "pipeline.py", "content": self.PIPELINE_PY},
+                    {"path": "pipeline.py", "content": "x = 1"},
+                ]
+            ),
+        )
+        self.assertFalse(result["success"])
+        self.assertEqual(result["errors"], ["INVALID_VERSION_FILES"])
+        self.assertIn("duplicate path", result["details"])
+        self.assertIn("pipeline.py", result["details"])
+
     def test_create_pipeline_version_not_found(self):
         result = create_pipeline_version(
             user=self.USER_ADMIN,
             workspace_slug=self.WORKSPACE.slug,
             pipeline_code="nonexistent",
-            source_code=self.SOURCE_CODE,
+            files_json=self.FILES_JSON,
         )
         self.assertFalse(result["success"])
         self.assertIn("PIPELINE_NOT_FOUND", result["errors"])
@@ -258,7 +325,7 @@ class CreatePipelineVersionTest(MCPTestCase):
             user=self.USER_OUTSIDER,
             workspace_slug=self.WORKSPACE.slug,
             pipeline_code="test-pipeline",
-            source_code=self.SOURCE_CODE,
+            files_json=self.FILES_JSON,
         )
         self.assertFalse(result["success"])
         self.assertIn("PIPELINE_NOT_FOUND", result["errors"])

--- a/backend/hexa/mcp/tools/pipelines.py
+++ b/backend/hexa/mcp/tools/pipelines.py
@@ -1,7 +1,4 @@
-import base64
-import io
 import json
-from zipfile import ZipFile
 
 from hexa.mcp.protocol import tool
 from hexa.pipelines.models import PipelineFunctionalType
@@ -105,11 +102,12 @@ def update_pipeline(
     return data["updatePipeline"]
 
 
-def _build_zipfile_b64(source_code: str) -> str:
-    buf = io.BytesIO()
-    with ZipFile(buf, "w") as zf:
-        zf.writestr("pipeline.py", source_code)
-    return base64.b64encode(buf.getvalue()).decode("ascii")
+def _parse_files_json(files_json: str) -> tuple[list[dict] | None, dict | None]:
+    try:
+        files = json.loads(files_json)
+    except json.JSONDecodeError:
+        return None, {"errors": [{"message": "Invalid JSON in files_json"}]}
+    return files, None
 
 
 _PIPELINE_AUTHORING_CHEAT_SHEET = """
@@ -243,28 +241,38 @@ def create_pipeline(
     user,
     workspace_slug: str,
     name: str,
-    source_code: str,
+    files_json: str,
     description: str = "",
     functional_type: PipelineFunctionalType | None = None,
 ) -> dict:
-    """Create a new pipeline in the current workspace and upload Python source code as the first version (v1).
+    r"""Create a new pipeline in the current workspace and upload its files as the first version (v1).
 
     Always provide a meaningful description summarizing what the pipeline does.
     If the pipeline has no clear purpose or is blank, use "" as the description.
-    The source_code must follow the OpenHEXA SDK structure (use @pipeline and @task decorators).
+
+    Provide files_json as a JSON array of {path, content, encoding?} objects, e.g.
+    '[{"path": "pipeline.py", "content": "from openhexa.sdk import pipeline\n..."},
+      {"path": "helpers.py", "content": "def clean(df): ..."},
+      {"path": "requirements.txt", "content": "pandas\nrequests"}]'.
+
+    A file named 'pipeline.py' is required at the root and must follow the OpenHEXA SDK
+    structure (use @pipeline and @task decorators). Other files (helper modules, requirements.txt,
+    READMEs, config) can be added alongside it.
+
+    `encoding` defaults to TEXT (UTF-8 string). Use BASE64 for binary assets bundled with the
+    pipeline (rare — workspace files are usually the right place for data).
     """
-    if not source_code or not source_code.strip():
-        return {"errors": [{"message": "source_code is required and cannot be empty"}]}
-    zipfile_b64 = _build_zipfile_b64(source_code)
+    files, error = _parse_files_json(files_json)
+    if error is not None:
+        return error
 
     create_input = {
         "workspaceSlug": workspace_slug,
         "name": name,
         "description": description or None,
         "functionalType": functional_type or None,
+        "version": {"files": files},
     }
-    if zipfile_b64 is not None:
-        create_input["version"] = {"zipfile": zipfile_b64}
 
     data = execute_graphql(
         user,
@@ -281,20 +289,34 @@ def create_pipeline_version(
     user,
     workspace_slug: str,
     pipeline_code: str,
-    source_code: str,
+    files_json: str,
     name: str = "",
     description: str = "",
 ) -> dict:
-    """Upload a new version of an existing pipeline. Requires the workspace slug, the pipeline code (from get_pipeline), and the Python source code for the new version.
+    r"""Upload a new version of an existing pipeline. Requires the workspace slug, the pipeline code (from get_pipeline), and the files that make up the new version.
 
     Optionally provide a version name and description. The version number is auto-incremented.
 
-    The source_code must follow the OpenHEXA SDK structure (use @pipeline and @task decorators).
-    Use get_pipeline first to read the current source code, then modify it and pass it here.
+    Provide files_json as a JSON array of {path, content, encoding?} objects, e.g.
+    '[{"path": "pipeline.py", "content": "from openhexa.sdk import pipeline\n..."},
+      {"path": "helpers.py", "content": "def clean(df): ..."},
+      {"path": "requirements.txt", "content": "pandas\nrequests"}]'.
+
+    A file named 'pipeline.py' is required at the root and must follow the OpenHEXA SDK
+    structure (use @pipeline and @task decorators). Other files (helper modules, requirements.txt,
+    READMEs, config) can be added alongside it.
+
+    `encoding` defaults to TEXT (UTF-8 string). Use BASE64 for binary assets bundled with the
+    pipeline (rare — workspace files are usually the right place for data).
+
+    Use get_pipeline first to read the current files, then modify them and pass the full set here
+    — each upload replaces the previous version's files entirely.
 
     Returns the created version details including id, version number, and parsed parameters.
     """
-    zipfile_b64 = _build_zipfile_b64(source_code)
+    files, error = _parse_files_json(files_json)
+    if error is not None:
+        return error
 
     data = execute_graphql(
         user,
@@ -303,7 +325,7 @@ def create_pipeline_version(
             "input": {
                 "workspaceSlug": workspace_slug,
                 "pipelineCode": pipeline_code,
-                "zipfile": zipfile_b64,
+                "files": files,
                 "name": name or None,
                 "description": description or None,
             }

--- a/backend/hexa/pipelines/graphql/schema.graphql
+++ b/backend/hexa/pipelines/graphql/schema.graphql
@@ -398,6 +398,7 @@ enum PipelineError {
   PIPELINE_CODE_PARSING_ERROR
   WORKSPACE_NOT_FOUND
   INVALID_CONFIG
+  INVALID_VERSION_FILES
   PIPELINE_ALREADY_COMPLETED
   PIPELINE_ALREADY_STOPPED
   INVALID_TIMEOUT_VALUE
@@ -422,11 +423,28 @@ enum PipelineOrderBy {
 }
 
 """
+A single file in a pipeline version.
+
+`content` is interpreted according to `encoding`:
+  * TEXT (default)  — content is a UTF-8 string; suitable for Python code, requirements.txt, READMEs.
+  * BASE64          — content is base64-encoded raw bytes; use for binary assets bundled with the pipeline.
+"""
+input PipelineFileInput {
+  path: String!  # File path relative to the pipeline root (e.g. "pipeline.py", "lib/helpers.py").
+  content: String!
+  encoding: FileEncoding = TEXT
+}
+
+"""
 Configures the first pipeline version, created atomically alongside the pipeline.
 Providing this sub-input signals that a first version should be created.
+
+Provide exactly one of `zipfile` (base64-encoded ZIP) or `files` (list of source files
+the server will zip up). `files` requires a `pipeline.py` at the root.
 """
 input CreatePipelineVersionInput {
-  zipfile: String!  # Base64-encoded ZIP file containing the version code.
+  zipfile: String  # Base64-encoded ZIP file containing the version code.
+  files: [PipelineFileInput!]  # Source files; the server builds the zip.
   name: String  # The name of the first pipeline version.
   description: String  # The description of the first pipeline version.
   externalLink: URL  # The external link associated with the first pipeline version.
@@ -631,7 +649,8 @@ input UploadPipelineInput {
   description: String  # The description of the pipeline.
   externalLink: URL  # The external link associated with the pipeline.
   parameters: [ParameterInput!]  # The parameters of the pipeline.
-  zipfile: String!  # The path to the ZIP file containing the pipeline.
+  zipfile: String  # Base64-encoded ZIP file containing the version code. Exactly one of `zipfile` or `files` must be provided.
+  files: [PipelineFileInput!]  # Source files; the server builds the zip. Exactly one of `zipfile` or `files` must be provided.
   config: JSON # The default configuration to set on newly created pipeline runs
   timeout: Int  # The timeout value for the pipeline.
   tags: [String!]  # The names of tags to associate with the pipeline.

--- a/backend/hexa/pipelines/graphql/schema.graphql
+++ b/backend/hexa/pipelines/graphql/schema.graphql
@@ -473,6 +473,7 @@ Represents the result of creating a pipeline.
 type CreatePipelineResult {
   success: Boolean!  # Indicates if the pipeline was created successfully.
   errors: [PipelineError!]!  # The list of errors that occurred during the creation of the pipeline.
+  details: String  # Additional details about the failure (e.g. why files were rejected).
   pipeline: Pipeline  # The created pipeline.
   pipelineVersion: PipelineVersion  # The first pipeline version, if a zipfile was provided.
 }

--- a/backend/hexa/pipelines/schema/mutations.py
+++ b/backend/hexa/pipelines/schema/mutations.py
@@ -58,6 +58,56 @@ def _parse_parameters_from_zipfile(zipfile_data: bytes) -> list:
         raise PipelineCodeParsingError(str(e))
 
 
+class InvalidVersionFilesError(Exception):
+    """Raised when a pipeline version's file input is malformed or ambiguous."""
+
+
+def _build_zipfile_from_files(files: list[dict]) -> bytes:
+    if not files:
+        raise InvalidVersionFilesError("files must be a non-empty list")
+    seen: set[str] = set()
+    buf = io.BytesIO()
+    with ZipFile(buf, "w") as zf:
+        for entry in files:
+            path = entry.get("path")
+            content = entry.get("content")
+            if not isinstance(path, str) or not path or not isinstance(content, str):
+                raise InvalidVersionFilesError(
+                    "each file must have a non-empty 'path' and a 'content' string"
+                )
+            if path in seen:
+                raise InvalidVersionFilesError(f"duplicate path in files: {path}")
+            seen.add(path)
+            encoding = (entry.get("encoding") or "TEXT").upper()
+            if encoding == "BASE64":
+                try:
+                    data = base64.b64decode(content, validate=True)
+                except (ValueError, base64.binascii.Error) as e:
+                    raise InvalidVersionFilesError(
+                        f"invalid base64 content for {path}: {e}"
+                    )
+            elif encoding == "TEXT":
+                data = content.encode("utf-8")
+            else:
+                raise InvalidVersionFilesError(
+                    f"invalid encoding {encoding!r} for {path} — must be TEXT or BASE64"
+                )
+            zf.writestr(path, data)
+    return buf.getvalue()
+
+
+def _resolve_version_zipfile_bytes(version_input: dict) -> bytes:
+    has_zipfile = version_input.get("zipfile") is not None
+    has_files = version_input.get("files") is not None
+    if has_zipfile and has_files:
+        raise InvalidVersionFilesError("provide either 'zipfile' or 'files', not both")
+    if not has_zipfile and not has_files:
+        raise InvalidVersionFilesError("either 'zipfile' or 'files' is required")
+    if has_zipfile:
+        return base64.b64decode(version_input["zipfile"].encode("ascii"))
+    return _build_zipfile_from_files(version_input["files"])
+
+
 def _validate_pipeline_version_timeout(
     timeout: int | None, workspace: Workspace
 ) -> None:
@@ -154,6 +204,12 @@ def resolve_create_pipeline(_, info, **kwargs):
         return {"success": False, "errors": ["PIPELINE_DOES_NOT_SUPPORT_PARAMETERS"]}
     except InvalidTimeoutValueError:
         return {"success": False, "errors": ["INVALID_TIMEOUT_VALUE"]}
+    except InvalidVersionFilesError as e:
+        return {
+            "success": False,
+            "errors": ["INVALID_VERSION_FILES"],
+            "details": str(e),
+        }
 
     return {
         "pipeline": pipeline,
@@ -166,7 +222,7 @@ def resolve_create_pipeline(_, info, **kwargs):
 def _create_first_pipeline_version(
     user: User, workspace: Workspace, pipeline: Pipeline, version_input: dict
 ) -> PipelineVersion:
-    zipfile_data = base64.b64decode(version_input["zipfile"].encode("ascii"))
+    zipfile_data = _resolve_version_zipfile_bytes(version_input)
     parameters = version_input.get("parameters") or _parse_parameters_from_zipfile(
         zipfile_data
     )
@@ -428,7 +484,7 @@ def resolve_upload_pipeline(_, info, **kwargs):
     try:
         _validate_pipeline_version_timeout(input.get("timeout"), pipeline.workspace)
 
-        zipfile_data = base64.b64decode(input.get("zipfile").encode("ascii"))
+        zipfile_data = _resolve_version_zipfile_bytes(input)
         parameters = input.get("parameters")
 
         if not parameters:
@@ -473,6 +529,12 @@ def resolve_upload_pipeline(_, info, **kwargs):
         }
     except InvalidTimeoutValueError:
         return {"success": False, "errors": ["INVALID_TIMEOUT_VALUE"]}
+    except InvalidVersionFilesError as e:
+        return {
+            "success": False,
+            "errors": ["INVALID_VERSION_FILES"],
+            "details": str(e),
+        }
     except PermissionDenied:
         return {"success": False, "errors": ["PERMISSION_DENIED"]}
     except IntegrityError as e:

--- a/backend/hexa/pipelines/tests/test_schema/test_pipeline_versions.py
+++ b/backend/hexa/pipelines/tests/test_schema/test_pipeline_versions.py
@@ -633,3 +633,148 @@ def test_pipeline(input_file, threshold, enable_debug):
         )
         self.assertEqual(r["data"]["updatePipelineVersion"]["success"], True)
         self.assertEqual(r["data"]["updatePipelineVersion"]["errors"], [])
+
+
+class UploadPipelineFilesInputTest(GraphQLTestCase):
+    """Tests for UploadPipelineInput.files — the alternative to a base64 zipfile."""
+
+    PIPELINE_PY = (
+        "from openhexa.sdk import pipeline\n\n"
+        '@pipeline("test")\n'
+        "def test_pipeline():\n"
+        "    pass\n"
+    )
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.USER_ROOT = User.objects.create_user(
+            "root-files@bluesquarehub.com",
+            "standardpassword",
+            is_superuser=True,
+        )
+        cls.USER_ADMIN = User.objects.create_user(
+            "admin-files@bluesquarehub.com",
+            "standardpassword",
+        )
+        with patch("hexa.workspaces.models.create_database"), patch(
+            "hexa.workspaces.models.load_database_sample_data"
+        ):
+            cls.WORKSPACE = Workspace.objects.create_if_has_perm(
+                cls.USER_ROOT,
+                name="WS Files",
+                description="Files-input workspace",
+            )
+        WorkspaceMembership.objects.create(
+            workspace=cls.WORKSPACE,
+            user=cls.USER_ADMIN,
+            role=WorkspaceMembershipRole.ADMIN,
+        )
+        cls.PIPELINE = Pipeline.objects.create(
+            code="pipeline-files", name="Files Pipeline", workspace=cls.WORKSPACE
+        )
+
+    def _upload(self, **input_overrides):
+        self.client.force_login(self.USER_ADMIN)
+        return self.run_query(
+            """
+            mutation uploadPipeline($input: UploadPipelineInput!) {
+                uploadPipeline(input: $input) {
+                    success
+                    errors
+                    details
+                    pipelineVersion { id versionNumber }
+                }
+            }
+            """,
+            {
+                "input": {
+                    "workspaceSlug": self.WORKSPACE.slug,
+                    "pipelineCode": self.PIPELINE.code,
+                    **input_overrides,
+                }
+            },
+        )
+
+    def _zip_contents(self, version: PipelineVersion) -> dict[str, bytes]:
+        with zipfile.ZipFile(io.BytesIO(version.zipfile)) as zf:
+            return {name: zf.read(name) for name in zf.namelist()}
+
+    def test_upload_with_files_builds_zip(self):
+        files = [
+            {"path": "pipeline.py", "content": self.PIPELINE_PY},
+            {"path": "lib/helpers.py", "content": "def clean(df):\n    return df\n"},
+            {"path": "requirements.txt", "content": "pandas\n"},
+        ]
+        r = self._upload(name="v-files", files=files)
+        self.assertTrue(r["data"]["uploadPipeline"]["success"], r["data"])
+
+        version = PipelineVersion.objects.get(
+            id=r["data"]["uploadPipeline"]["pipelineVersion"]["id"]
+        )
+        contents = self._zip_contents(version)
+        self.assertEqual(
+            set(contents), {"pipeline.py", "lib/helpers.py", "requirements.txt"}
+        )
+        self.assertEqual(contents["requirements.txt"], b"pandas\n")
+
+    def test_upload_with_base64_file(self):
+        binary_payload = b"\x89PNG\r\n\x1a\n\x00"
+        files = [
+            {"path": "pipeline.py", "content": self.PIPELINE_PY},
+            {
+                "path": "assets/logo.png",
+                "content": base64.b64encode(binary_payload).decode("ascii"),
+                "encoding": "BASE64",
+            },
+        ]
+        r = self._upload(name="v-b64", files=files)
+        self.assertTrue(r["data"]["uploadPipeline"]["success"], r["data"])
+
+        version = PipelineVersion.objects.get(
+            id=r["data"]["uploadPipeline"]["pipelineVersion"]["id"]
+        )
+        self.assertEqual(self._zip_contents(version)["assets/logo.png"], binary_payload)
+
+    def test_upload_rejects_both_zipfile_and_files(self):
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, "w") as zf:
+            zf.writestr("pipeline.py", self.PIPELINE_PY)
+        zip_b64 = base64.b64encode(zip_buffer.getvalue()).decode("ascii")
+
+        r = self._upload(
+            name="v-both",
+            zipfile=zip_b64,
+            files=[{"path": "pipeline.py", "content": self.PIPELINE_PY}],
+        )
+        self.assertFalse(r["data"]["uploadPipeline"]["success"])
+        self.assertEqual(
+            r["data"]["uploadPipeline"]["errors"], ["INVALID_VERSION_FILES"]
+        )
+
+    def test_upload_rejects_neither_zipfile_nor_files(self):
+        r = self._upload(name="v-neither")
+        self.assertFalse(r["data"]["uploadPipeline"]["success"])
+        self.assertEqual(
+            r["data"]["uploadPipeline"]["errors"], ["INVALID_VERSION_FILES"]
+        )
+
+    def test_upload_rejects_duplicate_paths(self):
+        files = [
+            {"path": "pipeline.py", "content": self.PIPELINE_PY},
+            {"path": "pipeline.py", "content": "x = 1\n"},
+        ]
+        r = self._upload(name="v-dup", files=files)
+        self.assertFalse(r["data"]["uploadPipeline"]["success"])
+        self.assertEqual(
+            r["data"]["uploadPipeline"]["errors"], ["INVALID_VERSION_FILES"]
+        )
+        self.assertIn("duplicate", r["data"]["uploadPipeline"]["details"].lower())
+
+    def test_upload_missing_pipeline_py_is_not_enforced(self):
+        files = [{"path": "helpers.py", "content": "x = 1\n"}]
+        r = self._upload(name="v-nopipeline", files=files)
+        self.assertTrue(r["data"]["uploadPipeline"]["success"], r["data"])
+        version = PipelineVersion.objects.get(
+            id=r["data"]["uploadPipeline"]["pipelineVersion"]["id"]
+        )
+        self.assertEqual(version.parameters, [])

--- a/frontend/schema.generated.graphql
+++ b/frontend/schema.generated.graphql
@@ -1056,6 +1056,7 @@ input CreatePipelineRecipientInput {
 
 """Represents the result of creating a pipeline."""
 type CreatePipelineResult {
+  details: String
   errors: [PipelineError!]!
   pipeline: Pipeline
   pipelineVersion: PipelineVersion

--- a/frontend/schema.generated.graphql
+++ b/frontend/schema.generated.graphql
@@ -1099,15 +1099,19 @@ type CreatePipelineTemplateVersionResult {
 """
 Configures the first pipeline version, created atomically alongside the pipeline.
 Providing this sub-input signals that a first version should be created.
+
+Provide exactly one of `zipfile` (base64-encoded ZIP) or `files` (list of source files
+the server will zip up). `files` requires a `pipeline.py` at the root.
 """
 input CreatePipelineVersionInput {
   config: JSON
   description: String
   externalLink: URL
+  files: [PipelineFileInput!]
   name: String
   parameters: [ParameterInput!]
   timeout: Int
-  zipfile: String!
+  zipfile: String
 }
 
 """
@@ -3386,6 +3390,7 @@ enum PipelineError {
   FILE_NOT_FOUND
   INVALID_CONFIG
   INVALID_TIMEOUT_VALUE
+  INVALID_VERSION_FILES
   PERMISSION_DENIED
   PIPELINE_ALREADY_COMPLETED
   PIPELINE_ALREADY_STOPPED
@@ -3396,6 +3401,19 @@ enum PipelineError {
   PIPELINE_VERSION_NOT_FOUND
   TABLE_NOT_FOUND
   WORKSPACE_NOT_FOUND
+}
+
+"""
+A single file in a pipeline version.
+
+`content` is interpreted according to `encoding`:
+  * TEXT (default)  — content is a UTF-8 string; suitable for Python code, requirements.txt, READMEs.
+  * BASE64          — content is base64-encoded raw bytes; use for binary assets bundled with the pipeline.
+"""
+input PipelineFileInput {
+  content: String!
+  encoding: FileEncoding = TEXT
+  path: String!
 }
 
 """
@@ -5368,6 +5386,7 @@ input UploadPipelineInput {
   config: JSON
   description: String
   externalLink: URL
+  files: [PipelineFileInput!]
   functionalType: PipelineFunctionalType
   name: String
   parameters: [ParameterInput!]
@@ -5375,7 +5394,7 @@ input UploadPipelineInput {
   tags: [String!]
   timeout: Int
   workspaceSlug: String!
-  zipfile: String!
+  zipfile: String
 }
 
 """Represents the result of uploading a pipeline."""

--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -1110,15 +1110,19 @@ export type CreatePipelineTemplateVersionResult = {
 /**
  * Configures the first pipeline version, created atomically alongside the pipeline.
  * Providing this sub-input signals that a first version should be created.
+ *
+ * Provide exactly one of `zipfile` (base64-encoded ZIP) or `files` (list of source files
+ * the server will zip up). `files` requires a `pipeline.py` at the root.
  */
 export type CreatePipelineVersionInput = {
   config?: InputMaybe<Scalars['JSON']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   externalLink?: InputMaybe<Scalars['URL']['input']>;
+  files?: InputMaybe<Array<PipelineFileInput>>;
   name?: InputMaybe<Scalars['String']['input']>;
   parameters?: InputMaybe<Array<ParameterInput>>;
   timeout?: InputMaybe<Scalars['Int']['input']>;
-  zipfile: Scalars['String']['input'];
+  zipfile?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** The CreateTeamError enum represents the possible errors that can occur during the createTeam mutation. */
@@ -4007,6 +4011,7 @@ export enum PipelineError {
   FileNotFound = 'FILE_NOT_FOUND',
   InvalidConfig = 'INVALID_CONFIG',
   InvalidTimeoutValue = 'INVALID_TIMEOUT_VALUE',
+  InvalidVersionFiles = 'INVALID_VERSION_FILES',
   PermissionDenied = 'PERMISSION_DENIED',
   PipelineAlreadyCompleted = 'PIPELINE_ALREADY_COMPLETED',
   PipelineAlreadyStopped = 'PIPELINE_ALREADY_STOPPED',
@@ -4018,6 +4023,19 @@ export enum PipelineError {
   TableNotFound = 'TABLE_NOT_FOUND',
   WorkspaceNotFound = 'WORKSPACE_NOT_FOUND'
 }
+
+/**
+ * A single file in a pipeline version.
+ *
+ * `content` is interpreted according to `encoding`:
+ *   * TEXT (default)  — content is a UTF-8 string; suitable for Python code, requirements.txt, READMEs.
+ *   * BASE64          — content is base64-encoded raw bytes; use for binary assets bundled with the pipeline.
+ */
+export type PipelineFileInput = {
+  content: Scalars['String']['input'];
+  encoding?: InputMaybe<FileEncoding>;
+  path: Scalars['String']['input'];
+};
 
 /**
  * Represents the functional purpose of a pipeline in data workflows.
@@ -6166,6 +6184,7 @@ export type UploadPipelineInput = {
   config?: InputMaybe<Scalars['JSON']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
   externalLink?: InputMaybe<Scalars['URL']['input']>;
+  files?: InputMaybe<Array<PipelineFileInput>>;
   functionalType?: InputMaybe<PipelineFunctionalType>;
   name?: InputMaybe<Scalars['String']['input']>;
   parameters?: InputMaybe<Array<ParameterInput>>;
@@ -6173,7 +6192,7 @@ export type UploadPipelineInput = {
   tags?: InputMaybe<Array<Scalars['String']['input']>>;
   timeout?: InputMaybe<Scalars['Int']['input']>;
   workspaceSlug: Scalars['String']['input'];
-  zipfile: Scalars['String']['input'];
+  zipfile?: InputMaybe<Scalars['String']['input']>;
 };
 
 /** Represents the result of uploading a pipeline. */

--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -1068,6 +1068,7 @@ export type CreatePipelineRecipientInput = {
 /** Represents the result of creating a pipeline. */
 export type CreatePipelineResult = {
   __typename?: 'CreatePipelineResult';
+  details?: Maybe<Scalars['String']['output']>;
   errors: Array<PipelineError>;
   pipeline?: Maybe<Pipeline>;
   pipelineVersion?: Maybe<PipelineVersion>;


### PR DESCRIPTION
The MCP was only able to create pipelines with one file. 

Allow creating using a dict of files. Implementation in the GraphQL layer fro keeping the MCP layer as thin as possible