### PR TITLE
fix:allow re-publishing pipeline after deletion

### DIFF
--- a/backend/hexa/pipelines/schema/types.py
+++ b/backend/hexa/pipelines/schema/types.py
@@ -171,9 +171,11 @@ def resolve_pipeline_permissions_create_template_version(
     user_has_permission = request.user.is_authenticated and request.user.has_perm(
         "pipeline_templates.create_pipeline_template_version", pipeline.workspace
     )
-    current_version_has_template = pipeline.last_version and hasattr(
-        pipeline.last_version, "template_version"
-    ) and not pipeline.last_version.template_version.template.is_deleted
+    current_version_has_template = (
+        pipeline.last_version
+        and hasattr(pipeline.last_version, "template_version")
+        and not pipeline.last_version.template_version.template.is_deleted
+    )
     pipeline_is_created_from_a_template = pipeline.source_template
     pipeline_is_notebook = pipeline.type == PipelineType.NOTEBOOK
     is_allowed = (

--- a/backend/hexa/pipelines/schema/types.py
+++ b/backend/hexa/pipelines/schema/types.py
@@ -173,7 +173,7 @@ def resolve_pipeline_permissions_create_template_version(
     )
     current_version_has_template = pipeline.last_version and hasattr(
         pipeline.last_version, "template_version"
-    )
+    ) and not pipeline.last_version.template_version.template.is_deleted
     pipeline_is_created_from_a_template = pipeline.source_template
     pipeline_is_notebook = pipeline.type == PipelineType.NOTEBOOK
     is_allowed = (

--- a/backend/hexa/pipelines/tests/test_schema/test_pipelines.py
+++ b/backend/hexa/pipelines/tests/test_schema/test_pipelines.py
@@ -68,8 +68,9 @@ class PipelinesV2Test(GraphQLTestCase):
             "standardpassword",
         )
 
-        with patch("hexa.workspaces.models.create_database"), patch(
-            "hexa.workspaces.models.load_database_sample_data"
+        with (
+            patch("hexa.workspaces.models.create_database"),
+            patch("hexa.workspaces.models.load_database_sample_data"),
         ):
             cls.WS1 = Workspace.objects.create_if_has_perm(
                 cls.USER_ROOT,

--- a/backend/hexa/pipelines/tests/test_schema/test_pipelines.py
+++ b/backend/hexa/pipelines/tests/test_schema/test_pipelines.py
@@ -3099,6 +3099,11 @@ def test_pipeline(input_file, threshold, enable_debug):
         self.assertFalse(
             r["data"]["pipeline"]["permissions"]["createTemplateVersion"]["isAllowed"]
         )
+        template.delete()
+        r = self._get_pipeline(source_pipeline.id)
+        self.assertTrue(
+            r["data"]["pipeline"]["permissions"]["createTemplateVersion"]["isAllowed"]
+        )
 
     def test_upload_pipeline_with_valid_tags(self):
         self.client.force_login(self.USER_ROOT)


### PR DESCRIPTION
When a pipeline template is soft-deleted, its PipelineTemplateVersion rows are not removed. The createTemplateVersion permission check was seeing the stale relation and blocking the button permanently.

Fixed by skipping the relation when the linked template's deleted_at is set, so the permission is correctly reenabled after deletion.