### PR TITLE
fix: iframe webapp source url change (HEXA-1723)

### DIFF
--- a/backend/hexa/webapps/schema/mutations.py
+++ b/backend/hexa/webapps/schema/mutations.py
@@ -191,7 +191,7 @@ def resolve_update_webapp(_, info, **kwargs):
         webapp.is_public = input["is_public"]
     if "allowed_operations" in input:
         webapp.allowed_operations = input["allowed_operations"]
-    if "subdomain" in input:
+    if "subdomain" in input and input["subdomain"] is not None:
         subdomain = input["subdomain"]
         if not subdomain:
             return {"success": False, "errors": ["SUBDOMAIN_REQUIRED"], "webapp": None}

--- a/backend/hexa/webapps/tests/test_schema/test_schema.py
+++ b/backend/hexa/webapps/tests/test_schema/test_schema.py
@@ -159,6 +159,37 @@ class WebappsTest(GraphQLTestCase):
         self.assertEqual(
             "Updated Webapp", response["data"]["updateWebapp"]["webapp"]["name"]
         )
+        self.WEBAPP.refresh_from_db()
+        self.assertEqual("http://updatedwebapp.com", self.WEBAPP.url)
+
+    def test_update_iframe_webapp_url_with_null_subdomain(self):
+        """The web app form does not expose the subdomain for iframe webapps and
+        sends ``subdomain: null``; this must not block the URL update."""
+        self.client.force_login(self.USER_ROOT)
+        response = self.run_query(
+            """
+            mutation updateWebapp($input: UpdateWebappInput!) {
+                updateWebapp(input: $input) {
+                    success
+                    errors
+                    webapp {
+                        id
+                    }
+                }
+            }
+            """,
+            {
+                "input": {
+                    "id": str(self.WEBAPP.id),
+                    "subdomain": None,
+                    "source": {"iframe": {"url": "http://newurl.com"}},
+                }
+            },
+        )
+        self.assertEqual([], response["data"]["updateWebapp"]["errors"])
+        self.assertTrue(response["data"]["updateWebapp"]["success"])
+        self.WEBAPP.refresh_from_db()
+        self.assertEqual("http://newurl.com", self.WEBAPP.url)
 
     def test_update_webapp_subdomain(self):
         self.client.force_login(self.USER_ROOT)
@@ -174,7 +205,10 @@ class WebappsTest(GraphQLTestCase):
         self.WEBAPP.refresh_from_db()
         self.assertEqual(self.WEBAPP.subdomain, "my-webapp")
 
-    def test_update_webapp_subdomain_required(self):
+    def test_update_webapp_subdomain_null_is_noop(self):
+        """An explicit ``subdomain: null`` means "leave it untouched" and must
+        not error. The web app form sends it for iframe webapps that do not
+        expose a subdomain field."""
         self.client.force_login(self.USER_ROOT)
         original_subdomain = self.WEBAPP.subdomain
 
@@ -182,12 +216,14 @@ class WebappsTest(GraphQLTestCase):
             self.UPDATE_WEBAPP_SUBDOMAIN_MUTATION,
             {"input": {"id": str(self.WEBAPP.id), "subdomain": None}},
         )
-        self.assertFalse(response["data"]["updateWebapp"]["success"])
-        self.assertEqual(
-            response["data"]["updateWebapp"]["errors"], ["SUBDOMAIN_REQUIRED"]
-        )
+        self.assertEqual([], response["data"]["updateWebapp"]["errors"])
+        self.assertTrue(response["data"]["updateWebapp"]["success"])
         self.WEBAPP.refresh_from_db()
         self.assertEqual(self.WEBAPP.subdomain, original_subdomain)
+
+    def test_update_webapp_subdomain_empty_is_rejected(self):
+        self.client.force_login(self.USER_ROOT)
+        original_subdomain = self.WEBAPP.subdomain
 
         response = self.run_query(
             self.UPDATE_WEBAPP_SUBDOMAIN_MUTATION,

--- a/backend/hexa/webapps/tests/test_schema/test_schema.py
+++ b/backend/hexa/webapps/tests/test_schema/test_schema.py
@@ -236,6 +236,98 @@ class WebappsTest(GraphQLTestCase):
         self.WEBAPP.refresh_from_db()
         self.assertEqual(self.WEBAPP.subdomain, original_subdomain)
 
+    def test_update_webapp_subdomain_and_url_together(self):
+        """A single mutation updating both the subdomain and the source URL must
+        persist both changes."""
+        self.client.force_login(self.USER_ROOT)
+        response = self.run_query(
+            """
+            mutation updateWebapp($input: UpdateWebappInput!) {
+                updateWebapp(input: $input) {
+                    success
+                    errors
+                    webapp {
+                        id
+                    }
+                }
+            }
+            """,
+            {
+                "input": {
+                    "id": str(self.WEBAPP.id),
+                    "subdomain": "combined-webapp",
+                    "source": {"iframe": {"url": "http://combined.com"}},
+                }
+            },
+        )
+        self.assertEqual([], response["data"]["updateWebapp"]["errors"])
+        self.assertTrue(response["data"]["updateWebapp"]["success"])
+        self.WEBAPP.refresh_from_db()
+        self.assertEqual("combined-webapp", self.WEBAPP.subdomain)
+        self.assertEqual("http://combined.com", self.WEBAPP.url)
+
+    def test_update_webapp_url_not_persisted_when_subdomain_invalid(self):
+        """The resolver assigns the new URL before validating the subdomain. If
+        the subdomain is rejected, the whole update must fail atomically and the
+        URL must stay unchanged."""
+        self.client.force_login(self.USER_ROOT)
+        original_url = self.WEBAPP.url
+
+        response = self.run_query(
+            """
+            mutation updateWebapp($input: UpdateWebappInput!) {
+                updateWebapp(input: $input) {
+                    success
+                    errors
+                    webapp {
+                        id
+                    }
+                }
+            }
+            """,
+            {
+                "input": {
+                    "id": str(self.WEBAPP.id),
+                    "subdomain": "",
+                    "source": {"iframe": {"url": "http://should-not-persist.com"}},
+                }
+            },
+        )
+        self.assertFalse(response["data"]["updateWebapp"]["success"])
+        self.assertEqual(
+            response["data"]["updateWebapp"]["errors"], ["SUBDOMAIN_REQUIRED"]
+        )
+        self.WEBAPP.refresh_from_db()
+        self.assertEqual(original_url, self.WEBAPP.url)
+
+    def test_update_iframe_webapp_invalid_url_rejected(self):
+        self.client.force_login(self.USER_ROOT)
+        original_url = self.WEBAPP.url
+
+        response = self.run_query(
+            """
+            mutation updateWebapp($input: UpdateWebappInput!) {
+                updateWebapp(input: $input) {
+                    success
+                    errors
+                    webapp {
+                        id
+                    }
+                }
+            }
+            """,
+            {
+                "input": {
+                    "id": str(self.WEBAPP.id),
+                    "source": {"iframe": {"url": "not-a-valid-url"}},
+                }
+            },
+        )
+        self.assertFalse(response["data"]["updateWebapp"]["success"])
+        self.assertEqual(response["data"]["updateWebapp"]["errors"], ["INVALID_URL"])
+        self.WEBAPP.refresh_from_db()
+        self.assertEqual(original_url, self.WEBAPP.url)
+
     def test_update_webapp_subdomain_not_lowercase(self):
         self.client.force_login(self.USER_ROOT)
         original_subdomain = self.WEBAPP.subdomain

--- a/backend/hexa/webapps/tests/test_schema/test_schema.py
+++ b/backend/hexa/webapps/tests/test_schema/test_schema.py
@@ -164,7 +164,8 @@ class WebappsTest(GraphQLTestCase):
 
     def test_update_iframe_webapp_url_with_null_subdomain(self):
         """The web app form does not expose the subdomain for iframe webapps and
-        sends ``subdomain: null``; this must not block the URL update."""
+        sends ``subdomain: null``; this must not block the URL update.
+        """
         self.client.force_login(self.USER_ROOT)
         response = self.run_query(
             """
@@ -208,7 +209,8 @@ class WebappsTest(GraphQLTestCase):
     def test_update_webapp_subdomain_null_is_noop(self):
         """An explicit ``subdomain: null`` means "leave it untouched" and must
         not error. The web app form sends it for iframe webapps that do not
-        expose a subdomain field."""
+        expose a subdomain field.
+        """
         self.client.force_login(self.USER_ROOT)
         original_subdomain = self.WEBAPP.subdomain
 
@@ -238,7 +240,8 @@ class WebappsTest(GraphQLTestCase):
 
     def test_update_webapp_subdomain_and_url_together(self):
         """A single mutation updating both the subdomain and the source URL must
-        persist both changes."""
+        persist both changes.
+        """
         self.client.force_login(self.USER_ROOT)
         response = self.run_query(
             """
@@ -269,7 +272,8 @@ class WebappsTest(GraphQLTestCase):
     def test_update_webapp_url_not_persisted_when_subdomain_invalid(self):
         """The resolver assigns the new URL before validating the subdomain. If
         the subdomain is rejected, the whole update must fail atomically and the
-        URL must stay unchanged."""
+        URL must stay unchanged.
+        """
         self.client.force_login(self.USER_ROOT)
         original_url = self.WEBAPP.url
 

--- a/frontend/public/locales/en/messages.json
+++ b/frontend/public/locales/en/messages.json
@@ -814,6 +814,7 @@
   "Stopped": "Stopped",
   "Stopped by": "Stopped by",
   "Stopped on": "Stopped on",
+  "Subdomain is required": "Subdomain is required",
   "Subdomain must be a single label (no dots)": "Subdomain must be a single label (no dots)",
   "Subdomain must be alphanumeric with hyphens, no leading/trailing hyphens, and 63 characters or fewer": "Subdomain must be alphanumeric with hyphens, no leading/trailing hyphens, and 63 characters or fewer",
   "Subdomain must be at least 3 characters": "Subdomain must be at least 3 characters",

--- a/frontend/public/locales/fr/messages.json
+++ b/frontend/public/locales/fr/messages.json
@@ -824,6 +824,7 @@
   "Stopped": "Arrêtée",
   "Stopped by": "Arrêtée par",
   "Stopped on": "Arrêtée le",
+  "Subdomain is required": "Un sous-domaine est obligatoire",
   "Subdomain must be a single label (no dots)": "Le sous-domaine ne doit pas contenir de points",
   "Subdomain must be alphanumeric with hyphens, no leading/trailing hyphens, and 63 characters or fewer": "Le sous-domaine doit être alphanumérique avec des tirets, sans tirets en début/fin, et de 63 caractères maximum",
   "Subdomain must be at least 3 characters": "Le sous-domaine doit contenir au moins 3 caractères",

--- a/frontend/src/webapps/features/WebappForm/WebappForm.test.tsx
+++ b/frontend/src/webapps/features/WebappForm/WebappForm.test.tsx
@@ -122,4 +122,60 @@ describe("WebappForm", () => {
     });
     expect(sentInput).not.toHaveProperty("subdomain", null);
   });
+
+  it("sends the subdomain when the field is present (non-iframe webapp)", async () => {
+    const staticWebapp = {
+      ...webapp,
+      type: WebappType.Static,
+      previewUrl: null,
+    } as any;
+
+    const updateVariables = jest.fn();
+    const updateMock: MockedResponse = {
+      request: { query: UpdateWebappDocument },
+      variableMatcher: (variables) => {
+        updateVariables(variables);
+        return true;
+      },
+      result: {
+        data: {
+          updateWebapp: {
+            __typename: "UpdateWebappResult",
+            success: true,
+            errors: [],
+            webapp: {
+              __typename: "Webapp",
+              id: "webapp-1",
+              allowedOperations: [],
+              url: "https://old.example.com",
+              source: { __typename: "GitSource", publishedVersion: null },
+            },
+          },
+        },
+      },
+    };
+
+    render(
+      <TestApp mocks={[supersetInstancesMock, updateMock]}>
+        <WebappForm workspace={workspace} webapp={staticWebapp} />
+      </TestApp>,
+    );
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Save")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        "Web app updated successfully",
+      );
+    });
+
+    const sentInput = updateVariables.mock.calls[0][0].input;
+    expect(sentInput.subdomain).toBe("test-webapp");
+    expect(sentInput).not.toHaveProperty("source");
+  });
 });

--- a/frontend/src/webapps/features/WebappForm/WebappForm.test.tsx
+++ b/frontend/src/webapps/features/WebappForm/WebappForm.test.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MockedResponse } from "@apollo/client/testing";
+import { toast } from "react-toastify";
+import { TestApp } from "core/helpers/testutils";
+import { WebappType } from "graphql/types";
+import { SupersetInstancesDocument } from "webapps/graphql/queries.generated";
+import { UpdateWebappDocument } from "webapps/graphql/mutations.generated";
+import WebappForm from "./WebappForm";
+
+jest.mock("react-toastify", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock("next-i18next", () => ({
+  useTranslation: jest.fn().mockReturnValue({ t: (key: string) => key }),
+}));
+
+const workspace = {
+  __typename: "Workspace",
+  slug: "test-workspace",
+  name: "Test Workspace",
+  countries: [],
+  organization: null,
+  permissions: {
+    launchNotebookServer: false,
+    manageMembers: false,
+    update: true,
+  },
+} as any;
+
+const webapp = {
+  __typename: "Webapp",
+  id: "webapp-1",
+  slug: "test-webapp",
+  name: "Test Webapp",
+  description: "",
+  url: "https://old.example.com",
+  previewUrl: null,
+  type: WebappType.Iframe,
+  icon: null,
+  isPublic: false,
+  subdomain: "test-webapp",
+  serveUrl: "https://test-webapp.apps.openhexa.org",
+  source: null,
+  permissions: {
+    update: true,
+    delete: true,
+  },
+} as any;
+
+const supersetInstancesMock: MockedResponse = {
+  request: {
+    query: SupersetInstancesDocument,
+    variables: { workspaceSlug: "test-workspace" },
+  },
+  maxUsageCount: Infinity,
+  result: { data: { supersetInstances: [] } },
+};
+
+describe("WebappForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("updates an iframe webapp url without sending a null subdomain", async () => {
+    const updateVariables = jest.fn();
+    const updateMock: MockedResponse = {
+      request: { query: UpdateWebappDocument },
+      variableMatcher: (variables) => {
+        updateVariables(variables);
+        return true;
+      },
+      result: {
+        data: {
+          updateWebapp: {
+            __typename: "UpdateWebappResult",
+            success: true,
+            errors: [],
+            webapp: {
+              __typename: "Webapp",
+              id: "webapp-1",
+              allowedOperations: [],
+              url: "https://new.example.com",
+              source: {
+                __typename: "IframeSource",
+                url: "https://new.example.com",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    render(
+      <TestApp mocks={[supersetInstancesMock, updateMock]}>
+        <WebappForm workspace={workspace} webapp={webapp} />
+      </TestApp>,
+    );
+
+    fireEvent.click(screen.getByText("Edit"));
+
+    const urlInput = await screen.findByDisplayValue("https://old.example.com");
+    fireEvent.change(urlInput, {
+      target: { value: "https://new.example.com" },
+    });
+
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        "Web app updated successfully",
+      );
+    });
+
+    const sentInput = updateVariables.mock.calls[0][0].input;
+    expect(sentInput.source).toEqual({
+      iframe: { url: "https://new.example.com" },
+    });
+    expect(sentInput).not.toHaveProperty("subdomain", null);
+  });
+});

--- a/frontend/src/webapps/features/WebappForm/WebappForm.tsx
+++ b/frontend/src/webapps/features/WebappForm/WebappForm.tsx
@@ -98,7 +98,7 @@ const WebappForm = ({ workspace, webapp }: WebappFormProps) => {
             name: values.name,
             icon: values.icon,
             isPublic: values.isPublic,
-            subdomain: values.subdomain || null,
+            ...(values.subdomain && { subdomain: values.subdomain }),
             ...(webapp!.type !== WebappType.Static && {
               source: buildSource[webapp!.type](values),
             }),
@@ -119,6 +119,8 @@ const WebappForm = ({ workspace, webapp }: WebappFormProps) => {
           toast.error(t("Cannot change the type of an existing web app"));
         } else if (error === UpdateWebappError.InvalidUrl) {
           toast.error(t("Invalid URL. Only http and https URLs are allowed"));
+        } else if (error === UpdateWebappError.SubdomainRequired) {
+          toast.error(t("Subdomain is required"));
         } else if (error === UpdateWebappError.SubdomainNotLowercase) {
           toast.error(t("Subdomain must be lowercase"));
         } else if (error === UpdateWebappError.SubdomainTooShort) {

--- a/frontend/src/webapps/graphql/mutations.generated.tsx
+++ b/frontend/src/webapps/graphql/mutations.generated.tsx
@@ -8,7 +8,7 @@ export type UpdateWebappMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateWebappMutation = { __typename?: 'Mutation', updateWebapp: { __typename?: 'UpdateWebappResult', success: boolean, errors: Array<Types.UpdateWebappError>, webapp?: { __typename?: 'Webapp', id: string, allowedOperations: Array<Types.WebappOperationScope>, source: { __typename?: 'GitSource', publishedVersion?: string | null } | { __typename?: 'IframeSource' } | { __typename?: 'SupersetSource' } } | null } };
+export type UpdateWebappMutation = { __typename?: 'Mutation', updateWebapp: { __typename?: 'UpdateWebappResult', success: boolean, errors: Array<Types.UpdateWebappError>, webapp?: { __typename?: 'Webapp', id: string, allowedOperations: Array<Types.WebappOperationScope>, url: string, source: { __typename?: 'GitSource', publishedVersion?: string | null } | { __typename?: 'IframeSource', url: string } | { __typename?: 'SupersetSource' } } | null } };
 
 export type CreateWebappMutationVariables = Types.Exact<{
   input: Types.CreateWebappInput;
@@ -54,7 +54,11 @@ export const UpdateWebappDocument = gql`
     webapp {
       id
       allowedOperations
+      url
       source {
+        ... on IframeSource {
+          url
+        }
         ... on GitSource {
           publishedVersion
         }

--- a/frontend/src/webapps/graphql/mutations.graphql
+++ b/frontend/src/webapps/graphql/mutations.graphql
@@ -5,7 +5,11 @@ mutation UpdateWebapp($input: UpdateWebappInput!) {
     webapp {
       id
       allowedOperations
+      url
       source {
+        ... on IframeSource {
+          url
+        }
         ... on GitSource {
           publishedVersion
         }

--- a/frontend/src/webapps/tests/WorkspaceWebappPage.test.tsx
+++ b/frontend/src/webapps/tests/WorkspaceWebappPage.test.tsx
@@ -152,7 +152,6 @@ describe("WorkspaceWebappPage", () => {
                   name: "Updated Webapp",
                   icon: "",
                   isPublic: false,
-                  subdomain: null,
                   source: {
                     iframe: {
                       url: "https://updated-url.com",


### PR DESCRIPTION
When changing the source URL of an iframe webapp, actually update the URL (was failing silently)

## Changes

- Added frontend tests to webapp form
- Added backend tests to check it doesn't fail to change source url
- Added fix (problem was coming from frontend sending `subdomain` in the update web app mutation, which failed silently as it was sent empty)

## How/what to test

- Try to change the source URL of an iframe webapp