### PR TITLE
chore: Enable GZip compression on Django endpoints

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -350,9 +350,11 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
-    # Enable gzip compression on everything served from Django. This impacts
-    # /graphql/, /mcp, all web apps and the Django admin.
-    "django.middleware.gzip.GZipMiddleware",
+    # Enable gzip compression on everything served from Django except SSE
+    # streams. This impacts /graphql/, /mcp, all web apps and the Django admin.
+    # Note: SSE issues appears resolved in Django 6.0, to check when we upgrade:
+    # https://github.com/django/django/commit/bb4fcf5f67e6a39440bb1271450319604a755f2e
+    "hexa.core.middlewares.SSEAwareGZipMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "hexa.core.middlewares.RequestTooBigMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -350,6 +350,9 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    # Enable gzip compression on everything served from Django. This impacts
+    # /graphql/, /mcp, all web apps and the Django admin.
+    "django.middleware.gzip.GZipMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "hexa.core.middlewares.RequestTooBigMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",

--- a/backend/hexa/core/middlewares.py
+++ b/backend/hexa/core/middlewares.py
@@ -3,11 +3,27 @@ import logging
 from django.core.exceptions import RequestDataTooBig
 from django.db import connection
 from django.http import HttpRequest, JsonResponse
+from django.middleware.gzip import GZipMiddleware
 from django.utils import timezone
 from oauth2_provider.models import AccessToken
 
 logger = logging.getLogger(__name__)
 security_logger = logging.getLogger("django.security.RequestDataTooBig")
+
+
+class SSEAwareGZipMiddleware(GZipMiddleware):
+    """GZipMiddleware that leaves Server-Sent Events responses uncompressed.
+
+    GZipMiddleware compresses each chunk of an async streaming response as a
+    separate gzip member, which browsers can't reliably stream-decode, and it
+    reintroduces the buffering that SSE responses explicitly disable
+    (X-Accel-Buffering: no) — events would arrive late or not at all.
+    """
+
+    def process_response(self, request, response):
+        if response.get("Content-Type", "").startswith("text/event-stream"):
+            return response
+        return super().process_response(request, response)
 
 
 class RequestTooBigMiddleware:

--- a/backend/hexa/pipelines/tests/test_views.py
+++ b/backend/hexa/pipelines/tests/test_views.py
@@ -561,6 +561,21 @@ class SSEStreamTest(TestCase):
         self.assertEqual(events[0]["data"]["message"], "Second")
         self.assertEqual(events[1]["event"], "done")
 
+    def test_stream_is_not_gzipped(self):
+        # SSEAwareGZipMiddleware must skip SSE responses: compressing each
+        # streamed chunk as a separate gzip member breaks browser-side decoding
+        # and buffers events instead of delivering them in real time.
+        messages = [{"message": "Starting", "timestamp": None, "priority": "INFO"}]
+        run = self._make_run(PipelineRunState.SUCCESS, messages=messages)
+        self.client.force_login(self.USER)
+        response = self.client.get(self._url(run.id), HTTP_ACCEPT_ENCODING="gzip")
+        self.assertEqual(response.status_code, 200)
+        # GZip middleware sets `Content-Encoding: gzip`, verify that it didn't do that
+        self.assertNotIn("Content-Encoding", response)
+        events = self._consume(response)
+        self.assertEqual(events[0]["data"]["message"], "Starting")
+        self.assertEqual(events[-1]["event"], "done")
+
     def test_terminal_run_invalid_cursor_defaults_to_zero(self):
         run = self._make_run(PipelineRunState.SUCCESS, messages=[])
         self.client.force_login(self.USER)

--- a/backend/hexa/webapps/tests/test_compression.py
+++ b/backend/hexa/webapps/tests/test_compression.py
@@ -1,0 +1,76 @@
+import gzip
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from hexa.core.test import TestCase
+from hexa.user_management.models import User
+from hexa.webapps.models import GitWebapp, Webapp
+from hexa.workspaces.models import Workspace
+
+
+@override_settings(
+    WEBAPPS_DOMAIN="webapps.localhost:8000",
+    ALLOWED_HOSTS=["*"],
+)
+class WebappCompressionTest(TestCase):
+    """Nothing downstream of Django compresses in production (GCLB does no
+    dynamic compression), so GZipMiddleware must gzip webapp responses itself —
+    and it must run *after* the middlewares that rewrite the response body
+    (banner/context injection), otherwise those would corrupt the gzip stream.
+    """
+
+    SUBDOMAIN_BASE = "webapps.localhost:8000"
+    # GZipMiddleware skips bodies under 200 bytes; make ours comfortably bigger.
+    HTML = b"<html><head></head><body>" + b"x" * 500 + b"</body></html>"
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.USER = User.objects.create_user("gzip@test.com", "password")
+        cls.WORKSPACE = Workspace.objects.create(
+            name="Gzip Workspace", slug="gzip-workspace"
+        )
+        cls.WEBAPP = GitWebapp.objects.create(
+            workspace=cls.WORKSPACE,
+            name="Gzip Public",
+            slug="gzip-public",
+            subdomain="gzip-public",
+            type=Webapp.WebappType.STATIC,
+            created_by=cls.USER,
+            repository="gzip-public-repo",
+            published_commit="sha-gzip-v1",
+            is_public=True,
+        )
+
+    def _get(self, **kwargs):
+        return self.client.get(
+            "/", HTTP_HOST=f"{self.WEBAPP.subdomain}.{self.SUBDOMAIN_BASE}", **kwargs
+        )
+
+    @patch("hexa.webapps.views.get_forgejo_client")
+    def test_response_is_gzipped_when_client_accepts_it(self, mock_get_client):
+        mock_get_client.return_value.get_file.return_value = self.HTML
+
+        response = self._get(HTTP_ACCEPT_ENCODING="gzip")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Encoding"], "gzip")
+        self.assertIn("Accept-Encoding", response["Vary"])
+        # The ETag must stay weak so the 304 revalidation flow keeps working
+        # on compressed representations.
+        self.assertEqual(response["ETag"], 'W/"sha-gzip-v1"')
+
+        body = gzip.decompress(response.content)
+        # Body injection (banner, OPENHEXA context) must have happened before
+        # compression — the decompressed payload is the fully rewritten HTML.
+        self.assertIn(b"x" * 500, body)
+        self.assertIn(b"window.OPENHEXA", body)
+        self.assertIn(b"Powered by", body)
+
+    @patch("hexa.webapps.views.get_forgejo_client")
+    def test_response_is_not_gzipped_without_accept_encoding(self, mock_get_client):
+        mock_get_client.return_value.get_file.return_value = self.HTML
+
+        response = self._get(HTTP_ACCEPT_ENCODING="identity")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Content-Encoding", response)
+        self.assertIn(b"x" * 500, response.content)


### PR DESCRIPTION
A suggestion from @madewulf :

This commit enables gzip compression on everything served from Django.

This is huge, it impacts:
- `/graphql/`
- `/mcp`
- Served web apps
- the Django admin

This means we can expect a 3–10x reduction on size of text-based payloads on all API calls and served web apps.

## Screenshots / screencast

### Serving a web app
<img width="1856" height="716" alt="2026-07-08_16-00" src="https://github.com/user-attachments/assets/0bbebd08-a9e2-4738-a5d3-f0718f17d7d9" />
<img width="1860" height="740" alt="2026-07-08_16-01" src="https://github.com/user-attachments/assets/feaa7d64-1f1e-4bed-9de9-48d04981243d" />


### Regular GraphQL calls
<img width="1864" height="550" alt="2026-07-08_16-41" src="https://github.com/user-attachments/assets/f58e58c2-871e-4998-9274-b29546fc15ff" />
<img width="1859" height="620" alt="2026-07-08_16-42" src="https://github.com/user-attachments/assets/7aaa2e40-6dcc-45c7-8af2-22c2efd7c7de" />


