### PR TITLE
chore: Speed up Django test suite

### DIFF
--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -1,6 +1,12 @@
 [run]
 omit = */migrations/*
 source = hexa/
+# Required so coverage keeps measuring inside the worker processes spawned by
+# `manage.py test --parallel`; the per-process data files are merged with
+# `coverage combine` before reporting.
+parallel = True
+concurrency = multiprocessing
+sigterm = True
 
 [html]
 directory = htmlcov/

--- a/backend/config/settings/test.py
+++ b/backend/config/settings/test.py
@@ -1,5 +1,10 @@
 import os
 
+# Logfire (configured in hexa.assistant.apps) must not export spans during
+# tests: its gzipped OTLP requests get captured by `responses` mocks and break
+# tests that inspect mocked request bodies.
+os.environ["LOGFIRE_SEND_TO_LOGFIRE"] = "false"
+
 STORAGE_BACKEND = "dummy"
 
 from .base import *  # noqa: E402, F401, F403

--- a/backend/config/settings/test.py
+++ b/backend/config/settings/test.py
@@ -6,6 +6,10 @@ from .base import *  # noqa: E402, F401, F403
 
 DEBUG = False
 
+# Speed up tests: the default PBKDF2 hasher is intentionally slow (~100ms per
+# hash), which adds up since many tests create users in setUp/setUpTestData.
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
+
 ALLOWED_HOSTS = ["*"]
 CORS_ALLOWED_ORIGINS = ["http://localhost:3000"]
 CORS_ALLOW_CREDENTIALS = True

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -59,14 +59,22 @@ case "$command" in
   wait-for-it ${DATABASE_HOST:-db}:${DATABASE_PORT:-5432}
   export DJANGO_SETTINGS_MODULE=config.settings.test
   python manage.py makemigrations --check
-  python manage.py test $arguments
+  python manage.py test --parallel auto $arguments
   ;;
 "coveraged-test")
   wait-for-it ${DATABASE_HOST:-db}:${DATABASE_PORT:-5432}
   export DJANGO_SETTINGS_MODULE=config.settings.test
+  # sysmon uses Python 3.12+'s sys.monitoring, which has much lower tracing
+  # overhead than the default coverage core
+  export COVERAGE_CORE=${COVERAGE_CORE:-sysmon}
   python manage.py makemigrations --check
-  coverage run manage.py test $arguments
+  coverage erase
+  # Combine & report even when tests fail, but preserve the test exit code
+  test_status=0
+  coverage run manage.py test --parallel auto $arguments || test_status=$?
+  coverage combine --quiet
   coverage report --skip-empty --fail-under=80
+  exit $test_status
   ;;
 "manage")
   wait-for-it ${DATABASE_HOST:-db}:${DATABASE_PORT:-5432}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -47,31 +47,3 @@ ignore = [
 [tool.ruff.lint.pydocstyle]
 convention = "numpy" # Accepts: "google", "numpy", or "pep257".
 
-[tool.coverage.report]
-exclude_lines = [
-    # Have to re-enable the standard pragma
-    "pragma: no cover",
-
-    # Don't complain about missing debug-only code:
-    "def __repr__",
-    "if self\\.debug",
-
-    # Don't complain if tests don't hit defensive assertion code:
-    "raise AssertionError",
-    "raise NotImplementedError",
-
-    # Don't complain if non-runnable code isn't run:
-    "if 0:",
-    "if __name__ == .__main__.:",
-]
-
-omit = [
-    "*/__init__.py",
-    "*/migrations/*",
-    "*/tests/*",
-    "config/*",
-    "*/admin.py",
-    "*/apps.py",
-    "*/urls.py",
-    "manage.py",
-]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,6 +31,9 @@ services:
   db:
     platform: linux/amd64
     image: postgis/postgis:16-3.5
+    # Trade crash-durability for speed: fine for a dev/CI database, do not
+    # reuse for production deployments.
+    command: postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off
     env_file:
       - path: ./.env
         required: true


### PR DESCRIPTION
I noticed that the backend tests **grew from ~8 mins to ~12 mins over the last 12 months**.
Since I found myself often waiting for tests to finish running, I decided to have a go at it with Claude and ended up with a **new test duration of ~6 mins**. :tada: :rocket: 

### Changes

- Change pw hasher to speed up tests (interesting, this is a big one!)
- Make sure Logfire is disabled in tests
- Run tests in parallel
- Speed up coverage calculation
- Speed up Postgres for dev/CI by disabling crash-durability features


<img width="2626" height="1743" alt="image" src="https://github.com/user-attachments/assets/6d547b90-da40-4229-b286-005675dea069" />
