### PR TITLE
fix: Small Django admin improvements

### DIFF
--- a/backend/hexa/pipeline_templates/admin.py
+++ b/backend/hexa/pipeline_templates/admin.py
@@ -7,7 +7,8 @@ from hexa.pipeline_templates.models import PipelineTemplate, PipelineTemplateVer
 @admin.register(PipelineTemplate)
 class PipelineTemplateAdmin(GlobalObjectsModelAdmin):
     list_display = ("name", "code", "workspace", "validated_at", "is_deleted")
-    list_filter = ("workspace", "validated_at")
+    list_select_related = ("workspace",)
+    list_filter = ("validated_at",)
     search_fields = ("id", "code", "name")
     fields = (
         "name",
@@ -22,12 +23,13 @@ class PipelineTemplateAdmin(GlobalObjectsModelAdmin):
         "updated_at",
         "deleted_at",
     )
-    readonly_fields = ("created_at", "updated_at")
+    readonly_fields = ("workspace", "source_pipeline", "created_at", "updated_at")
 
 
 @admin.register(PipelineTemplateVersion)
 class PipelineTemplateVersionAdmin(admin.ModelAdmin):
     list_display = ("version_number", "template", "created_at")
-    list_filter = ("template", "template__workspace")
+    list_select_related = ("template",)
+    list_filter = ("template__workspace",)
     search_fields = ("template__name", "template__code", "template__id")
-    autocomplete_fields = ["source_pipeline_version"]
+    readonly_fields = ("template", "source_pipeline_version")

--- a/backend/hexa/pipelines/admin.py
+++ b/backend/hexa/pipelines/admin.py
@@ -18,7 +18,9 @@ def restore_pipelines(modeladmin, request, queryset):
 
 @admin.register(Pipeline)
 class PipelineAdmin(GlobalObjectsModelAdmin):
+    readonly_fields = ("workspace", "source_template", "scheduled_pipeline_version")
     list_display = ("name", "code", "workspace")
+    list_select_related = ("workspace",)
     list_filter = ("workspace",)
     search_fields = ("id", "code", "name")
     actions = [restore_pipelines]
@@ -28,21 +30,27 @@ class PipelineAdmin(GlobalObjectsModelAdmin):
 class PipelineRunAdmin(admin.ModelAdmin):
     readonly_fields = ("pipeline", "pipeline_version")
     list_display = (
+        "run_id",
         "pipeline",
-        "trigger_mode",
         "state",
         "execution_date",
-        "timeout",
-        "cpu_limit",
-        "memory_limit",
+        "duration",
+        "limits",
     )
-    list_filter = ("trigger_mode", "state", "execution_date", "pipeline")
+    list_select_related = ("pipeline",)
+    list_filter = ("trigger_mode", "state", "execution_date")
     search_fields = ("pipeline__name", "pipeline__code", "pipeline__id", "id")
+    date_hierarchy = "execution_date"
+
+    @admin.display(description="Limits (CPU / Memory / Timeout)")
+    def limits(self, obj):
+        return f"{obj.cpu_limit} / {obj.memory_limit} / {obj.timeout}"
 
 
 @admin.register(PipelineVersion)
 class PipelineVersionAdmin(admin.ModelAdmin):
     list_display = ("version_number", "name", "pipeline", "created_at")
+    list_select_related = ("pipeline",)
     list_filter = ("pipeline", "pipeline__workspace")
     search_fields = ("name", "pipeline__name", "pipeline__code", "pipeline__id")
 

--- a/backend/hexa/user_management/admin.py
+++ b/backend/hexa/user_management/admin.py
@@ -99,6 +99,7 @@ class CustomUserAdmin(UserAdmin):
         "last_login",
         "is_staff",
         "is_superuser",
+        "is_active",
         "teams",
         "assistant_usage_this_month",
         "assistant_usage",


### PR DESCRIPTION
The pipeline details page actually timed out due to the N+1 queries to construct the dropdowns for pipeline versions. (read-only prints just the resource, removing the dropdown altogether)

Changes:
- Performance improvements on pipelines, pipeline versions and pipeline runs pages
- More date filtering on pipeline runs, remove the pipeline filter (unusable anyways)
- Show if user is active

**Before:**
<img width="3860" height="2169" alt="image" src="https://github.com/user-attachments/assets/85d250bb-80f8-4f00-b771-8ce7ef3b34c0" />

**After:**
<img width="3834" height="1706" alt="image" src="https://github.com/user-attachments/assets/4f9f7c6a-e065-4782-a916-0df7e37bae5d" />
