### PR TITLE
fix: read only db user has no select grant on tutorial covid data table (HEXA-1734)

### DIFF
--- a/backend/hexa/databases/api.py
+++ b/backend/hexa/databases/api.py
@@ -266,6 +266,11 @@ def load_database_sample_data(db_name: str):
                         role_name=sql.Identifier(db_name)
                     )
                 )
+                cursor.execute(
+                    sql.SQL("GRANT SELECT ON covid_data TO {ro_role};").format(
+                        ro_role=sql.Identifier(f"{db_name}_ro")
+                    )
+                )
 
     finally:
         if conn:

--- a/backend/hexa/databases/api.py
+++ b/backend/hexa/databases/api.py
@@ -18,15 +18,17 @@ def get_db_server_credentials():
     }
 
 
-def get_database_connection(database: str):
+def get_database_connection(database: str, user: str = None, password: str = None):
     credentials = get_db_server_credentials()
-    role = credentials["role"]
-    password = credentials["password"]
     host = credentials["host"]
     port = credentials["port"]
 
     return psycopg2.connect(
-        host=host, port=port, dbname=database, user=role, password=password
+        host=host,
+        port=port,
+        dbname=database,
+        user=user or credentials["role"],
+        password=password or credentials["password"],
     )
 
 
@@ -251,27 +253,16 @@ def update_database_password(db_role: str, new_password: str):
             conn.close()
 
 
-def load_database_sample_data(db_name: str):
+def load_database_sample_data(db_name: str, db_password: str):
     conn = None
     try:
-        conn = get_database_connection(db_name)
+        conn = get_database_connection(db_name, user=db_name, password=db_password)
         conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         with conn.cursor() as cursor:
             with open(
                 os.path.join(os.path.dirname(__file__), "static/demo.sql")
             ) as file:
                 cursor.execute(file.read())
-                cursor.execute(
-                    sql.SQL("ALTER TABLE covid_data OWNER TO {role_name};").format(
-                        role_name=sql.Identifier(db_name)
-                    )
-                )
-                cursor.execute(
-                    sql.SQL("GRANT SELECT ON covid_data TO {ro_role};").format(
-                        ro_role=sql.Identifier(f"{db_name}_ro")
-                    )
-                )
-
     finally:
         if conn:
             conn.close()

--- a/backend/hexa/databases/tests/helpers.py
+++ b/backend/hexa/databases/tests/helpers.py
@@ -1,12 +1,28 @@
 from psycopg2 import sql
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
+from hexa.databases.api import get_database_connection
 from hexa.databases.utils import get_workspace_database_connection
 
 
 def seed_demo_table(workspace, rows, table_name="demo"):
-    """Create a demo table on the workspace database using the read-write role."""
-    conn = get_workspace_database_connection(workspace)
+    """Create a demo table with the read-write role.
+
+    The read-only role is auto-granted SELECT on it via ALTER DEFAULT PRIVILEGES.
+    """
+    _seed_table(get_workspace_database_connection(workspace), rows, table_name)
+
+
+def seed_demo_table_as_admin(workspace, rows, table_name="demo"):
+    """Create a demo table with the admin role.
+
+    The read-only role has no SELECT grant on it, reproducing tables like the
+    tutorial ``covid_data``.
+    """
+    _seed_table(get_database_connection(workspace.db_name), rows, table_name)
+
+
+def _seed_table(conn, rows, table_name):
     conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
     table = sql.Identifier(table_name)
     try:

--- a/backend/hexa/databases/tests/helpers.py
+++ b/backend/hexa/databases/tests/helpers.py
@@ -1,28 +1,12 @@
 from psycopg2 import sql
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
-from hexa.databases.api import get_database_connection
 from hexa.databases.utils import get_workspace_database_connection
 
 
 def seed_demo_table(workspace, rows, table_name="demo"):
-    """Create a demo table with the read-write role.
-
-    The read-only role is auto-granted SELECT on it via ALTER DEFAULT PRIVILEGES.
-    """
-    _seed_table(get_workspace_database_connection(workspace), rows, table_name)
-
-
-def seed_demo_table_as_admin(workspace, rows, table_name="demo"):
-    """Create a demo table with the admin role.
-
-    The read-only role has no SELECT grant on it, reproducing tables like the
-    tutorial ``covid_data``.
-    """
-    _seed_table(get_database_connection(workspace.db_name), rows, table_name)
-
-
-def _seed_table(conn, rows, table_name):
+    """Create a demo table on the workspace database using the read-write role."""
+    conn = get_workspace_database_connection(workspace)
     conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
     table = sql.Identifier(table_name)
     try:

--- a/backend/hexa/databases/tests/test_api.py
+++ b/backend/hexa/databases/tests/test_api.py
@@ -161,7 +161,7 @@ class DatabaseAPITest(TestCase):
         credentials = get_db_server_credentials()
         host = credentials["host"]
         port = credentials["port"]
-        load_database_sample_data(self.DB1_NAME)
+        load_database_sample_data(self.DB1_NAME, self.PWD_1)
 
         with psycopg2.connect(
             host=host,

--- a/backend/hexa/databases/tests/test_api.py
+++ b/backend/hexa/databases/tests/test_api.py
@@ -184,6 +184,11 @@ class DatabaseAPITest(TestCase):
             )
             self.assertEqual(len(cursor.fetchall()), 1)
 
+        with self._connect_as_ro_role() as ro_conn:
+            ro_cursor = ro_conn.cursor()
+            ro_cursor.execute("SELECT count(*) FROM covid_data;")
+            self.assertGreater(ro_cursor.fetchone()[0], 0)
+
     def test_database_limitation_settings(self):
         """Test that database-level limits are properly configured when creating a database."""
         credentials = get_db_server_credentials()

--- a/backend/hexa/workspaces/migrations/0061_grant_select_on_covid_data_to_ro_role.py
+++ b/backend/hexa/workspaces/migrations/0061_grant_select_on_covid_data_to_ro_role.py
@@ -5,19 +5,14 @@ from psycopg2 import sql
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 
-def get_admin_connection(db_name):
-    """Get a connection to a specific database using the admin role."""
-    host = settings.WORKSPACES_DATABASE_HOST
-    port = settings.WORKSPACES_DATABASE_PORT
-    admin_role = settings.WORKSPACES_DATABASE_ROLE
-    admin_password = settings.WORKSPACES_DATABASE_PASSWORD
-
+def get_rw_connection(workspace):
+    """Connect to a workspace database as its read-write role."""
     conn = psycopg2.connect(
-        host=host,
-        port=port,
-        dbname=db_name,
-        user=admin_role,
-        password=admin_password,
+        host=settings.WORKSPACES_DATABASE_HOST,
+        port=settings.WORKSPACES_DATABASE_PORT,
+        dbname=workspace.db_name,
+        user=workspace.db_name,
+        password=workspace.db_password,
     )
     conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
     return conn
@@ -36,7 +31,7 @@ def grant_select_on_covid_data(apps, schema_editor):
         ro_role = f"{db_name}_ro"
 
         try:
-            conn = get_admin_connection(db_name)
+            conn = get_rw_connection(workspace)
             try:
                 with conn.cursor() as cur:
                     cur.execute("SELECT to_regclass('public.covid_data');")

--- a/backend/hexa/workspaces/migrations/0061_grant_select_on_covid_data_to_ro_role.py
+++ b/backend/hexa/workspaces/migrations/0061_grant_select_on_covid_data_to_ro_role.py
@@ -1,0 +1,76 @@
+import psycopg2
+from django.conf import settings
+from django.db import migrations
+from psycopg2 import sql
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+
+def get_admin_connection(db_name):
+    """Get a connection to a specific database using the admin role."""
+    host = settings.WORKSPACES_DATABASE_HOST
+    port = settings.WORKSPACES_DATABASE_PORT
+    admin_role = settings.WORKSPACES_DATABASE_ROLE
+    admin_password = settings.WORKSPACES_DATABASE_PASSWORD
+
+    conn = psycopg2.connect(
+        host=host,
+        port=port,
+        dbname=db_name,
+        user=admin_role,
+        password=admin_password,
+    )
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    return conn
+
+
+def grant_select_on_covid_data(apps, schema_editor):
+    """
+    Back-fill the read-only role's SELECT grant on the tutorial covid_data table.
+    """
+    Workspace = apps.get_model("workspaces", "Workspace")
+
+    granted = 0
+    skipped = 0
+    for workspace in Workspace.objects.filter(db_ro_password__isnull=False):
+        db_name = workspace.db_name
+        ro_role = f"{db_name}_ro"
+
+        try:
+            conn = get_admin_connection(db_name)
+            try:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT to_regclass('public.covid_data');")
+                    if cur.fetchone()[0] is None:
+                        skipped += 1
+                        print(
+                            f"[0061] Skipping workspace {workspace.id} ({db_name}): "
+                            "no covid_data table"
+                        )
+                        continue
+                    cur.execute(
+                        sql.SQL("GRANT SELECT ON covid_data TO {role}").format(
+                            role=sql.Identifier(ro_role),
+                        )
+                    )
+                    granted += 1
+                    print(f"[0061] Granted SELECT on covid_data to {ro_role}")
+            finally:
+                conn.close()
+        except Exception as exc:
+            skipped += 1
+            print(f"[0061] Skipping workspace {workspace.id} ({db_name}): {exc}")
+
+    print(f"[0061] Done. Granted on {granted} workspace(s), skipped {skipped}.")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workspaces", "0060_grant_create_on_public_to_rw_role"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            grant_select_on_covid_data,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/backend/hexa/workspaces/migrations/0061_grant_select_on_covid_data_to_ro_role.py
+++ b/backend/hexa/workspaces/migrations/0061_grant_select_on_covid_data_to_ro_role.py
@@ -61,9 +61,13 @@ def grant_select_on_covid_data(apps, schema_editor):
             failed.append(db_name)
             print(f"[0061] Failed on workspace {workspace.id} ({db_name}): {exc}")
 
-    print(f"[0061] Done. Granted SELECT on covid_data for {granted}/{total} workspace(s).")
+    print(
+        f"[0061] Done. Granted SELECT on covid_data for {granted}/{total} workspace(s)."
+    )
     if no_table:
-        print(f"[0061] {len(no_table)} without the tutorial table: {', '.join(no_table)}")
+        print(
+            f"[0061] {len(no_table)} without the tutorial table: {', '.join(no_table)}"
+        )
     if failed:
         print(f"[0061] {len(failed)} failed: {', '.join(failed)}")
 

--- a/backend/hexa/workspaces/migrations/0061_grant_select_on_covid_data_to_ro_role.py
+++ b/backend/hexa/workspaces/migrations/0061_grant_select_on_covid_data_to_ro_role.py
@@ -21,12 +21,23 @@ def get_rw_connection(workspace):
 def grant_select_on_covid_data(apps, schema_editor):
     """
     Back-fill the read-only role's SELECT grant on the tutorial covid_data table.
+
+    Connect as the workspace's read-write role, which owns covid_data (created by
+    it on the current path, and reassigned to it via `ALTER TABLE OWNER` on the
+    legacy path). An object's owner can always GRANT, so this does not rely on the
+    admin role being a superuser or a member of the RW role — both of which are
+    false for workspaces created before those grants were introduced.
+
+    Idempotent: re-granting SELECT the RO role already holds is a no-op.
     """
     Workspace = apps.get_model("workspaces", "Workspace")
 
+    total = 0
     granted = 0
-    skipped = 0
-    for workspace in Workspace.objects.filter(db_ro_password__isnull=False):
+    no_table = []
+    failed = []
+    for workspace in Workspace.objects.all():
+        total += 1
         db_name = workspace.db_name
         ro_role = f"{db_name}_ro"
 
@@ -36,11 +47,7 @@ def grant_select_on_covid_data(apps, schema_editor):
                 with conn.cursor() as cur:
                     cur.execute("SELECT to_regclass('public.covid_data');")
                     if cur.fetchone()[0] is None:
-                        skipped += 1
-                        print(
-                            f"[0061] Skipping workspace {workspace.id} ({db_name}): "
-                            "no covid_data table"
-                        )
+                        no_table.append(db_name)
                         continue
                     cur.execute(
                         sql.SQL("GRANT SELECT ON covid_data TO {role}").format(
@@ -48,14 +55,17 @@ def grant_select_on_covid_data(apps, schema_editor):
                         )
                     )
                     granted += 1
-                    print(f"[0061] Granted SELECT on covid_data to {ro_role}")
             finally:
                 conn.close()
         except Exception as exc:
-            skipped += 1
-            print(f"[0061] Skipping workspace {workspace.id} ({db_name}): {exc}")
+            failed.append(db_name)
+            print(f"[0061] Failed on workspace {workspace.id} ({db_name}): {exc}")
 
-    print(f"[0061] Done. Granted on {granted} workspace(s), skipped {skipped}.")
+    print(f"[0061] Done. Granted SELECT on covid_data for {granted}/{total} workspace(s).")
+    if no_table:
+        print(f"[0061] {len(no_table)} without the tutorial table: {', '.join(no_table)}")
+    if failed:
+        print(f"[0061] {len(failed)} failed: {', '.join(failed)}")
 
 
 class Migration(migrations.Migration):

--- a/backend/hexa/workspaces/models.py
+++ b/backend/hexa/workspaces/models.py
@@ -148,7 +148,7 @@ class WorkspaceManager(models.Manager):
         create_kwargs["bucket_name"] = bucket_name
 
         if load_sample_data:
-            load_database_sample_data(db_name)
+            load_database_sample_data(db_name, db_password)
             load_bucket_sample_data(bucket_name)
 
         workspace = self.create(**create_kwargs)

--- a/backend/hexa/workspaces/tests/migrations/test_0061_grant_select_on_covid_data_to_ro_role.py
+++ b/backend/hexa/workspaces/tests/migrations/test_0061_grant_select_on_covid_data_to_ro_role.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import TransactionTestCase
 from psycopg2 import sql
 from psycopg2.errors import (
@@ -28,9 +30,12 @@ class Migration0061Test(TransactionTestCase):
         self.user = User.objects.create_user(
             "migration-test@example.com", "password", is_superuser=True
         )
-        self.workspace = Workspace.objects.create_if_has_perm(
-            self.user, name="Covid WS", description="", load_sample_data=True
-        )
+        # The dummy test storage doesn't support bucket sample data; the database
+        # part of the tutorial load is what matters here.
+        with patch("hexa.workspaces.models.load_bucket_sample_data"):
+            self.workspace = Workspace.objects.create_if_has_perm(
+                self.user, name="Covid WS", description="", load_sample_data=True
+            )
         # Revoke the auto-granted SELECT to reproduce a pre-fix workspace where
         # the read-only role cannot read the tutorial covid_data table.
         conn = get_workspace_database_connection(self.workspace)

--- a/backend/hexa/workspaces/tests/migrations/test_0061_grant_select_on_covid_data_to_ro_role.py
+++ b/backend/hexa/workspaces/tests/migrations/test_0061_grant_select_on_covid_data_to_ro_role.py
@@ -7,7 +7,6 @@ from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 from hexa.core.test.migrator import Migrator
 from hexa.databases.api import delete_database
-from hexa.databases.tests.helpers import seed_demo_table
 from hexa.databases.utils import (
     get_workspace_database_connection,
     get_workspace_database_ro_connection,
@@ -30,9 +29,10 @@ class Migration0061Test(TransactionTestCase):
             "migration-test@example.com", "password", is_superuser=True
         )
         self.workspace = Workspace.objects.create_if_has_perm(
-            self.user, name="Covid WS", description=""
+            self.user, name="Covid WS", description="", load_sample_data=True
         )
-        seed_demo_table(self.workspace, [(1, "Kinshasa")], table_name="covid_data")
+        # Revoke the auto-granted SELECT to reproduce a pre-fix workspace where
+        # the read-only role cannot read the tutorial covid_data table.
         conn = get_workspace_database_connection(self.workspace)
         conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
         with conn.cursor() as cur:
@@ -61,4 +61,4 @@ class Migration0061Test(TransactionTestCase):
 
         self.migrator.migrate(*self.migrate_to)
 
-        self.assertEqual(self._count_covid_data_as_ro(), 1)
+        self.assertGreater(self._count_covid_data_as_ro(), 0)

--- a/backend/hexa/workspaces/tests/migrations/test_0061_grant_select_on_covid_data_to_ro_role.py
+++ b/backend/hexa/workspaces/tests/migrations/test_0061_grant_select_on_covid_data_to_ro_role.py
@@ -1,12 +1,17 @@
 from django.test import TransactionTestCase
+from psycopg2 import sql
 from psycopg2.errors import (
     InsufficientPrivilege,  # type: ignore[import-not-found] # psycopg2.errors is not in typeshed yet
 )
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 from hexa.core.test.migrator import Migrator
 from hexa.databases.api import delete_database
-from hexa.databases.tests.helpers import seed_demo_table_as_admin
-from hexa.databases.utils import get_workspace_database_ro_connection
+from hexa.databases.tests.helpers import seed_demo_table
+from hexa.databases.utils import (
+    get_workspace_database_connection,
+    get_workspace_database_ro_connection,
+)
 from hexa.files import storage
 from hexa.user_management.models import User
 from hexa.workspaces.models import Workspace
@@ -27,9 +32,16 @@ class Migration0061Test(TransactionTestCase):
         self.workspace = Workspace.objects.create_if_has_perm(
             self.user, name="Covid WS", description=""
         )
-        seed_demo_table_as_admin(
-            self.workspace, [(1, "Kinshasa")], table_name="covid_data"
-        )
+        seed_demo_table(self.workspace, [(1, "Kinshasa")], table_name="covid_data")
+        conn = get_workspace_database_connection(self.workspace)
+        conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        with conn.cursor() as cur:
+            cur.execute(
+                sql.SQL("REVOKE SELECT ON covid_data FROM {role};").format(
+                    role=sql.Identifier(self.workspace.db_ro_username)
+                )
+            )
+        conn.close()
 
     def tearDown(self):
         delete_database(self.workspace.db_name)

--- a/backend/hexa/workspaces/tests/migrations/test_0061_grant_select_on_covid_data_to_ro_role.py
+++ b/backend/hexa/workspaces/tests/migrations/test_0061_grant_select_on_covid_data_to_ro_role.py
@@ -1,0 +1,52 @@
+from django.test import TransactionTestCase
+from psycopg2.errors import (
+    InsufficientPrivilege,  # type: ignore[import-not-found] # psycopg2.errors is not in typeshed yet
+)
+
+from hexa.core.test.migrator import Migrator
+from hexa.databases.api import delete_database
+from hexa.databases.tests.helpers import seed_demo_table_as_admin
+from hexa.databases.utils import get_workspace_database_ro_connection
+from hexa.files import storage
+from hexa.user_management.models import User
+from hexa.workspaces.models import Workspace
+
+
+class Migration0061Test(TransactionTestCase):
+    migrate_from = ("workspaces", "0060_grant_create_on_public_to_rw_role")
+    migrate_to = ("workspaces", "0061_grant_select_on_covid_data_to_ro_role")
+
+    def setUp(self):
+        storage.reset()
+        self.migrator = Migrator()
+        self.migrator.migrate(*self.migrate_from)
+
+        self.user = User.objects.create_user(
+            "migration-test@example.com", "password", is_superuser=True
+        )
+        self.workspace = Workspace.objects.create_if_has_perm(
+            self.user, name="Covid WS", description=""
+        )
+        seed_demo_table_as_admin(
+            self.workspace, [(1, "Kinshasa")], table_name="covid_data"
+        )
+
+    def tearDown(self):
+        delete_database(self.workspace.db_name)
+
+    def _count_covid_data_as_ro(self):
+        conn = get_workspace_database_ro_connection(self.workspace)
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT count(*) FROM covid_data;")
+                return cur.fetchone()[0]
+        finally:
+            conn.close()
+
+    def test_migration_grants_ro_role_select_on_covid_data(self):
+        with self.assertRaises(InsufficientPrivilege):
+            self._count_covid_data_as_ro()
+
+        self.migrator.migrate(*self.migrate_to)
+
+        self.assertEqual(self._count_covid_data_as_ro(), 1)


### PR DESCRIPTION
We were not granting permissions on the tutorial table to the read-only role. 

Longer term fix by using the RW role to seed the database