### PR TITLE
feat: s3 storage bucket configuration

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -234,7 +234,7 @@ OVERRIDE_WORKSPACES_DATABASE_HOST=
 WORKSPACE_BUCKET_PREFIX=
 
 # Enable object versioning on newly created buckets (default: true, applies to the gcp and s3 backends)
-# Note: MinIO single-drive deployments do not support versioning; the setting is then ignored.
+# On S3-compatible stores that do not support versioning, the setting is ignored.
 WORKSPACE_BUCKET_VERSIONING_ENABLED=true
 
 ## Local FS (STORAGE_BACKEND=fs): Define the root location where the workspaces files will be stored

--- a/.env.dist
+++ b/.env.dist
@@ -233,6 +233,10 @@ OVERRIDE_WORKSPACES_DATABASE_HOST=
 # Add a prefix to the bucket name (may be useful to separate dev and prod workspaces inside a shared storage account)
 WORKSPACE_BUCKET_PREFIX=
 
+# Enable object versioning on newly created buckets (default: true, applies to the gcp and s3 backends)
+# Note: MinIO single-drive deployments do not support versioning; the setting is then ignored.
+WORKSPACE_BUCKET_VERSIONING_ENABLED=true
+
 ## Local FS (STORAGE_BACKEND=fs): Define the root location where the workspaces files will be stored
 # Absolute path to the directory where the workspaces data will be stored
 WORKSPACE_STORAGE_LOCATION=$WORKSPACE_STORAGE_LOCATION

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -634,6 +634,9 @@ WORKSPACE_DATASETS_FILE_SNAPSHOT_SIZE = int(
 )
 # Dynamically configure the storage backend based on the STORAGE_BACKEND environment variable
 STORAGE_BACKEND = os.environ.get("STORAGE_BACKEND", "fs")
+WORKSPACE_BUCKET_VERSIONING_ENABLED = (
+    os.environ.get("WORKSPACE_BUCKET_VERSIONING_ENABLED", "true").lower() == "true"
+)
 
 if STORAGE_BACKEND == "gcp":
     # GCP Settings if using GCS as a storage backend ###
@@ -653,7 +656,7 @@ if STORAGE_BACKEND == "gcp":
                 "WORKSPACE_STORAGE_BACKEND_GCS_SERVICE_ACCOUNT_KEY"
             ),
             "region": os.environ.get("WORKSPACE_BUCKET_REGION", "europe-west1"),
-            "enable_versioning": True,
+            "enable_versioning": WORKSPACE_BUCKET_VERSIONING_ENABLED,
         },
     }
 elif STORAGE_BACKEND == "azure":
@@ -696,6 +699,7 @@ elif STORAGE_BACKEND == "s3":
             or None,
             "role_arn": os.environ.get("WORKSPACE_STORAGE_BACKEND_AWS_ROLE_ARN")
             or None,
+            "enable_versioning": WORKSPACE_BUCKET_VERSIONING_ENABLED,
         },
     }
 else:  # Default to filesystem storage
@@ -711,7 +715,6 @@ else:  # Default to filesystem storage
     }
 
 WORKSPACE_BUCKET_PREFIX = os.environ.get("WORKSPACE_BUCKET_PREFIX", "")
-WORKSPACE_BUCKET_VERSIONING_ENABLED = False
 
 # MIXPANEL
 MIXPANEL_TOKEN = os.environ.get("MIXPANEL_TOKEN")

--- a/backend/hexa/files/backends/s3.py
+++ b/backend/hexa/files/backends/s3.py
@@ -148,13 +148,15 @@ class S3Storage(Storage):
         """Apply a post-creation bucket configuration step.
 
         S3-compatible stores (e.g. MinIO) do not implement all bucket
-        configuration APIs; skip those instead of failing bucket creation.
-        Any other error propagates, like a failed bucket.patch() on GCP.
+        configuration APIs; skip those (NotImplemented/MethodNotAllowed)
+        instead of failing bucket creation. Any other error propagates,
+        like a failed bucket.patch() on GCP.
         """
         try:
             step()
         except ClientError as e:
             if e.response["Error"]["Code"] in ("NotImplemented", "MethodNotAllowed"):
+                # Swallowed on purpose (methods not supported on S3-compatible stores)
                 sentry_sdk.capture_exception(e)
             else:
                 raise
@@ -191,39 +193,51 @@ class S3Storage(Storage):
         # classes that keep objects instantly readable up to 365 days. Past
         # 365 days objects land in DEEP_ARCHIVE and need a restore before
         # they can be read again.
-        self.client.put_bucket_lifecycle_configuration(
-            Bucket=bucket_name,
-            LifecycleConfiguration={
-                "Rules": [
-                    {
-                        "ID": "transition-storage-classes",
-                        "Status": "Enabled",
-                        "Filter": {},
-                        "Transitions": [
-                            {"Days": 30, "StorageClass": "STANDARD_IA"},
-                            {"Days": 90, "StorageClass": "GLACIER_IR"},
-                            {"Days": 365, "StorageClass": "DEEP_ARCHIVE"},
-                        ],
-                    },
-                    {
-                        "ID": "cleanup-noncurrent-versions",
-                        "Status": "Enabled",
-                        "Filter": {},
-                        "NoncurrentVersionExpiration": {
-                            "NoncurrentDays": 1,
-                            "NewerNoncurrentVersions": 3,
-                        },
-                    },
-                    {
-                        "ID": "cleanup-incomplete-uploads",
-                        "Status": "Enabled",
-                        "Filter": {},
-                        "AbortIncompleteMultipartUpload": {"DaysAfterInitiation": 7},
-                        "Expiration": {"ExpiredObjectDeleteMarker": True},
-                    },
-                ]
+        rules = [
+            {
+                "ID": "transition-storage-classes",
+                "Status": "Enabled",
+                "Filter": {},
+                "Transitions": [
+                    {"Days": 30, "StorageClass": "STANDARD_IA"},
+                    {"Days": 90, "StorageClass": "GLACIER_IR"},
+                    {"Days": 365, "StorageClass": "DEEP_ARCHIVE"},
+                ],
             },
-        )
+            {
+                "ID": "cleanup-noncurrent-versions",
+                "Status": "Enabled",
+                "Filter": {},
+                "NoncurrentVersionExpiration": {
+                    "NoncurrentDays": 1,
+                    "NewerNoncurrentVersions": 3,
+                },
+            },
+            {
+                "ID": "cleanup-incomplete-uploads",
+                "Status": "Enabled",
+                "Filter": {},
+                "AbortIncompleteMultipartUpload": {"DaysAfterInitiation": 7},
+                "Expiration": {"ExpiredObjectDeleteMarker": True},
+            },
+        ]
+        try:
+            self.client.put_bucket_lifecycle_configuration(
+                Bucket=bucket_name,
+                LifecycleConfiguration={"Rules": rules},
+            )
+        except ClientError as e:
+            if e.response["Error"]["Code"] != "InvalidStorageClass":
+                raise
+            # Stores without storage tiers (e.g. MinIO) reject the transition
+            # rule but do support the cleanup rules — retry with those only.
+            sentry_sdk.capture_exception(e)
+            self.client.put_bucket_lifecycle_configuration(
+                Bucket=bucket_name,
+                LifecycleConfiguration={
+                    "Rules": [rule for rule in rules if "Transitions" not in rule]
+                },
+            )
 
     def _set_bucket_tags(self, bucket_name: str, labels: dict | None) -> None:
         if not labels:

--- a/backend/hexa/files/backends/s3.py
+++ b/backend/hexa/files/backends/s3.py
@@ -1,6 +1,7 @@
 import fnmatch
 import io
 import json
+from collections.abc import Callable
 from mimetypes import guess_type
 
 import boto3
@@ -65,6 +66,7 @@ class S3Storage(Storage):
         endpoint_url: str | None = None,
         public_endpoint_url: str | None = None,
         role_arn: str | None = None,
+        enable_versioning: bool = False,
     ):
         super().__init__()
         self._access_key_id = access_key_id
@@ -73,6 +75,7 @@ class S3Storage(Storage):
         self._endpoint_url = endpoint_url or None
         self._public_endpoint_url = public_endpoint_url or endpoint_url or None
         self._role_arn = role_arn or None
+        self.enable_versioning = enable_versioning
         self._client = None
         self._public_client = None
 
@@ -113,7 +116,9 @@ class S3Storage(Storage):
                 return False
             raise
 
-    def create_bucket(self, bucket_name: str, *args, **kwargs) -> str:
+    def create_bucket(
+        self, bucket_name: str, labels: dict | None = None, *args, **kwargs
+    ) -> str:
         try:
             # us-east-1 is the default region and rejects an explicit LocationConstraint
             if self.region == "us-east-1":
@@ -123,7 +128,6 @@ class S3Storage(Storage):
                     Bucket=bucket_name,
                     CreateBucketConfiguration={"LocationConstraint": self.region},
                 )
-            return bucket_name
         except ClientError as e:
             if e.response["Error"]["Code"] in (
                 "BucketAlreadyExists",
@@ -133,6 +137,105 @@ class S3Storage(Storage):
                     f"S3: Bucket {bucket_name} already exists!"
                 )
             raise
+
+        self._apply_bucket_config(lambda: self._set_bucket_cors(bucket_name))
+        self._apply_bucket_config(lambda: self._set_bucket_versioning(bucket_name))
+        self._apply_bucket_config(lambda: self._set_bucket_lifecycle(bucket_name))
+        self._apply_bucket_config(lambda: self._set_bucket_tags(bucket_name, labels))
+        return bucket_name
+
+    def _apply_bucket_config(self, step: Callable[[], None]) -> None:
+        """Apply a post-creation bucket configuration step.
+
+        S3-compatible stores (e.g. MinIO) do not implement all bucket
+        configuration APIs; skip those instead of failing bucket creation.
+        Any other error propagates, like a failed bucket.patch() on GCP.
+        """
+        try:
+            step()
+        except ClientError as e:
+            if e.response["Error"]["Code"] in ("NotImplemented", "MethodNotAllowed"):
+                sentry_sdk.capture_exception(e)
+            else:
+                raise
+
+    def _set_bucket_cors(self, bucket_name: str) -> None:
+        # Uploads/downloads are made by the browser straight to the bucket via
+        # presigned URLs, so cross-origin requests must be allowed. The wildcard
+        # origin is safe: access control comes from the presigned signature.
+        self.client.put_bucket_cors(
+            Bucket=bucket_name,
+            CORSConfiguration={
+                "CORSRules": [
+                    {
+                        "AllowedOrigins": ["*"],
+                        "AllowedMethods": ["GET", "PUT", "POST", "DELETE", "HEAD"],
+                        "AllowedHeaders": ["*"],
+                        "ExposeHeaders": ["ETag", "Content-Type", "Content-Length"],
+                        "MaxAgeSeconds": 3600,
+                    }
+                ]
+            },
+        )
+
+    def _set_bucket_versioning(self, bucket_name: str) -> None:
+        if not self.enable_versioning:
+            return
+        self.client.put_bucket_versioning(
+            Bucket=bucket_name,
+            VersioningConfiguration={"Status": "Enabled"},
+        )
+
+    def _set_bucket_lifecycle(self, bucket_name: str) -> None:
+        # S3 translation of the GCP backend lifecycle rules, using storage
+        # classes that keep objects instantly readable up to 365 days. Past
+        # 365 days objects land in DEEP_ARCHIVE and need a restore before
+        # they can be read again.
+        self.client.put_bucket_lifecycle_configuration(
+            Bucket=bucket_name,
+            LifecycleConfiguration={
+                "Rules": [
+                    {
+                        "ID": "transition-storage-classes",
+                        "Status": "Enabled",
+                        "Filter": {},
+                        "Transitions": [
+                            {"Days": 30, "StorageClass": "STANDARD_IA"},
+                            {"Days": 90, "StorageClass": "GLACIER_IR"},
+                            {"Days": 365, "StorageClass": "DEEP_ARCHIVE"},
+                        ],
+                    },
+                    {
+                        "ID": "cleanup-noncurrent-versions",
+                        "Status": "Enabled",
+                        "Filter": {},
+                        "NoncurrentVersionExpiration": {
+                            "NoncurrentDays": 1,
+                            "NewerNoncurrentVersions": 3,
+                        },
+                    },
+                    {
+                        "ID": "cleanup-incomplete-uploads",
+                        "Status": "Enabled",
+                        "Filter": {},
+                        "AbortIncompleteMultipartUpload": {"DaysAfterInitiation": 7},
+                        "Expiration": {"ExpiredObjectDeleteMarker": True},
+                    },
+                ]
+            },
+        )
+
+    def _set_bucket_tags(self, bucket_name: str, labels: dict | None) -> None:
+        if not labels:
+            return
+        self.client.put_bucket_tagging(
+            Bucket=bucket_name,
+            Tagging={
+                "TagSet": [
+                    {"Key": key, "Value": value} for key, value in labels.items()
+                ]
+            },
+        )
 
     def delete_bucket(self, bucket_name: str, force: bool = False) -> None:
         if force:

--- a/backend/hexa/files/tests/backends/test_s3.py
+++ b/backend/hexa/files/tests/backends/test_s3.py
@@ -101,6 +101,47 @@ class S3StorageTest(StorageTestMixin, TestCase):
         with self.assertRaises(ClientError):
             self.storage.client.get_bucket_tagging(Bucket=BUCKET)
 
+    def test_create_bucket_lifecycle_falls_back_without_transitions(self):
+        # MinIO-like stores reject transition rules with InvalidStorageClass;
+        # the cleanup rules must still be applied.
+        invalid_storage_class = ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidStorageClass",
+                    "Message": "Invalid storage class.",
+                }
+            },
+            "PutBucketLifecycleConfiguration",
+        )
+        original = self.storage.client.put_bucket_lifecycle_configuration
+        calls = []
+
+        def fail_on_transitions(**kwargs):
+            calls.append(kwargs)
+            if any(
+                "Transitions" in rule
+                for rule in kwargs["LifecycleConfiguration"]["Rules"]
+            ):
+                raise invalid_storage_class
+            return original(**kwargs)
+
+        with patch.object(
+            self.storage.client,
+            "put_bucket_lifecycle_configuration",
+            side_effect=fail_on_transitions,
+        ), patch("sentry_sdk.capture_exception") as mock_capture:
+            self.storage.create_bucket(BUCKET)
+
+        mock_capture.assert_called_once()
+        self.assertEqual(len(calls), 2)
+        lifecycle = self.storage.client.get_bucket_lifecycle_configuration(
+            Bucket=BUCKET
+        )
+        rule_ids = {rule["ID"] for rule in lifecycle["Rules"]}
+        self.assertEqual(
+            rule_ids, {"cleanup-noncurrent-versions", "cleanup-incomplete-uploads"}
+        )
+
     def test_create_bucket_tolerates_not_implemented(self):
         # S3-compatible stores like MinIO do not implement every bucket
         # configuration API; creation must still succeed.

--- a/backend/hexa/files/tests/backends/test_s3.py
+++ b/backend/hexa/files/tests/backends/test_s3.py
@@ -2,6 +2,7 @@ import io
 from unittest.mock import patch
 from urllib.parse import parse_qs, unquote, urlparse
 
+from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from hexa.core.test import TestCase
@@ -32,6 +33,99 @@ class S3StorageTest(StorageTestMixin, TestCase):
     def tearDown(self):
         self.mock.stop()
         super().tearDown()
+
+    def test_create_bucket_sets_cors(self):
+        self.storage.create_bucket(BUCKET)
+        cors = self.storage.client.get_bucket_cors(Bucket=BUCKET)
+        self.assertEqual(len(cors["CORSRules"]), 1)
+        rule = cors["CORSRules"][0]
+        self.assertEqual(rule["AllowedOrigins"], ["*"])
+        self.assertEqual(
+            sorted(rule["AllowedMethods"]), ["DELETE", "GET", "HEAD", "POST", "PUT"]
+        )
+        self.assertEqual(rule["AllowedHeaders"], ["*"])
+        self.assertIn("ETag", rule["ExposeHeaders"])
+        self.assertEqual(rule["MaxAgeSeconds"], 3600)
+
+    def test_create_bucket_enables_versioning(self):
+        storage = S3Storage(
+            access_key_id="fake-access-key",
+            secret_access_key="fake-secret-key",
+            region=REGION,
+            enable_versioning=True,
+        )
+        storage.create_bucket(BUCKET)
+        versioning = storage.client.get_bucket_versioning(Bucket=BUCKET)
+        self.assertEqual(versioning.get("Status"), "Enabled")
+
+    def test_create_bucket_versioning_disabled(self):
+        self.storage.create_bucket(BUCKET)
+        versioning = self.storage.client.get_bucket_versioning(Bucket=BUCKET)
+        self.assertNotIn("Status", versioning)
+
+    def test_create_bucket_sets_lifecycle(self):
+        self.storage.create_bucket(BUCKET)
+        lifecycle = self.storage.client.get_bucket_lifecycle_configuration(
+            Bucket=BUCKET
+        )
+        rules = {rule["ID"]: rule for rule in lifecycle["Rules"]}
+        self.assertEqual(
+            rules["transition-storage-classes"]["Transitions"],
+            [
+                {"Days": 30, "StorageClass": "STANDARD_IA"},
+                {"Days": 90, "StorageClass": "GLACIER_IR"},
+                {"Days": 365, "StorageClass": "DEEP_ARCHIVE"},
+            ],
+        )
+        # moto accepts NewerNoncurrentVersions on put but does not return it on get
+        self.assertEqual(
+            rules["cleanup-noncurrent-versions"]["NoncurrentVersionExpiration"][
+                "NoncurrentDays"
+            ],
+            1,
+        )
+        self.assertEqual(
+            rules["cleanup-incomplete-uploads"]["AbortIncompleteMultipartUpload"],
+            {"DaysAfterInitiation": 7},
+        )
+
+    def test_create_bucket_sets_labels(self):
+        self.storage.create_bucket(BUCKET, labels={"hexa_workspace": "test"})
+        tagging = self.storage.client.get_bucket_tagging(Bucket=BUCKET)
+        self.assertEqual(
+            tagging["TagSet"], [{"Key": "hexa_workspace", "Value": "test"}]
+        )
+
+    def test_create_bucket_without_labels_sets_no_tags(self):
+        self.storage.create_bucket(BUCKET)
+        with self.assertRaises(ClientError):
+            self.storage.client.get_bucket_tagging(Bucket=BUCKET)
+
+    def test_create_bucket_tolerates_not_implemented(self):
+        # S3-compatible stores like MinIO do not implement every bucket
+        # configuration API; creation must still succeed.
+        not_implemented = ClientError(
+            {"Error": {"Code": "NotImplemented", "Message": "not supported"}},
+            "PutBucketCors",
+        )
+        with patch.object(
+            self.storage.client, "put_bucket_cors", side_effect=not_implemented
+        ), patch("sentry_sdk.capture_exception") as mock_capture:
+            self.storage.create_bucket(BUCKET)
+
+        mock_capture.assert_called_once()
+        self.assertTrue(self.storage.bucket_exists(BUCKET))
+
+    def test_create_bucket_config_error_raises(self):
+        access_denied = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+            "PutBucketCors",
+        )
+        with patch.object(
+            self.storage.client, "put_bucket_cors", side_effect=access_denied
+        ):
+            with self.assertRaises(ClientError):
+                self.storage.create_bucket(BUCKET)
 
     def test_delete_bucket(self):
         self.storage.create_bucket(BUCKET)


### PR DESCRIPTION
Added S3 storage bucket configuration (CORS, lifecycle and versioning)

## Changes

- Added `WORKSPACE_BUCKET_VERSIONING_ENABLED` env variable (was already in codebase but not in env file). True by default
- Align `enable_versioning` config with gcp.py
- Added CORS config (`*` as in gcp)
- Set bucket versioning
- Set bucket objects lifecycle, mimicking GCP config:
  - `STANDARD_IA` @ 30 days
  - `GLACIER_IR` @ 90 days
  - `DEEP_ARCHIVE` @ 365 days
- Added bucket labels for consistency
- Added config tests