### PR TITLE
feat: mcp tools get dbschema and dbtable schema

### DIFF
--- a/backend/hexa/databases/schema.py
+++ b/backend/hexa/databases/schema.py
@@ -11,14 +11,13 @@ from django.http import HttpRequest
 from psycopg2 import Error as Psycopg2Error
 from psycopg2.errors import QueryCanceled
 
-from hexa.core.graphql import result_page
 from hexa.workspaces.models import Workspace
 
 from .utils import (
     MultipleStatementsError,
     OrderByDirectionEnum,
     execute_database_query,
-    get_database_definition,
+    get_database_definition_page,
     get_table_definition,
     get_table_rows,
     get_table_sample_data,
@@ -38,10 +37,9 @@ order_by_direction_enum = EnumType("OrderByDirection", OrderByDirectionEnum)
 
 @database_object.field("tables")
 def resolve_database_tables(workspace, info, page=1, per_page=15, **kwargs):
-    tables = get_database_definition(
-        workspace=workspace,
+    return get_database_definition_page(
+        workspace=workspace, page=page, per_page=per_page
     )
-    return result_page(tables, page=page, per_page=per_page)
 
 
 @database_object.field("table")

--- a/backend/hexa/databases/tests/helpers.py
+++ b/backend/hexa/databases/tests/helpers.py
@@ -1,16 +1,23 @@
+from psycopg2 import sql
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 from hexa.databases.utils import get_workspace_database_connection
 
 
-def seed_demo_table(workspace, rows):
-    """Create a `demo` table on the workspace database using the read-write role."""
+def seed_demo_table(workspace, rows, table_name="demo"):
+    """Create a demo table on the workspace database using the read-write role."""
     conn = get_workspace_database_connection(workspace)
     conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    table = sql.Identifier(table_name)
     try:
         with conn.cursor() as cursor:
-            cursor.execute("DROP TABLE IF EXISTS demo;")
-            cursor.execute("CREATE TABLE demo (id int, label text);")
-            cursor.executemany("INSERT INTO demo (id, label) VALUES (%s, %s);", rows)
+            cursor.execute(sql.SQL("DROP TABLE IF EXISTS {};").format(table))
+            cursor.execute(
+                sql.SQL("CREATE TABLE {} (id int, label text);").format(table)
+            )
+            cursor.executemany(
+                sql.SQL("INSERT INTO {} (id, label) VALUES (%s, %s);").format(table),
+                rows,
+            )
     finally:
         conn.close()

--- a/backend/hexa/databases/tests/test_schema.py
+++ b/backend/hexa/databases/tests/test_schema.py
@@ -127,9 +127,14 @@ class DatabaseTest(GraphQLTestCase):
     def test_get_database_tables_empty(self):
         self.client.force_login(self.USER_SABRINA)
         with mock.patch(
-            "hexa.databases.schema.get_database_definition"
+            "hexa.databases.schema.get_database_definition_page"
         ) as mocked_get_database_definition:
-            mocked_get_database_definition.return_value = []
+            mocked_get_database_definition.return_value = {
+                "page_number": 1,
+                "total_pages": 1,
+                "total_items": 0,
+                "items": [],
+            }
             r = self.run_query(
                 """
                 query workspaceById($slug: String!) {
@@ -156,11 +161,16 @@ class DatabaseTest(GraphQLTestCase):
         table_name = "test_table"
         count = 2
         with mock.patch(
-            "hexa.databases.schema.get_database_definition"
+            "hexa.databases.schema.get_database_definition_page"
         ) as mocked_get_database_definition:
-            mocked_get_database_definition.return_value = [
-                {"workspace": self.WORKSPACE, "name": table_name, "count": count}
-            ]
+            mocked_get_database_definition.return_value = {
+                "page_number": 1,
+                "total_pages": 1,
+                "total_items": 1,
+                "items": [
+                    {"workspace": self.WORKSPACE, "name": table_name, "count": count}
+                ],
+            }
 
             r = self.run_query(
                 """

--- a/backend/hexa/databases/tests/test_utils.py
+++ b/backend/hexa/databases/tests/test_utils.py
@@ -210,6 +210,17 @@ class DatabaseUtilsTest(TestCase):
         self.assertEqual([], result["items"])
         self.assertGreaterEqual(result["total_items"], 1)
 
+    def test_get_database_definition_page_clamps_arguments(self):
+        seed_demo_table(self.WORKSPACE, [(1, "a")])
+
+        # Zero, negative or null page/per_page must not reach LIMIT/OFFSET
+        for page, per_page in [(0, 0), (-1, -5), (None, None)]:
+            result = get_database_definition_page(
+                self.WORKSPACE, page=page, per_page=per_page
+            )
+            self.assertEqual(1, result["page_number"])
+            self.assertEqual(1, len(result["items"]))
+
     @mock.patch("psycopg2.connect")
     def test_get_table_definition(self, mock_connect):
         table_name = "database_tutorial"

--- a/backend/hexa/databases/tests/test_utils.py
+++ b/backend/hexa/databases/tests/test_utils.py
@@ -15,6 +15,7 @@ from hexa.databases.utils import (
     ensure_single_statement,
     execute_database_query,
     get_database_definition,
+    get_database_definition_page,
     get_row_count,
     get_table_definition,
     get_table_rows,
@@ -186,6 +187,28 @@ class DatabaseUtilsTest(TestCase):
 
         self.assertEqual(1, len(result))
         self.assertEqual(table_name, result[0]["name"])
+
+    def test_get_database_definition_page(self):
+        seed_demo_table(self.WORKSPACE, [(1, "a")])
+        seed_demo_table(self.WORKSPACE, [(1, "a"), (2, "b")], table_name="demo_2")
+
+        result = get_database_definition_page(self.WORKSPACE, page=2, per_page=1)
+
+        self.assertEqual(2, result["page_number"])
+        self.assertEqual(2, result["total_pages"])
+        self.assertEqual(2, result["total_items"])
+        self.assertEqual(
+            [{"workspace": self.WORKSPACE, "name": "demo_2", "count": 2}],
+            result["items"],
+        )
+
+    def test_get_database_definition_page_out_of_range(self):
+        seed_demo_table(self.WORKSPACE, [(1, "a")])
+
+        result = get_database_definition_page(self.WORKSPACE, page=10, per_page=15)
+
+        self.assertEqual([], result["items"])
+        self.assertGreaterEqual(result["total_items"], 1)
 
     @mock.patch("psycopg2.connect")
     def test_get_table_definition(self, mock_connect):

--- a/backend/hexa/databases/utils.py
+++ b/backend/hexa/databases/utils.py
@@ -212,8 +212,10 @@ _TABLES_FROM_CLAUSE = """
 def get_database_definition_page(
     workspace: Workspace, page: int = 1, per_page: int = 15
 ):
-    if per_page > settings.GRAPHQL_MAX_PAGE_SIZE:
-        per_page = settings.GRAPHQL_MAX_PAGE_SIZE
+    # Clamp caller-provided values: a GraphQL client can send any Int (or an
+    # explicit null), and negative/zero values would end up in LIMIT/OFFSET.
+    page = max(page or 1, 1)
+    per_page = min(max(per_page or 1, 1), settings.GRAPHQL_MAX_PAGE_SIZE)
     conn = None
     try:
         conn = get_workspace_database_connection(workspace)

--- a/backend/hexa/databases/utils.py
+++ b/backend/hexa/databases/utils.py
@@ -1,5 +1,6 @@
 import enum
 import json
+import math
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
@@ -187,6 +188,66 @@ def get_database_definition(workspace: Workspace):
                 data["count"] = get_row_count(cursor, name, data["count"])
                 result.append({"workspace": workspace, **data})
             return result
+    finally:
+        if conn:
+            conn.close()
+
+
+# Filtering, ordering and slicing happen in SQL, and row counts are only
+# computed for the tables of the requested page, so that listing tables stays
+# cheap on workspaces with many (potentially large) tables.
+_TABLES_FROM_CLAUSE = """
+    FROM information_schema.tables
+    JOIN pg_class ON information_schema.tables.table_name = pg_class.relname
+    JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.oid
+        AND pg_namespace.nspname = information_schema.tables.table_schema
+    WHERE
+        table_schema = 'public'
+        -- Exclude child tables from inheritance hierarchies (e.g., partition children)
+        AND pg_class.oid NOT IN (SELECT inhrelid FROM pg_inherits)
+        AND table_name <> ALL(%(ignore_tables)s)
+"""
+
+
+def get_database_definition_page(
+    workspace: Workspace, page: int = 1, per_page: int = 15
+):
+    if per_page > settings.GRAPHQL_MAX_PAGE_SIZE:
+        per_page = settings.GRAPHQL_MAX_PAGE_SIZE
+    conn = None
+    try:
+        conn = get_workspace_database_connection(workspace)
+        with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+            cursor.execute(
+                "SELECT COUNT(*) AS total" + _TABLES_FROM_CLAUSE,
+                {"ignore_tables": IGNORE_TABLES},
+            )
+            total_items = cursor.fetchone()["total"]
+
+            cursor.execute(
+                "SELECT table_name AS name, pg_class.reltuples AS count"
+                + _TABLES_FROM_CLAUSE
+                + "ORDER BY table_name LIMIT %(limit)s OFFSET %(offset)s",
+                {
+                    "ignore_tables": IGNORE_TABLES,
+                    "limit": per_page,
+                    "offset": (page - 1) * per_page,
+                },
+            )
+            items = [
+                {
+                    "workspace": workspace,
+                    "name": row["name"],
+                    "count": get_row_count(cursor, row["name"], row["count"]),
+                }
+                for row in cursor.fetchall()
+            ]
+        return {
+            "page_number": page,
+            "total_pages": max(math.ceil(total_items / per_page), 1),
+            "total_items": total_items,
+            "items": items,
+        }
     finally:
         if conn:
             conn.close()

--- a/backend/hexa/mcp/graphql/databases.graphql
+++ b/backend/hexa/mcp/graphql/databases.graphql
@@ -1,0 +1,30 @@
+query GetDatabaseTables($workspaceSlug: String!, $page: Int, $perPage: Int) {
+  workspace(slug: $workspaceSlug) {
+    database {
+      tables(page: $page, perPage: $perPage) {
+        pageNumber
+        totalPages
+        totalItems
+        items {
+          name
+          count
+        }
+      }
+    }
+  }
+}
+
+query GetDatabaseTable($workspaceSlug: String!, $tableName: String!) {
+  workspace(slug: $workspaceSlug) {
+    database {
+      table(name: $tableName) {
+        name
+        count
+        columns {
+          name
+          type
+        }
+      }
+    }
+  }
+}

--- a/backend/hexa/mcp/tests/test_databases.py
+++ b/backend/hexa/mcp/tests/test_databases.py
@@ -1,0 +1,112 @@
+from unittest.mock import patch
+
+from hexa.mcp.tools.databases import get_db_schema, get_db_table_schema
+
+from .testutils import MCPTestCase
+
+TABLES = [
+    {"name": "patients", "count": 1000, "workspace": object()},
+    {"name": "visits", "count": 5000, "workspace": object()},
+]
+
+PATIENTS_DEF = {
+    "name": "patients",
+    "count": 1000,
+    "workspace": object(),
+    "columns": [
+        {"name": "id", "type": "integer"},
+        {"name": "name", "type": "text"},
+        {"name": "dob", "type": "date"},
+    ],
+}
+
+
+class GetDbSchemaTest(MCPTestCase):
+    def test_get_db_schema(self):
+        with patch(
+            "hexa.mcp.tools.databases.get_database_definition", return_value=TABLES
+        ):
+            result = get_db_schema(
+                user=self.USER_ADMIN, workspace_slug=self.WORKSPACE.slug
+            )
+
+        tables = result["tables"]
+        self.assertEqual(len(tables), 2)
+        self.assertEqual(tables[0]["name"], "patients")
+        self.assertEqual(tables[0]["count"], 1000)
+        self.assertEqual(tables[1]["name"], "visits")
+
+    def test_get_db_schema_workspace_not_found(self):
+        result = get_db_schema(user=self.USER_ADMIN, workspace_slug="nonexistent")
+        self.assertEqual(result, {"error": "Workspace not found"})
+
+    def test_get_db_schema_no_access(self):
+        result = get_db_schema(
+            user=self.USER_OUTSIDER, workspace_slug=self.WORKSPACE.slug
+        )
+        self.assertEqual(result, {"error": "Workspace not found"})
+
+    def test_get_db_schema_viewer_can_access(self):
+        with patch(
+            "hexa.mcp.tools.databases.get_database_definition", return_value=TABLES
+        ):
+            result = get_db_schema(
+                user=self.USER_VIEWER, workspace_slug=self.WORKSPACE.slug
+            )
+        self.assertIn("tables", result)
+
+
+class GetDbTableSchemaTest(MCPTestCase):
+    def test_get_db_table_schema(self):
+        with patch(
+            "hexa.mcp.tools.databases.get_table_definition", return_value=PATIENTS_DEF
+        ):
+            result = get_db_table_schema(
+                user=self.USER_ADMIN,
+                workspace_slug=self.WORKSPACE.slug,
+                table_name="patients",
+            )
+
+        self.assertEqual(result["name"], "patients")
+        self.assertEqual(result["count"], 1000)
+        columns = result["columns"]
+        self.assertEqual(len(columns), 3)
+        self.assertEqual(columns[0], {"name": "id", "type": "integer"})
+
+    def test_get_db_table_schema_table_not_found(self):
+        with patch(
+            "hexa.mcp.tools.databases.get_table_definition", return_value=None
+        ):
+            result = get_db_table_schema(
+                user=self.USER_ADMIN,
+                workspace_slug=self.WORKSPACE.slug,
+                table_name="nonexistent",
+            )
+        self.assertEqual(result, {"error": "Table 'nonexistent' not found"})
+
+    def test_get_db_table_schema_workspace_not_found(self):
+        result = get_db_table_schema(
+            user=self.USER_ADMIN,
+            workspace_slug="nonexistent",
+            table_name="patients",
+        )
+        self.assertEqual(result, {"error": "Workspace not found"})
+
+    def test_get_db_table_schema_no_access(self):
+        result = get_db_table_schema(
+            user=self.USER_OUTSIDER,
+            workspace_slug=self.WORKSPACE.slug,
+            table_name="patients",
+        )
+        self.assertEqual(result, {"error": "Workspace not found"})
+
+    def test_get_db_table_schema_viewer_can_access(self):
+        with patch(
+            "hexa.mcp.tools.databases.get_table_definition", return_value=PATIENTS_DEF
+        ):
+            result = get_db_table_schema(
+                user=self.USER_VIEWER,
+                workspace_slug=self.WORKSPACE.slug,
+                table_name="patients",
+            )
+        self.assertIn("columns", result)

--- a/backend/hexa/mcp/tests/test_databases.py
+++ b/backend/hexa/mcp/tests/test_databases.py
@@ -74,9 +74,7 @@ class GetDbTableSchemaTest(MCPTestCase):
         self.assertEqual(columns[0], {"name": "id", "type": "integer"})
 
     def test_get_db_table_schema_table_not_found(self):
-        with patch(
-            "hexa.mcp.tools.databases.get_table_definition", return_value=None
-        ):
+        with patch("hexa.mcp.tools.databases.get_table_definition", return_value=None):
             result = get_db_table_schema(
                 user=self.USER_ADMIN,
                 workspace_slug=self.WORKSPACE.slug,

--- a/backend/hexa/mcp/tests/test_databases.py
+++ b/backend/hexa/mcp/tests/test_databases.py
@@ -1,40 +1,67 @@
-from unittest.mock import patch
-
+from hexa.core.test import TestCase
+from hexa.databases.tests.helpers import seed_demo_table
 from hexa.mcp.tools.databases import get_db_schema, get_db_table_schema
-
-from .testutils import MCPTestCase
-
-TABLES = [
-    {"name": "patients", "count": 1000, "workspace": object()},
-    {"name": "visits", "count": 5000, "workspace": object()},
-]
-
-PATIENTS_DEF = {
-    "name": "patients",
-    "count": 1000,
-    "workspace": object(),
-    "columns": [
-        {"name": "id", "type": "integer"},
-        {"name": "name", "type": "text"},
-        {"name": "dob", "type": "date"},
-    ],
-}
+from hexa.user_management.models import User
+from hexa.workspaces.models import (
+    Workspace,
+    WorkspaceMembership,
+    WorkspaceMembershipRole,
+)
 
 
-class GetDbSchemaTest(MCPTestCase):
+# These tools query the workspace database through the GraphQL layer, so unlike
+# MCPTestCase (which patches database creation away) we need a workspace backed
+# by a real database that we can seed with a demo table.
+class DatabaseToolsTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.USER_ADMIN = User.objects.create_user(
+            "admin@openhexa.org", "password", is_superuser=True
+        )
+        cls.USER_VIEWER = User.objects.create_user("viewer@openhexa.org", "password")
+        cls.USER_OUTSIDER = User.objects.create_user(
+            "outsider@openhexa.org", "password"
+        )
+
+        cls.WORKSPACE = Workspace.objects.create_if_has_perm(
+            cls.USER_ADMIN,
+            name="Test Workspace",
+            description="A test workspace",
+        )
+
+        WorkspaceMembership.objects.create(
+            workspace=cls.WORKSPACE,
+            user=cls.USER_VIEWER,
+            role=WorkspaceMembershipRole.VIEWER,
+        )
+
+
+class GetDbSchemaTest(DatabaseToolsTestCase):
     def test_get_db_schema(self):
-        with patch(
-            "hexa.mcp.tools.databases.get_database_definition", return_value=TABLES
-        ):
-            result = get_db_schema(
-                user=self.USER_ADMIN, workspace_slug=self.WORKSPACE.slug
-            )
+        seed_demo_table(self.WORKSPACE, [(1, "a"), (2, "b"), (3, "c")])
 
-        tables = result["tables"]
-        self.assertEqual(len(tables), 2)
-        self.assertEqual(tables[0]["name"], "patients")
-        self.assertEqual(tables[0]["count"], 1000)
-        self.assertEqual(tables[1]["name"], "visits")
+        result = get_db_schema(user=self.USER_ADMIN, workspace_slug=self.WORKSPACE.slug)
+
+        self.assertEqual([{"name": "demo", "count": 3}], result["tables"])
+        self.assertEqual(1, result["pageNumber"])
+        self.assertEqual(1, result["totalPages"])
+        self.assertEqual(1, result["totalItems"])
+
+    def test_get_db_schema_pagination(self):
+        seed_demo_table(self.WORKSPACE, [(1, "a")])
+        seed_demo_table(self.WORKSPACE, [(1, "a"), (2, "b")], table_name="demo_2")
+
+        result = get_db_schema(
+            user=self.USER_ADMIN,
+            workspace_slug=self.WORKSPACE.slug,
+            page=2,
+            per_page=1,
+        )
+
+        self.assertEqual([{"name": "demo_2", "count": 2}], result["tables"])
+        self.assertEqual(2, result["pageNumber"])
+        self.assertEqual(2, result["totalPages"])
+        self.assertEqual(2, result["totalItems"])
 
     def test_get_db_schema_workspace_not_found(self):
         result = get_db_schema(user=self.USER_ADMIN, workspace_slug="nonexistent")
@@ -47,46 +74,52 @@ class GetDbSchemaTest(MCPTestCase):
         self.assertEqual(result, {"error": "Workspace not found"})
 
     def test_get_db_schema_viewer_can_access(self):
-        with patch(
-            "hexa.mcp.tools.databases.get_database_definition", return_value=TABLES
-        ):
-            result = get_db_schema(
-                user=self.USER_VIEWER, workspace_slug=self.WORKSPACE.slug
-            )
-        self.assertIn("tables", result)
+        seed_demo_table(self.WORKSPACE, [(1, "a")])
+
+        result = get_db_schema(
+            user=self.USER_VIEWER, workspace_slug=self.WORKSPACE.slug
+        )
+
+        # The workspace database is not rolled back between tests, so other
+        # tables seeded by sibling tests may still exist.
+        self.assertIn({"name": "demo", "count": 1}, result["tables"])
 
 
-class GetDbTableSchemaTest(MCPTestCase):
+class GetDbTableSchemaTest(DatabaseToolsTestCase):
     def test_get_db_table_schema(self):
-        with patch(
-            "hexa.mcp.tools.databases.get_table_definition", return_value=PATIENTS_DEF
-        ):
-            result = get_db_table_schema(
-                user=self.USER_ADMIN,
-                workspace_slug=self.WORKSPACE.slug,
-                table_name="patients",
-            )
+        seed_demo_table(self.WORKSPACE, [(1, "a"), (2, "b"), (3, "c")])
 
-        self.assertEqual(result["name"], "patients")
-        self.assertEqual(result["count"], 1000)
-        columns = result["columns"]
-        self.assertEqual(len(columns), 3)
-        self.assertEqual(columns[0], {"name": "id", "type": "integer"})
+        result = get_db_table_schema(
+            user=self.USER_ADMIN,
+            workspace_slug=self.WORKSPACE.slug,
+            table_name="demo",
+        )
+
+        self.assertEqual(
+            {
+                "name": "demo",
+                "count": 3,
+                "columns": [
+                    {"name": "id", "type": "integer"},
+                    {"name": "label", "type": "text"},
+                ],
+            },
+            result,
+        )
 
     def test_get_db_table_schema_table_not_found(self):
-        with patch("hexa.mcp.tools.databases.get_table_definition", return_value=None):
-            result = get_db_table_schema(
-                user=self.USER_ADMIN,
-                workspace_slug=self.WORKSPACE.slug,
-                table_name="nonexistent",
-            )
+        result = get_db_table_schema(
+            user=self.USER_ADMIN,
+            workspace_slug=self.WORKSPACE.slug,
+            table_name="nonexistent",
+        )
         self.assertEqual(result, {"error": "Table 'nonexistent' not found"})
 
     def test_get_db_table_schema_workspace_not_found(self):
         result = get_db_table_schema(
             user=self.USER_ADMIN,
             workspace_slug="nonexistent",
-            table_name="patients",
+            table_name="demo",
         )
         self.assertEqual(result, {"error": "Workspace not found"})
 
@@ -94,17 +127,18 @@ class GetDbTableSchemaTest(MCPTestCase):
         result = get_db_table_schema(
             user=self.USER_OUTSIDER,
             workspace_slug=self.WORKSPACE.slug,
-            table_name="patients",
+            table_name="demo",
         )
         self.assertEqual(result, {"error": "Workspace not found"})
 
     def test_get_db_table_schema_viewer_can_access(self):
-        with patch(
-            "hexa.mcp.tools.databases.get_table_definition", return_value=PATIENTS_DEF
-        ):
-            result = get_db_table_schema(
-                user=self.USER_VIEWER,
-                workspace_slug=self.WORKSPACE.slug,
-                table_name="patients",
-            )
-        self.assertIn("columns", result)
+        seed_demo_table(self.WORKSPACE, [(1, "a")])
+
+        result = get_db_table_schema(
+            user=self.USER_VIEWER,
+            workspace_slug=self.WORKSPACE.slug,
+            table_name="demo",
+        )
+
+        self.assertEqual("demo", result["name"])
+        self.assertEqual(2, len(result["columns"]))

--- a/backend/hexa/mcp/tools/__init__.py
+++ b/backend/hexa/mcp/tools/__init__.py
@@ -1,5 +1,6 @@
 from hexa.mcp.tools import (  # noqa: F401
     connections,
+    databases,
     datasets,
     files,
     help,

--- a/backend/hexa/mcp/tools/databases.py
+++ b/backend/hexa/mcp/tools/databases.py
@@ -1,0 +1,31 @@
+from hexa.databases.utils import get_database_definition, get_table_definition
+from hexa.mcp.protocol import tool
+from hexa.workspaces.models import Workspace
+
+
+@tool
+def get_db_schema(user, workspace_slug: str) -> dict:
+    """List all tables in the workspace database with their names and approximate row counts. Use this to get an overview of what data is available. Does not return actual table contents or row data."""
+    try:
+        workspace = Workspace.objects.filter_for_user(user).get(slug=workspace_slug)
+    except Workspace.DoesNotExist:
+        return {"error": "Workspace not found"}
+    tables = get_database_definition(workspace)
+    return {"tables": [{"name": t["name"], "count": t["count"]} for t in tables]}
+
+
+@tool
+def get_db_table_schema(user, workspace_slug: str, table_name: str) -> dict:
+    """Get column definitions for a specific table in the workspace database. Returns column names and PostgreSQL data types. Use this to understand the table structure before writing SQL queries."""
+    try:
+        workspace = Workspace.objects.filter_for_user(user).get(slug=workspace_slug)
+    except Workspace.DoesNotExist:
+        return {"error": "Workspace not found"}
+    table = get_table_definition(workspace, table_name)
+    if table is None:
+        return {"error": f"Table '{table_name}' not found"}
+    return {
+        "name": table["name"],
+        "count": table["count"],
+        "columns": [{"name": c["name"], "type": c["type"]} for c in table["columns"]],
+    }

--- a/backend/hexa/mcp/tools/databases.py
+++ b/backend/hexa/mcp/tools/databases.py
@@ -1,31 +1,44 @@
-from hexa.databases.utils import get_database_definition, get_table_definition
 from hexa.mcp.protocol import tool
-from hexa.workspaces.models import Workspace
+
+from ._graphql import execute_graphql
 
 
 @tool
-def get_db_schema(user, workspace_slug: str) -> dict:
-    """List all tables in the workspace database with their names and approximate row counts. Use this to get an overview of what data is available. Does not return actual table contents or row data."""
-    try:
-        workspace = Workspace.objects.filter_for_user(user).get(slug=workspace_slug)
-    except Workspace.DoesNotExist:
+def get_db_schema(user, workspace_slug: str, page: int = 1, per_page: int = 15) -> dict:
+    """List tables in the workspace database with their names and approximate row counts. Use this to get an overview of what data is available. Results are paginated; increase page to fetch more tables. Does not return actual table contents or row data."""
+    data = execute_graphql(
+        user,
+        "GetDatabaseTables",
+        {"workspaceSlug": workspace_slug, "page": page, "perPage": per_page},
+    )
+    if "errors" in data:
+        return data
+    workspace = data.get("workspace")
+    if workspace is None:
         return {"error": "Workspace not found"}
-    tables = get_database_definition(workspace)
-    return {"tables": [{"name": t["name"], "count": t["count"]} for t in tables]}
+    tables = workspace["database"]["tables"]
+    return {
+        "tables": tables["items"],
+        "pageNumber": tables["pageNumber"],
+        "totalPages": tables["totalPages"],
+        "totalItems": tables["totalItems"],
+    }
 
 
 @tool
 def get_db_table_schema(user, workspace_slug: str, table_name: str) -> dict:
     """Get column definitions for a specific table in the workspace database. Returns column names and PostgreSQL data types. Use this to understand the table structure before writing SQL queries."""
-    try:
-        workspace = Workspace.objects.filter_for_user(user).get(slug=workspace_slug)
-    except Workspace.DoesNotExist:
+    data = execute_graphql(
+        user,
+        "GetDatabaseTable",
+        {"workspaceSlug": workspace_slug, "tableName": table_name},
+    )
+    if "errors" in data:
+        return data
+    workspace = data.get("workspace")
+    if workspace is None:
         return {"error": "Workspace not found"}
-    table = get_table_definition(workspace, table_name)
+    table = workspace["database"]["table"]
     if table is None:
         return {"error": f"Table '{table_name}' not found"}
-    return {
-        "name": table["name"],
-        "count": table["count"],
-        "columns": [{"name": c["name"], "type": c["type"]} for c in table["columns"]],
-    }
+    return table


### PR DESCRIPTION
Adds two new MCP tools for inspecting a workspace's database schema:

## Changes
get_db_schema: lists all tables with their names and row counts
get_db_table_schem :returns column names and PostgreSQL data types for a specific table
