### PR TITLE
feat: Add Django admin SQL dashboards (HEXA-1738)

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -70,6 +70,9 @@ DATABASE_PASSWORD=hexa-app
 POSTGRES_DB=hexa-app
 POSTGRES_USER=hexa-app
 POSTGRES_PASSWORD=hexa-app
+# Read-only user for Django dashboards
+DATABASE_USER_READ_ONLY=hexa-app
+DATABASE_PASSWORD_READ_ONLY=hexa-app
 
 ## Custom domains for web apps
 ##############################

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -346,6 +346,7 @@ INSTALLED_APPS = [
     "allauth.account",
     "allauth.socialaccount",
     "allauth.socialaccount.providers.openid_connect",
+    "django_sql_dashboard",
 ]
 
 MIDDLEWARE = [
@@ -406,7 +407,19 @@ DATABASES = {
         "NAME": os.environ.get("DATABASE_NAME"),
         "USER": os.environ.get("DATABASE_USER"),
         "PASSWORD": os.environ.get("DATABASE_PASSWORD"),
-    }
+    },
+    "dashboard": {
+        "ENGINE": "django.db.backends.postgresql",
+        "HOST": os.environ.get("DATABASE_HOST"),
+        "PORT": os.environ.get("DATABASE_PORT"),
+        "NAME": os.environ.get("DATABASE_NAME"),
+        "USER": os.environ.get("DATABASE_USER_READ_ONLY"),
+        "PASSWORD": os.environ.get("DATABASE_PASSWORD_READ_ONLY"),
+        "OPTIONS": {
+            # Kill queries that take longer than 3 seconds
+            "options": "-c default_transaction_read_only=on -c statement_timeout=3000"
+        },
+    },
 }
 
 # Auth settings

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -17,6 +17,7 @@ Including another URLconf
 """
 
 import allauth.urls
+import django_sql_dashboard
 from ariadne_django.views import GraphQLView
 from django.conf import settings
 from django.contrib import admin
@@ -41,6 +42,7 @@ admin.site.index_title = "Welcome to OpenHEXA"
 # Core URLs
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("dashboard/", include(django_sql_dashboard.urls)),
     path("", include("hexa.core.urls", namespace="core")),
     path("notebooks/", include("hexa.notebooks.urls", namespace="notebooks")),
     path("assistant/", include("hexa.assistant.urls", namespace="assistant")),

--- a/backend/hexa/user_management/admin.py
+++ b/backend/hexa/user_management/admin.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from django import forms
 from django.contrib import admin, messages
+from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.forms import PasswordResetForm
 from django.contrib.auth.forms import UserCreationForm as BaseUserCreationForm
@@ -32,8 +33,45 @@ from .models import (
     User,
 )
 
-# We won't be using the Django group feature
+# Django groups are not part of OpenHEXA's access model (organizations, workspaces,
+# teams): they are only exposed here because django-sql-dashboard relies on them for
+# its group-based view/edit policies. We replace the default GroupAdmin with one that
+# carries a disclaimer and allows managing members directly (the default group admin
+# has no user picker, and our user admin does not expose the groups field).
 admin.site.unregister(Group)
+
+
+class GroupForm(forms.ModelForm):
+    users = forms.ModelMultipleChoiceField(
+        queryset=User.objects.order_by("email"),
+        required=False,
+        widget=FilteredSelectMultiple("users", is_stacked=False),
+    )
+
+    class Meta:
+        model = Group
+        fields = ("name", "users")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance.pk:
+            self.fields["users"].initial = self.instance.user_set.all()
+
+    def _save_m2m(self):
+        super()._save_m2m()
+        self.instance.user_set.set(self.cleaned_data["users"])
+
+
+@admin.register(Group)
+class GroupAdmin(admin.ModelAdmin):
+    form = GroupForm
+    list_display = ("name", "members_count")
+    search_fields = ("name",)
+
+    def members_count(self, obj):
+        return obj.user_set.count()
+
+    members_count.short_description = "Members Count"
 
 
 class UserCreationForm(BaseUserCreationForm):

--- a/backend/hexa/user_management/admin.py
+++ b/backend/hexa/user_management/admin.py
@@ -8,7 +8,7 @@ from django.contrib.auth.forms import PasswordResetForm
 from django.contrib.auth.forms import UserCreationForm as BaseUserCreationForm
 from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
-from django.db.models import OuterRef, Q, Subquery, Sum
+from django.db.models import Count, OuterRef, Q, Subquery, Sum
 from django.db.models.functions import Collate
 from django.utils import timezone
 from django.utils.crypto import get_random_string
@@ -68,10 +68,16 @@ class GroupAdmin(admin.ModelAdmin):
     list_display = ("name", "members_count")
     search_fields = ("name",)
 
-    def members_count(self, obj):
-        return obj.user_set.count()
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .annotate(_members_count=Count("user", distinct=True))
+        )
 
-    members_count.short_description = "Members Count"
+    @admin.display(description="Members Count", ordering="_members_count")
+    def members_count(self, obj):
+        return obj._members_count
 
 
 class UserCreationForm(BaseUserCreationForm):

--- a/backend/hexa/user_management/backends.py
+++ b/backend/hexa/user_management/backends.py
@@ -19,12 +19,15 @@ class PermissionsBackend(BaseBackend):
     ) -> typing.Optional[ModuleType]:
         try:
             app_config = apps.get_app_config(app_label)
-            import_path = f"{app_config.name}.permissions"
-            permissions_module = import_module(import_path)
         except LookupError:
             return None
 
-        return permissions_module
+        # Third-party apps (e.g. django_sql_dashboard) don't follow the OpenHEXA
+        # permissions module convention, so this backend can't handle their permissions
+        if not app_config.name.startswith("hexa."):
+            return None
+
+        return import_module(f"{app_config.name}.permissions")
 
     def has_perm(
         self,
@@ -39,9 +42,7 @@ class PermissionsBackend(BaseBackend):
 
         permission_module = self._get_permission_module(app_label)
         if permission_module is None:
-            raise ValueError(
-                f'Could not find a permission module for the "{app_label}" app'
-            )
+            return False  # Not an OpenHEXA app, let other backends handle it
 
         try:
             permission_function = getattr(permission_module, app_perm)

--- a/backend/hexa/user_management/templates/admin/auth/group/change_form.html
+++ b/backend/hexa/user_management/templates/admin/auth/group/change_form.html
@@ -1,0 +1,15 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block content_subtitle %}
+{{ block.super }}
+<ul class="messagelist">
+    <li class="warning">
+        {% blocktranslate trimmed %}
+        Django groups are not part of OpenHEXA's access model (organizations,
+        workspaces and teams). They are only used by SQL dashboards, for the
+        "users in group" view and edit policies.
+        {% endblocktranslate %}
+    </li>
+</ul>
+{% endblock %}

--- a/backend/hexa/user_management/templates/admin/auth/group/change_list.html
+++ b/backend/hexa/user_management/templates/admin/auth/group/change_list.html
@@ -1,0 +1,15 @@
+{% extends "admin/change_list.html" %}
+{% load i18n %}
+
+{% block content_subtitle %}
+{{ block.super }}
+<ul class="messagelist">
+    <li class="warning">
+        {% blocktranslate trimmed %}
+        Django groups are not part of OpenHEXA's access model (organizations,
+        workspaces and teams). They are only used by SQL dashboards, for the
+        "users in group" view and edit policies.
+        {% endblocktranslate %}
+    </li>
+</ul>
+{% endblock %}

--- a/backend/hexa/user_management/tests/test_backends.py
+++ b/backend/hexa/user_management/tests/test_backends.py
@@ -1,0 +1,59 @@
+from django.contrib.auth.models import Permission
+
+from hexa.core.test import TestCase
+from hexa.user_management.backends import PermissionsBackend
+from hexa.user_management.models import Membership, MembershipRole, Team, User
+
+
+class PermissionsBackendTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.ADMIN = User.objects.create_user("julia@bluesquarehub.com", "password")
+        cls.TEAM = Team.objects.create(name="Test team")
+        Membership.objects.create(
+            user=cls.ADMIN, team=cls.TEAM, role=MembershipRole.ADMIN
+        )
+        cls.backend = PermissionsBackend()
+
+    def test_hexa_app_permission_without_object(self):
+        self.assertTrue(
+            self.backend.has_perm(self.ADMIN, "user_management.create_team")
+        )
+
+    def test_hexa_app_permission_with_object(self):
+        self.assertTrue(
+            self.backend.has_perm(self.ADMIN, "user_management.update_team", self.TEAM)
+        )
+
+    def test_unknown_permission_in_hexa_app_raises(self):
+        with self.assertRaises(AttributeError):
+            self.backend.has_perm(self.ADMIN, "user_management.not_a_permission")
+
+    def test_non_hexa_app_permission_returns_false(self):
+        """Regression test: permissions of third-party apps (e.g. django_sql_dashboard)
+        must be delegated to other backends instead of raising ValueError.
+        """
+        self.assertFalse(
+            self.backend.has_perm(self.ADMIN, "django_sql_dashboard.execute_sql")
+        )
+
+    def test_unknown_app_label_returns_false(self):
+        self.assertFalse(self.backend.has_perm(self.ADMIN, "nonexistent_app.do_stuff"))
+
+    def test_permission_without_app_label_returns_false(self):
+        self.assertFalse(self.backend.has_perm(self.ADMIN, "no_dot_permission"))
+
+    def test_third_party_permission_falls_through_to_model_backend(self):
+        """The backend resolves third-party app permissions via Django's ModelBackend
+        without blowing up.
+        """
+        self.assertFalse(self.ADMIN.has_perm("django_sql_dashboard.execute_sql"))
+
+        permission = Permission.objects.get(
+            codename="execute_sql",
+            content_type__app_label="django_sql_dashboard",
+        )
+        self.ADMIN.user_permissions.add(permission)
+        # Re-fetch to clear ModelBackend's per-instance permission cache
+        user = User.objects.get(pk=self.ADMIN.pk)
+        self.assertTrue(user.has_perm("django_sql_dashboard.execute_sql"))

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -64,6 +64,7 @@ requests-mock
 mixpanel
 mixpanel-py-async
 ua-parser
+django-sql-dashboard
 
 # dataset explorer
 pyarrow

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -49,6 +49,8 @@ azure-storage-blob==12.28.0
     # via -r requirements.in
 black==26.3.1
     # via ariadne-codegen
+bleach==6.4.0
+    # via django-sql-dashboard
 boto3==1.40.76
     # via
     #   -r requirements.in
@@ -132,6 +134,7 @@ django==5.2.14
     #   django-oauth-toolkit
     #   django-otp
     #   django-postgres-queue
+    #   django-sql-dashboard
     #   django-storages
 django-allauth[socialaccount]==65.18.0
     # via -r requirements.in
@@ -150,6 +153,8 @@ django-oauth-toolkit==3.2.0
 django-otp==1.6.0
     # via -r requirements.in
 django-postgres-queue==1.0.0
+    # via -r requirements.in
+django-sql-dashboard==1.2
     # via -r requirements.in
 django-storages[google]==1.14.6
     # via -r requirements.in
@@ -295,7 +300,9 @@ logfire-api==4.25.0
 logzero==1.7.0
     # via dhis2-py
 markdown==3.8.2
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   django-sql-dashboard
 markdown-it-py==3.0.0
     # via rich
 markupsafe==3.0.2
@@ -618,6 +625,8 @@ uvicorn==0.34.0
     # via -r requirements.in
 vcrpy==8.2.1
     # via -r requirements.in
+webencodings==0.5.1
+    # via bleach
 websocket-client==1.8.0
     # via kubernetes
 werkzeug==3.1.6


### PR DESCRIPTION
Simple, pragmatic SQL dashboards served straight from Django.

https://bluesquare.atlassian.net/browse/HEXA-1738

Notes:
- We use a read-only DB user + tight statement_timeout for security and performance reasons
- Dashboards edit rights will belong only to the OH superadmin roles, viewer rights will be granted to specific persons
- This may feel weird, but it’s actually just a tailored view-only version of the Django admin

New ENV vars to add to your `.env`:
```env
# Read-only user for Django dashboards
DATABASE_USER_READ_ONLY=hexa-app
DATABASE_PASSWORD_READ_ONLY=hexa-app
```

## Changes

- Add django-sql-dashboard to Django requirements, wire it up with a read-only Postgres role
- Small fix to only require OH permission system for `hexa` Django apps
- Add a custom Django admin view for "Groups": Groups are a part of the standard Django permission system and
django-sql-dashboard relies on it. They were deliberately hidden in our admin for obvious reasons, now we
bring them back in a simplified fashion with a clear disclaimer about what it's for. A bit more code than I liked, but this allows us to give a specific user access to a specific dashboard.

## How/what to test

Create a dashboard via the Django admin and play around with the view/edit permissions. Attempt to access it when logged in as a different user to see if the permissions are respected.

## Screenshots / screencast

It's pretty cool:
<img width="4355" height="2101" alt="2026-07-08_16-23" src="https://github.com/user-attachments/assets/693b8295-8a84-42d8-b199-fd1c86bbd9e8" />
