### PR TITLE
chore: Bring back BYOK option on organization when the instance is managed (HEXA-1753)

### DIFF
--- a/frontend/src/organizations/features/OrganizationAiSettings/OrganizationAiSettings.tsx
+++ b/frontend/src/organizations/features/OrganizationAiSettings/OrganizationAiSettings.tsx
@@ -17,6 +17,11 @@ const MODELS: Record<string, string[]> = {
   [AiProvider.Anthropic]: ["", AiModel.Opus, AiModel.Sonnet, AiModel.Haiku],
 };
 
+const usesManagedProvider = (value: unknown) => value === AiProvider.Managed;
+
+const showByok = (values: { enableAI?: unknown; provider?: unknown }) =>
+  Boolean(values.enableAI) && !usesManagedProvider(values.provider);
+
 type OrganizationAiSettingsProps = {
   organization: Organization_OrganizationFragment;
 };
@@ -51,8 +56,6 @@ const OrganizationAiSettings = ({
     providersMap[type] || String(type);
   const getModelLabel = (type: string): string =>
     modelsMap[type] || String(type);
-
-  const usesManagedProvider = (value: unknown) => value === AiProvider.Managed;
 
   const providerOptions = isManagedInstance
     ? [AiProvider.Managed, AiProvider.Anthropic]
@@ -105,12 +108,8 @@ const OrganizationAiSettings = ({
           label={t("Model")}
           options={modelOptions}
           getOptionLabel={getModelLabel}
-          visible={(_, __, values) =>
-            Boolean(values.enableAI) && !usesManagedProvider(values.provider)
-          }
-          required={(_, __, values) =>
-            Boolean(values.enableAI) && !usesManagedProvider(values.provider)
-          }
+          visible={(_, __, values) => showByok(values)}
+          required={(_, __, values) => showByok(values)}
         />
         <TextProperty
           id="apiKey"
@@ -120,14 +119,8 @@ const OrganizationAiSettings = ({
             settings?.hasApiKey ? t("Leave blank to keep current API key") : ""
           }
           label={t("API Key")}
-          visible={(_, __, values) =>
-            Boolean(values.enableAI) && !usesManagedProvider(values.provider)
-          }
-          required={(_, __, values) =>
-            Boolean(values.enableAI) &&
-            !usesManagedProvider(values.provider) &&
-            !settings?.hasApiKey
-          }
+          visible={(_, __, values) => showByok(values)}
+          required={(_, __, values) => showByok(values) && !settings?.hasApiKey}
         />
       </DataCard.FormSection>
     </DataCard>

--- a/frontend/src/organizations/features/OrganizationAiSettings/OrganizationAiSettings.tsx
+++ b/frontend/src/organizations/features/OrganizationAiSettings/OrganizationAiSettings.tsx
@@ -54,14 +54,19 @@ const OrganizationAiSettings = ({
 
   const usesManagedProvider = (value: unknown) => value === AiProvider.Managed;
 
+  const providerOptions = isManagedInstance
+    ? [AiProvider.Managed, AiProvider.Anthropic]
+    : [AiProvider.Anthropic];
+
   const onSave: OnSaveFn = async (values) => {
+    const usesManaged = usesManagedProvider(values.provider);
     await updateOrganizationAiSettings({
       variables: {
         input: {
           organizationId: organization.id,
           enabled: values.enableAI,
-          provider: isManagedInstance ? AiProvider.Managed : values.provider,
-          ...(isManagedInstance
+          provider: values.provider,
+          ...(usesManaged
             ? {}
             : { model: values.model, apiKey: values.apiKey }),
         },
@@ -86,17 +91,13 @@ const OrganizationAiSettings = ({
           id="provider"
           accessor="aiSettings.provider"
           label={t("Provider")}
-          options={[AiProvider.Anthropic]}
+          options={providerOptions}
           getOptionLabel={getProviderLabel}
           onChange={(value: string) => {
             setProvider(value);
           }}
-          visible={(_, __, values) =>
-            Boolean(values.enableAI) && !isManagedInstance
-          }
-          required={(_, __, values) =>
-            Boolean(values.enableAI) && !isManagedInstance
-          }
+          visible={(_, __, values) => Boolean(values.enableAI)}
+          required={(_, __, values) => Boolean(values.enableAI)}
         />
         <SimpleSelectProperty
           id="model"
@@ -105,14 +106,10 @@ const OrganizationAiSettings = ({
           options={modelOptions}
           getOptionLabel={getModelLabel}
           visible={(_, __, values) =>
-            Boolean(values.enableAI) &&
-            !isManagedInstance &&
-            !usesManagedProvider(values.provider)
+            Boolean(values.enableAI) && !usesManagedProvider(values.provider)
           }
           required={(_, __, values) =>
-            Boolean(values.enableAI) &&
-            !isManagedInstance &&
-            !usesManagedProvider(values.provider)
+            Boolean(values.enableAI) && !usesManagedProvider(values.provider)
           }
         />
         <TextProperty
@@ -124,13 +121,10 @@ const OrganizationAiSettings = ({
           }
           label={t("API Key")}
           visible={(_, __, values) =>
-            Boolean(values.enableAI) &&
-            !isManagedInstance &&
-            !usesManagedProvider(values.provider)
+            Boolean(values.enableAI) && !usesManagedProvider(values.provider)
           }
           required={(_, __, values) =>
             Boolean(values.enableAI) &&
-            !isManagedInstance &&
             !usesManagedProvider(values.provider) &&
             !settings?.hasApiKey
           }

--- a/frontend/src/organizations/features/OrganizationAiSettings/__tests__/OrganizationAiSettings.test.tsx
+++ b/frontend/src/organizations/features/OrganizationAiSettings/__tests__/OrganizationAiSettings.test.tsx
@@ -43,14 +43,12 @@ const AI_LABELS = {
   ],
 };
 
-const buildOrganization = (
-  aiSettings: {
-    enabled: boolean;
-    provider: AiProvider | null;
-    model?: string | null;
-    hasApiKey?: boolean;
-  },
-) =>
+const buildOrganization = (aiSettings: {
+  enabled: boolean;
+  provider: AiProvider | null;
+  model?: string | null;
+  hasApiKey?: boolean;
+}) =>
   ({
     id: v4(),
     permissions: { update: true },
@@ -145,6 +143,34 @@ describe("OrganizationAiSettings", () => {
       expect(screen.getByText("Model")).toBeInTheDocument();
       expect(screen.getByText("API Key")).toBeInTheDocument();
     });
+  });
+
+  it("does not resend the masked API key when it is left untouched", async () => {
+    mockAiLabels(false);
+    const mutate = jest.fn().mockResolvedValue({});
+    useUpdateOrganizationAiSettingsMutationMock.mockReturnValue([mutate, {}]);
+    const user = userEvent.setup();
+
+    render(
+      <TestApp>
+        <OrganizationAiSettings
+          organization={buildOrganization({
+            enabled: true,
+            provider: AiProvider.Anthropic,
+            model: "opus",
+            hasApiKey: true,
+          })}
+        />
+      </TestApp>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(mutate).toHaveBeenCalled());
+
+    const { apiKey } = mutate.mock.calls[0][0].variables.input;
+    expect(apiKey).not.toBe("••••••");
   });
 
   it("only offers the Anthropic provider on a self-hosted instance", async () => {

--- a/frontend/src/organizations/features/OrganizationAiSettings/__tests__/OrganizationAiSettings.test.tsx
+++ b/frontend/src/organizations/features/OrganizationAiSettings/__tests__/OrganizationAiSettings.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { v4 } from "uuid";
+import { TestApp } from "core/helpers/testutils";
+import { AiProvider } from "graphql/types";
+import { useAiLabelsQuery } from "organizations/graphql/queries.generated";
+import { useUpdateOrganizationAiSettingsMutation } from "organizations/graphql/mutations.generated";
+import OrganizationAiSettings from "../OrganizationAiSettings";
+
+jest.mock("organizations/graphql/queries.generated", () => ({
+  ...jest.requireActual("organizations/graphql/queries.generated"),
+  useAiLabelsQuery: jest.fn(),
+}));
+
+jest.mock("organizations/graphql/mutations.generated", () => ({
+  ...jest.requireActual("organizations/graphql/mutations.generated"),
+  useUpdateOrganizationAiSettingsMutation: jest.fn(),
+}));
+
+jest.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  i18n: {
+    t: (key: string) => key,
+  },
+}));
+
+const useAiLabelsQueryMock = useAiLabelsQuery as jest.Mock;
+const useUpdateOrganizationAiSettingsMutationMock =
+  useUpdateOrganizationAiSettingsMutation as jest.Mock;
+
+const AI_LABELS = {
+  providers: [
+    { value: "managed", label: "Managed" },
+    { value: "anthropic", label: "Anthropic" },
+  ],
+  models: [
+    { value: "opus", label: "Opus" },
+    { value: "sonnet", label: "Sonnet" },
+    { value: "haiku", label: "Haiku" },
+  ],
+};
+
+const buildOrganization = (
+  aiSettings: {
+    enabled: boolean;
+    provider: AiProvider | null;
+    model?: string | null;
+    hasApiKey?: boolean;
+  },
+) =>
+  ({
+    id: v4(),
+    permissions: { update: true },
+    aiSettings: {
+      model: null,
+      hasApiKey: false,
+      ...aiSettings,
+    },
+  }) as any;
+
+const mockAiLabels = (assistantManaged: boolean) => {
+  useAiLabelsQueryMock.mockReturnValue({
+    data: {
+      aiLabels: AI_LABELS,
+      config: { assistantManaged },
+    },
+  });
+};
+
+const getProviderSelect = () => {
+  const selects = screen.getAllByRole("combobox");
+  const providerSelect = selects.find((select) =>
+    within(select).queryByRole("option", { name: "Anthropic" }),
+  );
+  if (!providerSelect) {
+    throw new Error("Provider select not found");
+  }
+  return providerSelect;
+};
+
+const getOptionLabels = (select: HTMLElement) =>
+  within(select)
+    .getAllByRole("option")
+    .map((option) => option.textContent);
+
+describe("OrganizationAiSettings", () => {
+  beforeEach(() => {
+    useAiLabelsQueryMock.mockReset();
+    useUpdateOrganizationAiSettingsMutationMock.mockReset();
+    useUpdateOrganizationAiSettingsMutationMock.mockReturnValue([
+      jest.fn().mockResolvedValue({}),
+      {},
+    ]);
+  });
+
+  it("offers both Managed and Anthropic providers on a managed instance", async () => {
+    mockAiLabels(true);
+    const user = userEvent.setup();
+
+    render(
+      <TestApp>
+        <OrganizationAiSettings
+          organization={buildOrganization({
+            enabled: true,
+            provider: AiProvider.Managed,
+          })}
+        />
+      </TestApp>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(getOptionLabels(getProviderSelect())).toEqual([
+      "Managed",
+      "Anthropic",
+    ]);
+
+    // Managed provider keeps the BYOK fields hidden.
+    expect(screen.queryByText("Model")).not.toBeInTheDocument();
+    expect(screen.queryByText("API Key")).not.toBeInTheDocument();
+  });
+
+  it("reveals the model and API key fields when switching to Anthropic on a managed instance", async () => {
+    mockAiLabels(true);
+    const user = userEvent.setup();
+
+    render(
+      <TestApp>
+        <OrganizationAiSettings
+          organization={buildOrganization({
+            enabled: true,
+            provider: AiProvider.Managed,
+          })}
+        />
+      </TestApp>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+    await user.selectOptions(getProviderSelect(), "anthropic");
+
+    await waitFor(() => {
+      expect(screen.getByText("Model")).toBeInTheDocument();
+      expect(screen.getByText("API Key")).toBeInTheDocument();
+    });
+  });
+
+  it("only offers the Anthropic provider on a self-hosted instance", async () => {
+    mockAiLabels(false);
+    const user = userEvent.setup();
+
+    render(
+      <TestApp>
+        <OrganizationAiSettings
+          organization={buildOrganization({
+            enabled: true,
+            provider: AiProvider.Anthropic,
+          })}
+        />
+      </TestApp>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(getOptionLabels(getProviderSelect())).toEqual(["Anthropic"]);
+
+    // Anthropic provider always exposes the BYOK fields.
+    expect(screen.getByText("Model")).toBeInTheDocument();
+    expect(screen.getByText("API Key")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
On managed instances (`ASSISTANT_MANAGED=true`), the organization AI Assistant settings previously only exposed the **Enabled** toggle, forcing the provider to "Managed". 

This adds the ability for admins to opt out of the managed provider and bring their own Anthropic API key.

Jira: https://bluesquare.atlassian.net/browse/HEXA-175

## How/what to test

Navigate to the organization settings, confirm that the Anthropic options is now available.

## Screenshots

<img width="2391" height="436" alt="image" src="https://github.com/user-attachments/assets/b88d9989-543c-48c0-899e-fbd74ef801c9" />
<img width="2402" height="925" alt="image" src="https://github.com/user-attachments/assets/5bfa207f-fa07-46a2-8398-c8d513a381bb" />
