### PR TITLE
Auto accept all pending invitations upon user registration (HEXA-1696)

### DIFF
--- a/backend/hexa/user_management/models.py
+++ b/backend/hexa/user_management/models.py
@@ -906,16 +906,17 @@ class OrganizationInvitation(Invitation):
         """Accept the invitation and create organization/workspace memberships."""
         from hexa.workspaces.models import WorkspaceMembership
 
-        OrganizationMembership.objects.create(
+        # get_or_create in case the user is already a member
+        OrganizationMembership.objects.get_or_create(
             organization=self.organization,
             user=user,
-            role=self.role,
+            defaults={"role": self.role},
         )
         for ws_invitation in self.workspace_invitations.all():
-            WorkspaceMembership.objects.create(
+            WorkspaceMembership.objects.get_or_create(
                 workspace=ws_invitation.workspace,
                 user=user,
-                role=ws_invitation.role,
+                defaults={"role": ws_invitation.role},
             )
         self.status = OrganizationInvitationStatus.ACCEPTED
         self.save()

--- a/backend/hexa/user_management/schema/mutations.py
+++ b/backend/hexa/user_management/schema/mutations.py
@@ -47,6 +47,7 @@ from hexa.workspaces.models import (
 
 from ..utils import (
     DEVICE_DEFAULT_NAME,
+    accept_pending_invitations,
     default_device,
     has_configured_two_factor,
     send_organization_add_user_email,
@@ -244,7 +245,7 @@ def resolve_register(_, info, **kwargs):
             first_name=mutation_input["first_name"],
             last_name=mutation_input["last_name"],
         )
-        invitation.accept(user)
+        accept_pending_invitations(user)
 
     track(
         request,

--- a/backend/hexa/user_management/sso/sso_adapter.py
+++ b/backend/hexa/user_management/sso/sso_adapter.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 
 from hexa.core.utils import get_email_attachments, send_mail
 from hexa.user_management.models import User
+from hexa.user_management.utils import accept_pending_invitations
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +89,8 @@ class OpenHexaSocialAccountAdapter(DefaultSocialAccountAdapter):
 
             sociallogin.user = user
             sociallogin.save(request)
+
+            accept_pending_invitations(user)
 
         try:
             self._send_new_account_email(user, sociallogin.account.provider)

--- a/backend/hexa/user_management/tests/sso/test_sso_adapter.py
+++ b/backend/hexa/user_management/tests/sso/test_sso_adapter.py
@@ -3,8 +3,25 @@ from unittest.mock import MagicMock, patch
 from allauth.core.exceptions import ImmediateHttpResponse
 from django.test import TestCase, override_settings
 
-from hexa.user_management.models import User
+from hexa.user_management.models import (
+    Organization,
+    OrganizationInvitation,
+    OrganizationInvitationStatus,
+    OrganizationMembership,
+    OrganizationMembershipRole,
+    SignupRequest,
+    SignupRequestStatus,
+    User,
+)
 from hexa.user_management.sso.sso_adapter import OpenHexaSocialAccountAdapter
+from hexa.workspaces.models import (
+    OrganizationWorkspaceInvitation,
+    Workspace,
+    WorkspaceInvitation,
+    WorkspaceInvitationStatus,
+    WorkspaceMembership,
+    WorkspaceMembershipRole,
+)
 
 _WHO_CONFIG = {
     "id": "who",
@@ -258,3 +275,132 @@ class IsAutoSignupAllowedTest(TestCase):
     def test_denied_when_email_absent(self):
         sociallogin = _make_sociallogin("")
         self.assertFalse(self.adapter.is_auto_signup_allowed(self.request, sociallogin))
+
+
+@override_settings(OIDC_PROVIDERS=[_WHO_CONFIG])
+class SaveUserAcceptsPendingInvitationsTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.ORGANIZATION = Organization.objects.create(name="WHO")
+        cls.WORKSPACE = Workspace.objects.create(
+            name="Workspace", slug="workspace", organization=cls.ORGANIZATION
+        )
+
+    def setUp(self):
+        self.adapter = OpenHexaSocialAccountAdapter()
+        self.request = MagicMock()
+
+    def _save_user(self, email="jane@who.int"):
+        sociallogin = _make_sociallogin(email)
+        with patch("hexa.user_management.sso.sso_adapter.send_mail"):
+            return self.adapter.save_user(self.request, sociallogin)
+
+    def test_accepts_pending_workspace_invitation(self):
+        invitation = WorkspaceInvitation.objects.create(
+            workspace=self.WORKSPACE,
+            email="jane@who.int",
+            role=WorkspaceMembershipRole.EDITOR,
+        )
+
+        user = self._save_user()
+
+        membership = WorkspaceMembership.objects.get(
+            user=user, workspace=self.WORKSPACE
+        )
+        self.assertEqual(membership.role, WorkspaceMembershipRole.EDITOR)
+        invitation.refresh_from_db()
+        self.assertEqual(invitation.status, WorkspaceInvitationStatus.ACCEPTED)
+
+    def test_accepts_pending_organization_invitation_with_workspaces(self):
+        org_invitation = OrganizationInvitation.objects.create(
+            organization=self.ORGANIZATION,
+            email="jane@who.int",
+            role=OrganizationMembershipRole.MEMBER,
+        )
+        OrganizationWorkspaceInvitation.objects.create(
+            organization_invitation=org_invitation,
+            workspace=self.WORKSPACE,
+            role=WorkspaceMembershipRole.VIEWER,
+        )
+
+        user = self._save_user()
+
+        org_membership = OrganizationMembership.objects.get(
+            user=user, organization=self.ORGANIZATION
+        )
+        self.assertEqual(org_membership.role, OrganizationMembershipRole.MEMBER)
+        workspace_membership = WorkspaceMembership.objects.get(
+            user=user, workspace=self.WORKSPACE
+        )
+        self.assertEqual(workspace_membership.role, WorkspaceMembershipRole.VIEWER)
+        org_invitation.refresh_from_db()
+        self.assertEqual(org_invitation.status, OrganizationInvitationStatus.ACCEPTED)
+
+    def test_overlapping_invitations_create_single_membership(self):
+        """A direct workspace invitation and an organization invitation covering the
+        same workspace must not raise on the membership unique constraint; the
+        direct invitation's role wins.
+        """
+        workspace_invitation = WorkspaceInvitation.objects.create(
+            workspace=self.WORKSPACE,
+            email="jane@who.int",
+            role=WorkspaceMembershipRole.EDITOR,
+        )
+        org_invitation = OrganizationInvitation.objects.create(
+            organization=self.ORGANIZATION,
+            email="jane@who.int",
+            role=OrganizationMembershipRole.MEMBER,
+        )
+        OrganizationWorkspaceInvitation.objects.create(
+            organization_invitation=org_invitation,
+            workspace=self.WORKSPACE,
+            role=WorkspaceMembershipRole.VIEWER,
+        )
+
+        user = self._save_user()
+
+        membership = WorkspaceMembership.objects.get(
+            user=user, workspace=self.WORKSPACE
+        )
+        self.assertEqual(membership.role, WorkspaceMembershipRole.EDITOR)
+        workspace_invitation.refresh_from_db()
+        org_invitation.refresh_from_db()
+        self.assertEqual(
+            workspace_invitation.status, WorkspaceInvitationStatus.ACCEPTED
+        )
+        self.assertEqual(org_invitation.status, OrganizationInvitationStatus.ACCEPTED)
+
+    def test_accepts_pending_signup_request(self):
+        signup_request = SignupRequest.objects.create(email="jane@who.int")
+
+        self._save_user()
+
+        signup_request.refresh_from_db()
+        self.assertEqual(signup_request.status, SignupRequestStatus.ACCEPTED)
+
+    def test_ignores_invitations_for_other_emails(self):
+        other_invitation = WorkspaceInvitation.objects.create(
+            workspace=self.WORKSPACE,
+            email="someone.else@who.int",
+            role=WorkspaceMembershipRole.EDITOR,
+        )
+
+        user = self._save_user()
+
+        self.assertFalse(WorkspaceMembership.objects.filter(user=user).exists())
+        other_invitation.refresh_from_db()
+        self.assertEqual(other_invitation.status, WorkspaceInvitationStatus.PENDING)
+
+    def test_ignores_non_pending_invitations(self):
+        declined_invitation = WorkspaceInvitation.objects.create(
+            workspace=self.WORKSPACE,
+            email="jane@who.int",
+            role=WorkspaceMembershipRole.EDITOR,
+            status=WorkspaceInvitationStatus.DECLINED,
+        )
+
+        user = self._save_user()
+
+        self.assertFalse(WorkspaceMembership.objects.filter(user=user).exists())
+        declined_invitation.refresh_from_db()
+        self.assertEqual(declined_invitation.status, WorkspaceInvitationStatus.DECLINED)

--- a/backend/hexa/user_management/tests/test_schema.py
+++ b/backend/hexa/user_management/tests/test_schema.py
@@ -28,6 +28,7 @@ from hexa.user_management.models import (
 from hexa.workspaces.models import (
     Workspace,
     WorkspaceInvitation,
+    WorkspaceInvitationStatus,
     WorkspaceMembership,
     WorkspaceMembershipRole,
 )
@@ -1647,6 +1648,77 @@ class RegisterTest(GraphQLTestCase):
         self.assertEqual(
             self.ORG_INVITATION.status, OrganizationInvitationStatus.ACCEPTED
         )
+
+    def test_register_accepts_all_pending_invitations(self):
+        """Registering with one invitation token also accepts the other pending
+        invitations for the same email.
+        """
+        other_workspace = Workspace.objects.create(
+            name="Other Workspace",
+            slug="other-workspace",
+            db_name="db_other_workspace",
+            bucket_name="bucket_other_workspace",
+        )
+        other_invitation = WorkspaceInvitation.objects.create(
+            workspace=other_workspace,
+            email=self.WORKSPACE_INVITATION.email,
+            role=WorkspaceMembershipRole.VIEWER,
+        )
+        org_invitation = OrganizationInvitation.objects.create(
+            organization=self.ORGANIZATION,
+            email=self.WORKSPACE_INVITATION.email,
+            role=OrganizationMembershipRole.MEMBER,
+            invited_by=self.ORG_OWNER,
+        )
+
+        r = self.run_query(
+            """
+            mutation register($input: RegisterInput!) {
+                register(input: $input) {
+                    success
+                    errors
+                }
+            }
+            """,
+            {
+                "input": {
+                    "password1": "Pa$$Word1",
+                    "password2": "Pa$$Word1",
+                    "firstName": "John",
+                    "lastName": "Doe",
+                    "invitationToken": self.WORKSPACE_INVITATION.generate_token(),
+                }
+            },
+        )
+
+        self.assertTrue(r["data"]["register"]["success"])
+
+        user = User.objects.get(email=self.WORKSPACE_INVITATION.email)
+        self.assertTrue(
+            WorkspaceMembership.objects.filter(
+                user=user, workspace=self.WORKSPACE, role=WorkspaceMembershipRole.EDITOR
+            ).exists()
+        )
+        self.assertTrue(
+            WorkspaceMembership.objects.filter(
+                user=user,
+                workspace=other_workspace,
+                role=WorkspaceMembershipRole.VIEWER,
+            ).exists()
+        )
+        self.assertTrue(
+            OrganizationMembership.objects.filter(
+                user=user, organization=self.ORGANIZATION
+            ).exists()
+        )
+        self.WORKSPACE_INVITATION.refresh_from_db()
+        other_invitation.refresh_from_db()
+        org_invitation.refresh_from_db()
+        self.assertEqual(
+            self.WORKSPACE_INVITATION.status, WorkspaceInvitationStatus.ACCEPTED
+        )
+        self.assertEqual(other_invitation.status, WorkspaceInvitationStatus.ACCEPTED)
+        self.assertEqual(org_invitation.status, OrganizationInvitationStatus.ACCEPTED)
 
     def test_register_with_signup_request(self):
         """Test registration using a self-registration signup request token."""

--- a/backend/hexa/user_management/utils.py
+++ b/backend/hexa/user_management/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from itertools import chain
 from urllib.parse import urlencode
 
 from django.conf import settings
@@ -7,7 +8,16 @@ from django_otp import devices_for_user, user_has_device
 
 from hexa.analytics.api import track
 from hexa.core.utils import get_email_attachments, send_mail
-from hexa.user_management.models import Organization, ServiceAccount
+from hexa.user_management.models import (
+    Organization,
+    OrganizationInvitation,
+    OrganizationInvitationStatus,
+    ServiceAccount,
+    SignupRequest,
+    SignupRequestStatus,
+    User,
+)
+from hexa.workspaces.models import WorkspaceInvitation, WorkspaceInvitationStatus
 
 USER_DEFAULT_DEVICE_ATTR_NAME = "_default_device"
 DEVICE_DEFAULT_NAME = "default"
@@ -128,3 +138,20 @@ def send_signup_email(signup_request):
             "email": signup_request.email,
         },
     )
+
+
+def accept_pending_invitations(user: User):
+    """Accept all pending invitations matching the user's email."""
+    pending_invitations = chain(
+        WorkspaceInvitation.objects.filter(
+            email=user.email, status=WorkspaceInvitationStatus.PENDING
+        ),
+        OrganizationInvitation.objects.filter(
+            email=user.email, status=OrganizationInvitationStatus.PENDING
+        ),
+        SignupRequest.objects.filter(
+            email=user.email, status=SignupRequestStatus.PENDING
+        ),
+    )
+    for invitation in pending_invitations:
+        invitation.accept(user)

--- a/backend/hexa/workspaces/models.py
+++ b/backend/hexa/workspaces/models.py
@@ -515,10 +515,11 @@ class WorkspaceInvitation(Invitation):
 
     def accept(self, user: User):
         """Accept the invitation and create workspace membership."""
-        WorkspaceMembership.objects.create(
+        # get_or_create in case the user is already a member
+        WorkspaceMembership.objects.get_or_create(
             workspace=self.workspace,
             user=user,
-            role=self.role,
+            defaults={"role": self.role},
         )
         self.status = WorkspaceInvitationStatus.ACCEPTED
         self.save()


### PR DESCRIPTION
This PR adds a helper to accept all pending invitations and uses it whenever a new user is created.

### Changes

It is used whenever a new user is created. More specifically, this means:
- when a user registers via user/pass
- when a user is created via SSO login

### How to test

- CIAM account creation after a workspace invitation should arrive directly on the workspace
- Regular signup with or without invitation should be unaffected