### PR TITLE
fix: mcp should not read binary webapps files (HEXA-1707)

### DIFF
--- a/backend/hexa/mcp/graphql/webapps.graphql
+++ b/backend/hexa/mcp/graphql/webapps.graphql
@@ -18,7 +18,7 @@ query ListStaticWebapps($workspaceSlug: String, $page: Int, $perPage: Int) {
   }
 }
 
-query GetStaticWebapp($workspaceSlug: String!, $slug: String!) {
+query GetStaticWebapp($workspaceSlug: String!, $slug: String!, $includeBinaryContent: Boolean) {
   webapp(workspaceSlug: $workspaceSlug, slug: $slug) {
     id
     slug
@@ -31,7 +31,7 @@ query GetStaticWebapp($workspaceSlug: String!, $slug: String!) {
     workspace {
       slug
     }
-    files {
+    files(includeBinaryContent: $includeBinaryContent) {
       path
       type
       content

--- a/backend/hexa/mcp/tests/test_webapps.py
+++ b/backend/hexa/mcp/tests/test_webapps.py
@@ -134,6 +134,44 @@ class GetStaticWebappTest(MCPTestCase):
         self.assertEqual(len(result["files"]), 1)
         self.assertEqual(result["files"][0]["path"], "index.html")
 
+    @_mock_forgejo()
+    def test_get_static_webapp_omits_binary_content(self, mock_forgejo):
+        client = mock_forgejo.return_value
+        create_result = create_static_webapp(
+            user=self.USER_ADMIN,
+            workspace_slug=self.WORKSPACE.slug,
+            name=_unique_name("Binary"),
+            files_json=json.dumps([{"path": "index.html", "content": "<html></html>"}]),
+        )
+        self.assertTrue(create_result["success"], create_result.get("errors"))
+        webapp_slug = create_result["webapp"]["slug"]
+
+        client.get_repository_files.return_value = [
+            {
+                "path": "index.html",
+                "type": "file",
+                "content": "<html>hi</html>",
+                "encoding": "TEXT",
+            },
+            {
+                "path": "logo.png",
+                "type": "file",
+                "content": "iVBORw0KGgoAAAANSUhEUg==",
+                "encoding": "BASE64",
+            },
+        ]
+
+        result = get_static_webapp(
+            user=self.USER_ADMIN,
+            workspace_slug=self.WORKSPACE.slug,
+            webapp_slug=webapp_slug,
+        )
+        files_by_path = {f["path"]: f for f in result["files"]}
+        self.assertEqual(files_by_path["index.html"]["content"], "<html>hi</html>")
+        self.assertEqual(files_by_path["index.html"]["encoding"], "TEXT")
+        self.assertIsNone(files_by_path["logo.png"]["content"])
+        self.assertEqual(files_by_path["logo.png"]["encoding"], "BASE64")
+
     def test_get_static_webapp_not_found(self):
         result = get_static_webapp(
             user=self.USER_ADMIN,

--- a/backend/hexa/mcp/tools/webapps.py
+++ b/backend/hexa/mcp/tools/webapps.py
@@ -19,14 +19,18 @@ def list_static_webapps(
 
 @tool
 def get_static_webapp(user, workspace_slug: str, webapp_slug: str) -> dict:
-    """Get full details of a static web app: metadata, allowed API operations, and the current files with their contents.
+    """Get full details of a static web app: metadata, allowed API operations, and the current files.
 
-    Use the slug from list_static_webapps (not the UUID). File contents are returned with an `encoding` field — TEXT for UTF-8 strings, BASE64 for binary files. Returns the webapp's `id` which can be passed to update_static_webapp.
+    Use the slug from list_static_webapps (not the UUID). Each file has an `encoding` field — TEXT for UTF-8 strings, BASE64 for binary files. Content is returned inline for text/code files (encoding TEXT); for binary files (encoding BASE64, e.g. images or fonts) `content` is null to avoid returning large base64 blobs. Returns the webapp's `id` which can be passed to update_static_webapp.
     """
     data = execute_graphql(
         user,
         "GetStaticWebapp",
-        {"workspaceSlug": workspace_slug, "slug": webapp_slug},
+        {
+            "workspaceSlug": workspace_slug,
+            "slug": webapp_slug,
+            "includeBinaryContent": False,
+        },
     )
     if "errors" in data:
         return data

--- a/backend/hexa/webapps/graphql/schema.graphql
+++ b/backend/hexa/webapps/graphql/schema.graphql
@@ -90,7 +90,7 @@ type Webapp {
   source: WebappSource!
   versions(page: Int, perPage: Int): WebappVersionsPage
   commitDiff(ref: String!): WebappCommitDiff
-  files(ref: String): [FileNode!]
+  files(ref: String, includeBinaryContent: Boolean = true): [FileNode!]  # When includeBinaryContent is false, the `content` of binary (non-TEXT) files is null.
   permissions: WebappPermissions!
 }
 """

--- a/backend/hexa/webapps/models.py
+++ b/backend/hexa/webapps/models.py
@@ -270,7 +270,7 @@ class GitWebapp(Webapp, GitRepoMixin):
         ".sql": "sql",
     }
 
-    def get_files(self, ref=None):
+    def get_files(self, ref=None, include_binary_content=True):
         ref = ref or "main"
         raw_files = self.client.get_repository_files(
             self.repository, ref, org_slug=self.git_org.slug
@@ -283,6 +283,9 @@ class GitWebapp(Webapp, GitRepoMixin):
             parent = "/".join(path.split("/")[:-1]) or None
             extension = os.path.splitext(path)[1].lower()
             is_text = encoding == FileEncoding.TEXT and content is not None
+
+            if not include_binary_content and not is_text:
+                content = None
 
             nodes.append(
                 {

--- a/backend/hexa/webapps/schema/types.py
+++ b/backend/hexa/webapps/schema/types.py
@@ -130,12 +130,16 @@ def resolve_commit_diff(webapp: Webapp, info, ref: str, **kwargs):
 
 
 @webapp_object.field("files")
-def resolve_files(webapp: Webapp, info, ref=None, **kwargs):
+def resolve_files(
+    webapp: Webapp, info, ref=None, include_binary_content=True, **kwargs
+):
     if webapp.type != Webapp.WebappType.STATIC:
         return None
     git_webapp = GitWebapp.objects.get(pk=webapp.pk)
     try:
-        return git_webapp.get_files(ref=ref)
+        return git_webapp.get_files(
+            ref=ref, include_binary_content=include_binary_content
+        )
     except ForgejoAPIError:
         return []
 

--- a/frontend/schema.generated.graphql
+++ b/frontend/schema.generated.graphql
@@ -5604,7 +5604,7 @@ type Webapp {
   commitDiff(ref: String!): WebappCommitDiff
   createdBy: User!
   description: String
-  files(ref: String): [FileNode!]
+  files(includeBinaryContent: Boolean = true, ref: String): [FileNode!]
   icon: String
   id: UUID!
   isFavorite: Boolean!

--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -6410,6 +6410,7 @@ export type WebappCommitDiffArgs = {
 
 /** Represents a web app. */
 export type WebappFilesArgs = {
+  includeBinaryContent?: InputMaybe<Scalars['Boolean']['input']>;
   ref?: InputMaybe<Scalars['String']['input']>;
 };
 


### PR DESCRIPTION
Through GQL, skip reading binary files for the MCP tool