### PR TITLE
test: sql security guards

### DIFF
--- a/backend/hexa/databases/tests/test_utils.py
+++ b/backend/hexa/databases/tests/test_utils.py
@@ -1,3 +1,4 @@
+import unittest
 from unittest import mock
 
 from psycopg2.errors import InsufficientPrivilege, QueryCanceled, UndefinedTable
@@ -11,6 +12,7 @@ from hexa.databases.utils import (
     TableNotFound,
     TableRowsPage,
     delete_table,
+    ensure_single_statement,
     execute_database_query,
     get_database_definition,
     get_row_count,
@@ -44,6 +46,58 @@ def dictrow_from_dict(my_dict):
         dict_row[k] = v
 
     return dict_row
+
+
+class EnsureSingleStatementTest(unittest.TestCase):
+    """Direct coverage of ensure_single_statement.
+
+    This single check is load-bearing for two separate guarantees of the
+    executeSQL endpoint:
+
+      1. The per-call statement_timeout cannot be defeated, because the only way
+         to raise it is to run `SET statement_timeout = ...` as a *separate*
+         statement before the query (statement_timeout is a USERSET GUC).
+      2. No write/DDL can be smuggled in alongside a read (the role blocks the
+         write itself, but stacking is the first line of defence).
+
+    Both rely entirely on sqlparse splitting statements exactly the way
+    PostgreSQL does. sqlparse is a third-party parser pinned in requirements.txt;
+    an upgrade could silently change its splitting of dollar-quotes, string
+    literals or comments and quietly weaken the endpoint. These tests turn that
+    parser-version dependency into something CI will catch -- they don't need a
+    database, so they stay fast.
+    """
+
+    def test_allows_single_statements_with_embedded_semicolons(self):
+        # Semicolons inside string literals, dollar-quoted bodies, and trailing
+        # comments must NOT be mistaken for statement separators.
+        allowed = [
+            "SELECT 1 AS id;",
+            "SELECT 'a;b' AS x",
+            "SELECT $tag$ a ; b ; c $tag$ AS x",
+            "SELECT 1 AS id; -- SELECT pg_sleep(3)",
+            "DO $$ BEGIN PERFORM 1; PERFORM 2; END $$;",
+        ]
+        for query in allowed:
+            with self.subTest(query=query):
+                ensure_single_statement(query)
+
+    def test_rejects_stacked_statements(self):
+        # The security-critical case is the first one: a SET that would disable
+        # the timeout, followed by an unbounded query. The rest are syntactic
+        # variations that must not slip a second statement past the parser.
+        rejected = [
+            "SET statement_timeout = 0; SELECT pg_sleep(3)",
+            "SELECT 1;SELECT 2",
+            "SET statement_timeout = 0\n;\nSELECT pg_sleep(3)",
+            "SET statement_timeout = 0 /* ; */ ; SELECT pg_sleep(3)",
+            "SELECT $tag$ x $tag$; SELECT pg_sleep(3)",
+            "SELECT 'a;b'; SELECT pg_sleep(3)",
+        ]
+        for query in rejected:
+            with self.subTest(query=query):
+                with self.assertRaises(MultipleStatementsError):
+                    ensure_single_statement(query)
 
 
 class GetRowCountTest(TestCase):
@@ -341,3 +395,54 @@ class DatabaseUtilsTest(TestCase):
 
         self.assertEqual(1, result["row_count"])
         self.assertEqual([{"id": 1}], result["rows"])
+
+    def test_execute_database_query_timeout_cannot_be_disabled_by_query(self):
+        """The per-call timeout cannot be disabled from within the query.
+
+        The timeout is the only thing bounding how long a single (possibly
+        AI-generated and untrusted) query can run. statement_timeout is a USERSET
+        GUC, so the read-only role is technically allowed to raise it -- the only
+        reason it can't is that ensure_single_statement forbids running a SET
+        *before* the query. This guards the remaining escape hatch: changing the
+        timeout from *within* the single executing statement. PostgreSQL arms the
+        timer once at statement start and never re-reads the GUC mid-statement, so
+        none of these tricks extends the deadline. If a future change (e.g. running
+        in autocommit, or committing between the SET LOCAL and the query) ever broke
+        that, these would start hanging instead of cancelling.
+        """
+        bypass_attempts = [
+            # Flip the GUC in the SELECT target list, then sleep in the same statement.
+            "SELECT set_config('statement_timeout', '0', false), pg_sleep(3);",
+            "SELECT set_config('statement_timeout', '0', true), pg_sleep(3);",
+            # Flip it inside an anonymous code block (a single top-level statement).
+            "DO $$ BEGIN PERFORM set_config('statement_timeout', '0', false); "
+            "PERFORM pg_sleep(3); END $$;",
+            "DO $$ BEGIN SET LOCAL statement_timeout = 0; PERFORM pg_sleep(3); END $$;",
+        ]
+        for statement in bypass_attempts:
+            with self.subTest(statement=statement):
+                with self.assertRaises(QueryCanceled):
+                    execute_database_query(self.WORKSPACE, statement, timeout_ms=100)
+
+    def test_execute_database_query_blocks_filesystem_and_credential_access(self):
+        """The read-only role cannot reach the host or other roles' credentials.
+
+        The read-only role is the real security boundary for this endpoint (we
+        deliberately rely on Postgres privileges rather than parsing/allowlisting
+        the SQL). test_execute_database_query_is_read_only covers writes; this
+        covers the higher-impact escalation vectors -- reaching the host
+        filesystem, executing OS programs, or reading other roles' credentials.
+        If the role provisioning in api.py or a future migration ever granted one
+        of these (e.g. pg_read_server_files, pg_execute_server_program), this fails.
+        """
+        escalation_attempts = [
+            "COPY demo TO PROGRAM 'cat';",
+            "COPY demo FROM '/etc/passwd';",
+            "SELECT pg_read_file('/etc/passwd');",
+            "SELECT * FROM pg_authid;",
+        ]
+        seed_demo_table(self.WORKSPACE, [(1, "a")])
+        for statement in escalation_attempts:
+            with self.subTest(statement=statement):
+                with self.assertRaises(InsufficientPrivilege):
+                    execute_database_query(self.WORKSPACE, statement)


### PR DESCRIPTION
Some security guards' confirmation on the Data Studio endpoint for the read-only SQL user (confirm that the SQL is not "hackable" by the AI agents):

1. Ensure single statement tests (stacked segments and enbedded semicolons)
2. Ensure statement timeout cannot be disabled from the query itself
3. Ensure queries block file system