### PR TITLE
feat: Support the copying of template pipelines to a remote server (HEXA-1757)

### DIFF
--- a/backend/hexa/pipeline_templates/admin.py
+++ b/backend/hexa/pipeline_templates/admin.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
+from django.urls import path
 
 from hexa.core.admin import GlobalObjectsModelAdmin
 from hexa.pipeline_templates.models import PipelineTemplate, PipelineTemplateVersion
+from hexa.workspace_copier.admin import copy_templates_view
 
 
 @admin.register(PipelineTemplate)
@@ -10,6 +12,7 @@ class PipelineTemplateAdmin(GlobalObjectsModelAdmin):
     list_select_related = ("workspace",)
     list_filter = ("validated_at",)
     search_fields = ("id", "code", "name")
+    change_list_template = "admin/pipeline_templates/pipelinetemplate/change_list.html"
     fields = (
         "name",
         "code",
@@ -24,6 +27,16 @@ class PipelineTemplateAdmin(GlobalObjectsModelAdmin):
         "deleted_at",
     )
     readonly_fields = ("workspace", "source_pipeline", "created_at", "updated_at")
+
+    def get_urls(self):
+        custom = [
+            path(
+                "copy/",
+                self.admin_site.admin_view(copy_templates_view),
+                name="pipeline_templates_pipelinetemplate_copy",
+            ),
+        ]
+        return custom + super().get_urls()
 
 
 @admin.register(PipelineTemplateVersion)

--- a/backend/hexa/pipeline_templates/templates/admin/pipeline_templates/pipelinetemplate/change_list.html
+++ b/backend/hexa/pipeline_templates/templates/admin/pipeline_templates/pipelinetemplate/change_list.html
@@ -1,0 +1,13 @@
+{% extends "admin/change_list.html" %}
+{% load i18n %}
+
+{% block object-tools-items %}
+{% if user.is_superuser %}
+<li>
+    <a href="{% url 'admin:pipeline_templates_pipelinetemplate_copy' %}" class="addlink">
+        {% trans 'Copy pipeline templates' %}
+    </a>
+</li>
+{% endif %}
+{{ block.super }}
+{% endblock %}

--- a/backend/hexa/workspace_copier/README.md
+++ b/backend/hexa/workspace_copier/README.md
@@ -32,7 +32,9 @@ order (see `orchestrator.WORKSPACE_COPIERS`):
 | `connections` | `ConnectionsCopier`       | connections + secret fields                                                                        |
 | `pipelines`   | `PipelinesCopier`         | pipelines + versions (depends on `files` for notebook pipelines)                                   |
 
-`templates.py` (`TemplatesCopier`) is **not** in the registry — template pipelines are server-wide and copied by a separate flow.
+Template pipelines are **not** in this registry — they are server-wide, not a
+per-workspace resource, so they are copied by a separate flow (see
+[Template pipelines](#template-pipelines) below).
 
 Adding a resource is a drop-in: one module under `resources/` + one registry entry.
 
@@ -91,3 +93,27 @@ Note: `BufferReporter` is also the shape a future async-job reporter could follo
 ## Results
 
 Copiers record what they did/skipped/failed on a shared `CopyResult` (per-resource result dataclasses in `results.py`). `format_summary()` renders the human-readable summary shown by both the CLI and the admin page.
+
+## Template pipelines
+
+Pipeline templates are **server-wide**, not owned by a workspace, so they are copied by their own flow (`templates.copy_templates`) instead of being a resource in the registry above. It runs **once per target server**, independently of any workspace copy, and is **remote→remote only** (both sides need a URL + ServiceAccount token). For each source template it ensures a host pipeline (and its versions) exists on the target, then recreates the template and its versions. It is re-runnable: templates match by name, versions by number.
+
+Note: `validatedAt` is not settable via the API, so an official source template appears as a community template on the target (warned in the summary).
+
+### CLI
+
+```
+# --source-url defaults to production (https://api.openhexa.org/graphql/),
+# so it can be omitted when copying from prod.
+./manage.py copy_templates \
+	--source-token 'my-prod-service-account-token' \
+	--target-url https://api.demo.openhexa.org/graphql/ \
+	--target-token 'my-demo-service-account-token' \
+	--target-organization 002f2f74-7cdb-452c-8ef5-28cc27c04fbe # BLSQ org
+```
+
+`--target-organization` is where the dedicated "Template pipelines" host workspace is created when it doesn't already exist on the target.
+
+### Django Admin
+
+On the pipeline templates list page, there's a Superuser-only "Copy pipeline templates" button, with the same transient-credentials behavior as the workspace-copy view.

--- a/backend/hexa/workspace_copier/admin.py
+++ b/backend/hexa/workspace_copier/admin.py
@@ -11,10 +11,14 @@ from django.contrib import admin, messages
 from django.core.exceptions import PermissionDenied
 from django.template.response import TemplateResponse
 
-from hexa.workspace_copier.forms import CopyWorkspaceForm
+from hexa.workspace_copier.forms import CopyTemplatesForm, CopyWorkspaceForm
 from hexa.workspace_copier.progress import BufferReporter
-from hexa.workspace_copier.results import format_summary
-from hexa.workspace_copier.service import CredentialError, run_copy
+from hexa.workspace_copier.results import format_summary, format_templates_summary
+from hexa.workspace_copier.service import (
+    CredentialError,
+    run_copy,
+    run_template_copy,
+)
 from hexa.workspace_copier.transport import GraphQLError
 
 
@@ -61,4 +65,47 @@ def copy_workspace_view(request):
     }
     return TemplateResponse(
         request, "admin/workspace_copier/copy_workspace.html", context
+    )
+
+
+def copy_templates_view(request):
+    if not request.user.is_superuser:
+        raise PermissionDenied
+
+    summary = None
+    log = None
+    if request.method == "POST":
+        form = CopyTemplatesForm(request.POST)
+        if form.is_valid():
+            data = form.cleaned_data
+            reporter = BufferReporter()
+            try:
+                result = run_template_copy(
+                    source_url=data["source_url"],
+                    source_token=data["source_token"],
+                    target_url=data["target_url"],
+                    target_token=data["target_token"],
+                    target_organization_id=data["target_organization"],
+                    reporter=reporter,
+                )
+                summary = format_templates_summary(result)
+                log = reporter.render()
+                messages.success(request, "Template copy finished.")
+            except CredentialError as exc:
+                for err in exc.errors:
+                    messages.error(request, err)
+            except GraphQLError as exc:
+                messages.error(request, f"Copy failed: {exc}")
+    else:
+        form = CopyTemplatesForm()
+
+    context = {
+        **admin.site.each_context(request),
+        "title": "Copy pipeline templates",
+        "form": form,
+        "summary": summary,
+        "log": log,
+    }
+    return TemplateResponse(
+        request, "admin/workspace_copier/copy_templates.html", context
     )

--- a/backend/hexa/workspace_copier/forms.py
+++ b/backend/hexa/workspace_copier/forms.py
@@ -3,6 +3,7 @@
 from django import forms
 
 from hexa.workspace_copier.orchestrator import WORKSPACE_COPIERS
+from hexa.workspace_copier.templates import DEFAULT_SOURCE_URL
 
 
 def _resource_choices() -> list[tuple[str, str]]:
@@ -88,3 +89,37 @@ class CopyWorkspaceForm(forms.Form):
         selected |= _mandatory_resources()
         cleaned["resources"] = selected
         return cleaned
+
+
+class CopyTemplatesForm(forms.Form):
+    """Pick a source and target server to copy all pipeline templates between.
+
+    Templates are server-wide, so there is no workspace slug or resource
+    selection — both sides are remote and each needs a ServiceAccount token. The
+    target organization is where the host "Template pipelines" workspace is
+    created when it doesn't already exist.
+    """
+
+    source_url = forms.URLField(
+        label="Source server URL",
+        initial=DEFAULT_SOURCE_URL,
+        help_text="GraphQL endpoint of the source server. Defaults to production.",
+    )
+    source_token = forms.CharField(
+        label="Source ServiceAccount token",
+        widget=forms.PasswordInput(render_value=True),
+    )
+
+    target_url = forms.URLField(
+        label="Target server URL",
+        help_text="GraphQL endpoint of the target server.",
+    )
+    target_token = forms.CharField(
+        label="Target ServiceAccount token",
+        widget=forms.PasswordInput(render_value=True),
+    )
+    target_organization = forms.CharField(
+        label="Target organization id",
+        help_text="UUID of the organization the host 'Template pipelines' "
+        "workspace is created under when needed.",
+    )

--- a/backend/hexa/workspace_copier/management/commands/copy_templates.py
+++ b/backend/hexa/workspace_copier/management/commands/copy_templates.py
@@ -1,0 +1,70 @@
+"""Copy all pipeline templates from one OpenHEXA server to another (CLI wrapper).
+
+Thin wrapper around :func:`hexa.workspace_copier.service.run_template_copy`.
+Templates are server-wide, so this runs once per target server, independently of
+any workspace copy. Both sides are remote: each needs a GraphQL URL and a
+ServiceAccount token, sent as an ``Authorization: Bearer`` header on every
+request.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from hexa.workspace_copier.progress import StreamReporter
+from hexa.workspace_copier.results import format_templates_summary
+from hexa.workspace_copier.service import CredentialError, run_template_copy
+from hexa.workspace_copier.templates import DEFAULT_SOURCE_URL
+from hexa.workspace_copier.transport import GraphQLError
+
+
+class Command(BaseCommand):
+    help = "Copy all pipeline templates from one OpenHEXA server to another."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--source-url",
+            default=DEFAULT_SOURCE_URL,
+            help=f"Source GraphQL endpoint (default: {DEFAULT_SOURCE_URL}).",
+        )
+        parser.add_argument(
+            "--source-token",
+            required=True,
+            help="ServiceAccount token for the source server.",
+        )
+        parser.add_argument(
+            "--target-url",
+            required=True,
+            help="Target GraphQL endpoint.",
+        )
+        parser.add_argument(
+            "--target-token",
+            required=True,
+            help="ServiceAccount token for the target server.",
+        )
+        parser.add_argument(
+            "--target-organization",
+            required=True,
+            help="UUID of the organization on the target server. The host "
+            "'Template pipelines' workspace is created under it when needed.",
+        )
+
+    def handle(self, *args, **options):
+        reporter = StreamReporter(self.stdout)
+
+        try:
+            result = run_template_copy(
+                source_url=options["source_url"],
+                source_token=options["source_token"],
+                target_url=options["target_url"],
+                target_token=options["target_token"],
+                target_organization_id=options["target_organization"],
+                reporter=reporter,
+            )
+        except CredentialError as exc:
+            raise CommandError(
+                "Endpoint verification failed:\n"
+                + "\n".join(f"  - {e}" for e in exc.errors)
+            )
+        except GraphQLError as exc:
+            raise CommandError(str(exc))
+
+        self.stdout.write(format_templates_summary(result))

--- a/backend/hexa/workspace_copier/results.py
+++ b/backend/hexa/workspace_copier/results.py
@@ -54,6 +54,28 @@ class PipelinesResult:
 
 
 @dataclass
+class TemplatesResult:
+    """What a template copy run did, for the summary.
+
+    Template copy is a server-wide flow (not a per-workspace
+    :class:`CopyResult` resource), so it carries its own aggregate and is
+    rendered by :func:`format_templates_summary`.
+    """
+
+    created: list[str] = field(default_factory=list)
+    """Names of templates newly created on target (didn't exist before)."""
+
+    versions_added: list[tuple[str, list[int]]] = field(default_factory=list)
+    """(template_name, [versionNumber, ...]) for versions added this run."""
+
+    skipped_unchanged: list[str] = field(default_factory=list)
+    """Names of templates that were already fully present on target."""
+
+    warnings: list[str] = field(default_factory=list)
+    """Human-readable warnings to print in the summary."""
+
+
+@dataclass
 class CopyResult:
     """Aggregate of a single workspace copy run.
 
@@ -126,6 +148,33 @@ def format_summary(result: CopyResult) -> str:
         if pipes.warnings:
             lines.append("Pipeline warnings:")
             lines.extend(f"  - {w}" for w in pipes.warnings)
+
+    if result.warnings:
+        lines.append("Warnings:")
+        lines.extend(f"  - {w}" for w in result.warnings)
+
+    return "\n".join(lines)
+
+
+def format_templates_summary(result: TemplatesResult) -> str:
+    """Render a human-readable summary of a template copy run."""
+    lines: list[str] = ["=== Template copy summary ==="]
+    lines.append(f"Templates created on target: {len(result.created)}")
+    lines.extend(f"  * {name}" for name in result.created)
+
+    if result.versions_added:
+        total = sum(len(nums) for _, nums in result.versions_added)
+        lines.append(f"Template versions added: {total}")
+        for name, nums in result.versions_added:
+            nums_str = ", ".join(f"v{n}" for n in nums)
+            lines.append(f"  * {name}: {nums_str}")
+
+    if result.skipped_unchanged:
+        lines.append(
+            f"Templates already up to date (skipped): "
+            f"{len(result.skipped_unchanged)}"
+        )
+        lines.extend(f"  * {name}" for name in result.skipped_unchanged)
 
     if result.warnings:
         lines.append("Warnings:")

--- a/backend/hexa/workspace_copier/service.py
+++ b/backend/hexa/workspace_copier/service.py
@@ -15,14 +15,17 @@ than fixing them one round-trip at a time.
 """
 
 from collections.abc import Callable
+from typing import Any
 
 import httpx
 from django.core.exceptions import ObjectDoesNotExist
+from openhexa.graphql.graphql_client.client import Client
 
 from hexa.workspace_copier.endpoints import Endpoint
 from hexa.workspace_copier.orchestrator import copy_workspace
 from hexa.workspace_copier.progress import ProgressReporter
-from hexa.workspace_copier.results import CopyResult
+from hexa.workspace_copier.results import CopyResult, TemplatesResult
+from hexa.workspace_copier.templates import copy_templates
 from hexa.workspace_copier.transport import GraphQLError, build_client
 from hexa.workspaces.models import Workspace
 
@@ -63,14 +66,25 @@ def _build_target(
     )
 
 
-def _verify_side(
-    side: str, build: Callable[[], Endpoint]
-) -> tuple[Endpoint | None, str | None]:
-    """Build one endpoint, returning ``(endpoint, error_message)``.
+def _build_remote_client(side: str, url: str, token: str) -> Client:
+    """Build and authenticate a remote SDK client (used by the template flow).
 
-    Building a remote endpoint authenticates against its server, so this is also
-    where bad credentials / unreachable hosts surface. The returned string is the
-    user-facing reason; ``None`` means the side is good.
+    The template copy flow is remote→remote only (templates are server-wide and
+    the local/ORM path is not implemented), so a blank URL is itself an error —
+    raised here so :func:`_verify_side` records it like any other verification
+    failure.
+    """
+    if not url:
+        raise GraphQLError(f"{side} server URL is required.")
+    return build_client(url, token, label=side)
+
+
+def _verify_side(side: str, build: Callable[[], Any]) -> tuple[Any | None, str | None]:
+    """Build one endpoint (or client), returning ``(value, error_message)``.
+
+    Building a remote endpoint/client authenticates against its server, so this
+    is also where bad credentials / unreachable hosts surface. The returned
+    string is the user-facing reason; ``None`` means the side is good.
     """
     try:
         return build(), None
@@ -136,3 +150,35 @@ def run_copy(
         target_workspace_name=target_workspace_name,
     )
     return copy_workspace(source, target, reporter, resources=resources)
+
+
+def run_template_copy(
+    *,
+    source_url: str,
+    source_token: str,
+    target_url: str,
+    target_token: str,
+    target_organization_id: str,
+    reporter: ProgressReporter,
+) -> TemplatesResult:
+    """Verify both remote endpoints, then copy every template, returning the result.
+
+    Both sides are checked even if the first fails, so the user sees every
+    problem at once. ``target_organization_id`` is the organization the host
+    "Template pipelines" workspace is created under on the target.
+    """
+    source, source_err = _verify_side(
+        "source", lambda: _build_remote_client("source", source_url, source_token)
+    )
+    target, target_err = _verify_side(
+        "target", lambda: _build_remote_client("target", target_url, target_token)
+    )
+    errors = [e for e in (source_err, target_err) if e]
+    if errors:
+        raise CredentialError(errors)
+    return copy_templates(
+        source,
+        target,
+        target_organization_id=target_organization_id,
+        reporter=reporter,
+    )

--- a/backend/hexa/workspace_copier/templates.py
+++ b/backend/hexa/workspace_copier/templates.py
@@ -1,0 +1,619 @@
+"""Pipeline template copy: server-wide templates copied to a target server.
+
+Templates are globally visible, so this runs once per target server,
+independently of any workspace copy (it is *not* a per-workspace
+:class:`~hexa.workspace_copier.resources.base.ResourceCopier` in the
+orchestrator registry). Each source template is recreated on the target by:
+
+1. Locating a host pipeline that can back the template on target:
+   - Prefer the *already-copied* source pipeline (in its original workspace on
+     target) if it exists — keeps the underlying pipeline visible inside its
+     real workspace.
+   - Otherwise create a host pipeline inside a dedicated "Template pipelines"
+     workspace.
+2. Ensuring each template version's underlying pipeline version exists on the
+   host pipeline (upload the source zipfile if missing).
+3. Calling ``createPipelineTemplateVersion`` per missing template version, in
+   source ``versionNumber`` order. The first call also creates the
+   ``PipelineTemplate`` on target (via ``Pipeline.get_or_create_template``).
+4. Applying metadata (description / functionalType / tags) via
+   ``updatePipelineTemplate``.
+
+Idempotent: matches templates by name (globally unique) and existing versions
+by ``versionNumber``.
+
+Reuses :func:`~hexa.workspace_copier.resources.pipelines._upload_version` to
+back template versions, and emits all progress through a
+:class:`~hexa.workspace_copier.progress.ProgressReporter` rather than printing.
+"""
+
+import time
+from typing import Any
+
+from openhexa.graphql.graphql_client.client import Client
+from openhexa.graphql.graphql_client.input_types import (
+    CreatePipelineInput,
+    CreateWorkspaceInput,
+)
+
+from hexa.workspace_copier.progress import ProgressReporter
+from hexa.workspace_copier.resources.pipelines import _upload_version
+from hexa.workspace_copier.results import TemplatesResult
+from hexa.workspace_copier.transport import GraphQLError, gql
+
+TEMPLATES_PAGE_SIZE = 50
+TEMPLATE_VERSIONS_PAGE_SIZE = 50
+PIPELINE_VERSIONS_PAGE_SIZE = 100
+
+HOST_WORKSPACE_NAME = "Template pipelines"
+
+# Templates are almost always copied *from* production, so both entry points
+# default the source to it.
+DEFAULT_SOURCE_URL = "https://api.openhexa.org/graphql/"
+
+# Back-off between createPipelineTemplateVersion calls. Each one triggers
+# auto-update of every dependent pipeline server-side, which can be heavy.
+PER_VERSION_DELAY_SECONDS = 0.5
+
+
+LIST_SOURCE_TEMPLATES_QUERY = """
+query ListSourceTemplates($page: Int!, $perPage: Int!) {
+    pipelineTemplates(page: $page, perPage: $perPage) {
+        pageNumber totalPages totalItems
+        items {
+            id name code description functionalType
+            validatedAt
+            tags { name }
+            sourcePipeline { id code name workspace { slug } }
+        }
+    }
+}
+"""
+
+LIST_TARGET_TEMPLATES_QUERY = """
+query ListTargetTemplates($page: Int!, $perPage: Int!) {
+    pipelineTemplates(page: $page, perPage: $perPage) {
+        pageNumber totalPages
+        items {
+            id name code
+            sourcePipeline { id code workspace { slug } }
+        }
+    }
+}
+"""
+
+TEMPLATE_VERSIONS_QUERY = """
+query TemplateVersions($code: String!, $page: Int!, $perPage: Int!) {
+    templateByCode(code: $code) {
+        id name
+        versions(page: $page, perPage: $perPage) {
+            pageNumber totalPages
+            items {
+                id versionNumber changelog
+                sourcePipelineVersion {
+                    id versionNumber name description externalLink config timeout
+                    zipfile
+                    parameters {
+                        code name type multiple required default help
+                        widget connection choices
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+TARGET_TEMPLATE_VERSIONS_QUERY = """
+query TargetTemplateVersions($code: String!, $page: Int!, $perPage: Int!) {
+    templateByCode(code: $code) {
+        id
+        versions(page: $page, perPage: $perPage) {
+            pageNumber totalPages
+            items { id versionNumber }
+        }
+    }
+}
+"""
+
+HOST_PIPELINE_VERSIONS_QUERY = """
+query HostPipelineVersions($id: UUID!, $page: Int!, $perPage: Int!) {
+    pipeline(id: $id) {
+        id
+        versions(page: $page, perPage: $perPage) {
+            pageNumber totalPages
+            items { id versionNumber }
+        }
+    }
+}
+"""
+
+CREATE_TEMPLATE_VERSION_MUTATION = """
+mutation CreateTemplateVersion($input: CreatePipelineTemplateVersionInput!) {
+    createPipelineTemplateVersion(input: $input) {
+        success errors
+        pipelineTemplate { id name code }
+    }
+}
+"""
+
+UPDATE_TEMPLATE_MUTATION = """
+mutation UpdateTemplate($input: UpdateTemplateInput!) {
+    updatePipelineTemplate(input: $input) {
+        success errors
+        template { id }
+    }
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def copy_templates(
+    source: Client,
+    target: Client,
+    *,
+    target_organization_id: str,
+    reporter: ProgressReporter,
+) -> TemplatesResult:
+    """Copy every pipeline template from ``source`` into ``target``.
+
+    ``target_organization_id`` is the organization the dedicated "Template
+    pipelines" host workspace is created under when it doesn't already exist on
+    the target.
+    """
+    result = TemplatesResult()
+
+    reporter.info(f"=> Ensuring '{HOST_WORKSPACE_NAME}' workspace exists on target ...")
+    host_ws_slug = _ensure_host_workspace(target, target_organization_id)
+    reporter.info(f"   host workspace slug: '{host_ws_slug}'")
+
+    # Listed once so re-runs find host pipelines whose code the server
+    # re-derived from name (e.g. underscores -> dashes), not the source's
+    # raw code.
+    host_pipelines_by_name = _list_pipelines_by_name(target, host_ws_slug)
+
+    reporter.info("=> Listing source templates ...")
+    src_templates = _list_all_source_templates(source)
+    reporter.info(f"   found {len(src_templates)} template(s)")
+
+    reporter.info("=> Listing existing target templates ...")
+    target_by_name = _list_all_target_templates(target)
+    reporter.info(f"   target already has {len(target_by_name)} template(s)")
+
+    for src in src_templates:
+        try:
+            _migrate_one(
+                source,
+                target,
+                src,
+                target_by_name,
+                host_ws_slug,
+                host_pipelines_by_name,
+                result,
+                reporter,
+            )
+        except GraphQLError as exc:
+            msg = f"template '{src['name']}' (code='{src['code']}'): {exc}"
+            result.warnings.append(msg)
+            reporter.error(f"     FAILED: {msg}")
+
+    return result
+
+
+def _migrate_one(
+    source: Client,
+    target: Client,
+    src_template: dict[str, Any],
+    target_by_name: dict[str, dict[str, Any]],
+    host_ws_slug: str,
+    host_pipelines_by_name: dict[str, str],
+    result: TemplatesResult,
+    reporter: ProgressReporter,
+) -> None:
+    name = src_template["name"]
+    code = src_template["code"]
+    reporter.info(f"   - template '{name}' (code='{code}') ...")
+
+    src_pipe = src_template.get("sourcePipeline")
+    if src_pipe is None:
+        result.warnings.append(
+            f"template '{name}' has no source pipeline on source — skipped."
+        )
+        return
+
+    existing_target = target_by_name.get(name)
+
+    # 1. Decide host (workspace_slug, pipeline_code) and existing version numbers.
+    if existing_target is not None:
+        host_pipe_code = existing_target["sourcePipeline"]["code"]
+        host_pipe_ws = existing_target["sourcePipeline"]["workspace"]["slug"]
+        existing_version_numbers = _fetch_target_template_version_numbers(target, code)
+        reporter.info(
+            f"       already exists on target at "
+            f"'{host_pipe_ws}/{host_pipe_code}'; "
+            f"{len(existing_version_numbers)} version(s) present"
+        )
+    else:
+        host_pipe_code, host_pipe_ws = _resolve_or_create_host_pipeline(
+            target, src_pipe, host_ws_slug, host_pipelines_by_name, reporter
+        )
+        existing_version_numbers = set()
+
+    # 2. Resolve host pipeline id and the versions it already has (by number).
+    host_pipe = target.pipeline(
+        workspace_slug=host_pipe_ws, pipeline_code=host_pipe_code
+    )
+    if host_pipe is None:
+        raise GraphQLError(
+            f"host pipeline '{host_pipe_ws}/{host_pipe_code}' could not be looked up"
+        )
+    host_pipe_id = str(host_pipe.id)
+    host_versions_by_number = _fetch_pipeline_versions_by_number(target, host_pipe_id)
+
+    # 3. Add missing template versions.
+    src_versions = _fetch_source_template_versions(source, code)
+    if not src_versions:
+        result.warnings.append(
+            f"template '{name}' has no versions on source — skipped."
+        )
+        return
+
+    added: list[int] = []
+    target_template_id: str | None = (
+        existing_target["id"] if existing_target is not None else None
+    )
+
+    for ver in src_versions:
+        vnum = ver["versionNumber"]
+        if vnum in existing_version_numbers:
+            continue
+
+        src_pipe_ver = ver["sourcePipelineVersion"]
+        target_pv_id = _ensure_host_pipeline_version(
+            target,
+            host_pipe_ws,
+            host_pipe_code,
+            src_pipe_ver,
+            host_versions_by_number,
+            reporter,
+        )
+
+        input_: dict[str, Any] = {
+            "workspaceSlug": host_pipe_ws,
+            "pipelineId": host_pipe_id,
+            "pipelineVersionId": target_pv_id,
+            "name": name,
+            "code": code,
+            "description": src_template.get("description") or "",
+            "changelog": ver.get("changelog") or None,
+            # versionName / documentation are not queryable on older source
+            # servers, so let the target extract documentation from the
+            # zipfile's README on its own (server default behavior).
+        }
+        input_ = {k: v for k, v in input_.items() if v is not None}
+
+        data = gql(
+            target,
+            CREATE_TEMPLATE_VERSION_MUTATION,
+            {"input": input_},
+            "CreateTemplateVersion",
+        )
+        cptv = data["createPipelineTemplateVersion"]
+        if not cptv["success"]:
+            raise GraphQLError(
+                f"createPipelineTemplateVersion v{vnum} failed: "
+                + ",".join(cptv.get("errors") or [])
+            )
+        if target_template_id is None and cptv.get("pipelineTemplate"):
+            target_template_id = cptv["pipelineTemplate"]["id"]
+
+        reporter.info(f"       added template version v{vnum}")
+        added.append(vnum)
+        time.sleep(PER_VERSION_DELAY_SECONDS)
+
+    if added:
+        if existing_target is None:
+            result.created.append(name)
+        result.versions_added.append((name, added))
+    else:
+        result.skipped_unchanged.append(name)
+
+    # 4. Apply metadata (idempotent re-application is fine).
+    if target_template_id is not None:
+        _apply_metadata(target, src_template, target_template_id, reporter)
+
+    # 5. Warn on validated-on-source.
+    if src_template.get("validatedAt"):
+        result.warnings.append(
+            f"template '{name}' is an official Bluesquare template on source; "
+            "on target it will appear as a community template "
+            "(validatedAt is not settable via the API)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Host workspace & host pipeline
+# ---------------------------------------------------------------------------
+
+
+def _ensure_host_workspace(target: Client, organization_id: str) -> str:
+    """Return the slug of the target workspace named HOST_WORKSPACE_NAME, creating it if needed."""
+    page = 1
+    while True:
+        page_result = target.workspaces(page=page, per_page=100)
+        for ws in page_result.items:
+            if ws.name == HOST_WORKSPACE_NAME:
+                return ws.slug
+        if page >= page_result.total_pages or page_result.total_pages == 0:
+            break
+        page += 1
+
+    created = target.create_workspace(
+        input=CreateWorkspaceInput(
+            name=HOST_WORKSPACE_NAME,
+            description=(
+                "Host workspace for source pipelines backing copied templates. "
+                "Auto-created by the template copier."
+            ),
+            countries=[],
+            load_sample_data=False,
+            configuration={},
+            organization_id=organization_id,
+        )
+    )
+    if not created.success or created.workspace is None:
+        raise GraphQLError(
+            f"could not create '{HOST_WORKSPACE_NAME}' workspace: "
+            + ",".join(created.errors or [])
+        )
+    return created.workspace.slug
+
+
+def _resolve_or_create_host_pipeline(
+    target: Client,
+    src_pipeline: dict[str, Any],
+    host_ws_slug: str,
+    host_pipelines_by_name: dict[str, str],
+    reporter: ProgressReporter,
+) -> tuple[str, str]:
+    """Return (pipeline_code, workspace_slug) of the host pipeline to use.
+
+    Reuses the source pipeline in its original workspace on target if it exists
+    there (because the workspace copy already brought it over). Otherwise reuses
+    or creates a host pipeline in HOST_WORKSPACE_NAME, matched by source pipeline
+    name (since the server re-derives code from name on create, e.g. dropping
+    underscores).
+    """
+    src_code = src_pipeline["code"]
+    src_name = src_pipeline["name"] or src_code
+    src_ws = src_pipeline.get("workspace") or {}
+    src_ws_slug = src_ws.get("slug")
+
+    if src_ws_slug:
+        existing = target.pipeline(workspace_slug=src_ws_slug, pipeline_code=src_code)
+        if existing is not None:
+            reporter.info(
+                f"       reusing already-copied source pipeline "
+                f"'{src_ws_slug}/{existing.code}'"
+            )
+            return existing.code, src_ws_slug
+
+    # Fallback: ensure pipeline exists inside the dedicated host workspace.
+    if src_name in host_pipelines_by_name:
+        host_code = host_pipelines_by_name[src_name]
+        reporter.info(
+            f"       reusing existing host pipeline '{host_ws_slug}/{host_code}'"
+        )
+        return host_code, host_ws_slug
+
+    create_result = target.create_pipeline(
+        input=CreatePipelineInput(
+            name=src_name,
+            workspace_slug=host_ws_slug,
+        )
+    )
+    if not create_result.success or create_result.pipeline is None:
+        raise GraphQLError(
+            f"createPipeline for template host '{src_code}' failed: "
+            + ",".join(e.value for e in (create_result.errors or []))
+        )
+    new_code = create_result.pipeline.code
+    host_pipelines_by_name[src_name] = new_code
+    reporter.info(f"       created host pipeline '{host_ws_slug}/{new_code}'")
+    return new_code, host_ws_slug
+
+
+def _ensure_host_pipeline_version(
+    target: Client,
+    ws_slug: str,
+    pipeline_code: str,
+    src_pipeline_version: dict[str, Any],
+    host_versions_by_number: dict[int, str],
+    reporter: ProgressReporter,
+) -> str:
+    """Return the target pipelineVersion id for the given source pipeline version.
+
+    Reuses an existing version on the host pipeline if one with the same
+    versionNumber exists; otherwise uploads the source zipfile and records the
+    new id in ``host_versions_by_number``.
+    """
+    src_vnum = src_pipeline_version["versionNumber"]
+    if src_vnum in host_versions_by_number:
+        return host_versions_by_number[src_vnum]
+
+    if not src_pipeline_version.get("zipfile"):
+        raise GraphQLError(
+            f"source pipeline version v{src_vnum} has no zipfile; cannot upload"
+        )
+
+    up = _upload_version(target, ws_slug, pipeline_code, src_pipeline_version)
+    reporter.info(
+        f"       uploaded host pipeline version v{src_vnum} -> {up['versionName']}"
+    )
+    host_versions_by_number[up["versionNumber"]] = up["id"]
+    return up["id"]
+
+
+# ---------------------------------------------------------------------------
+# Source / target fetch helpers
+# ---------------------------------------------------------------------------
+
+
+def _list_pipelines_by_name(target: Client, ws_slug: str) -> dict[str, str]:
+    """List pipelines in ``ws_slug``, return {pipeline.name: pipeline.code}."""
+    by_name: dict[str, str] = {}
+    page = 1
+    while True:
+        result = target.pipelines(workspace_slug=ws_slug, page=page, per_page=100)
+        for item in result.items:
+            if item.name:
+                by_name[item.name] = item.code
+        if page >= result.total_pages or result.total_pages == 0:
+            break
+        page += 1
+    return by_name
+
+
+def _list_all_source_templates(source: Client) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        data = gql(
+            source,
+            LIST_SOURCE_TEMPLATES_QUERY,
+            {"page": page, "perPage": TEMPLATES_PAGE_SIZE},
+            "ListSourceTemplates",
+        )
+        page_data = data["pipelineTemplates"]
+        items.extend(page_data["items"])
+        if page >= page_data["totalPages"] or page_data["totalPages"] == 0:
+            break
+        page += 1
+    return items
+
+
+def _list_all_target_templates(target: Client) -> dict[str, dict[str, Any]]:
+    """Return target templates keyed by name (globally unique)."""
+    by_name: dict[str, dict[str, Any]] = {}
+    page = 1
+    while True:
+        data = gql(
+            target,
+            LIST_TARGET_TEMPLATES_QUERY,
+            {"page": page, "perPage": TEMPLATES_PAGE_SIZE},
+            "ListTargetTemplates",
+        )
+        page_data = data["pipelineTemplates"]
+        for item in page_data["items"]:
+            by_name[item["name"]] = item
+        if page >= page_data["totalPages"] or page_data["totalPages"] == 0:
+            break
+        page += 1
+    return by_name
+
+
+def _fetch_source_template_versions(source: Client, code: str) -> list[dict[str, Any]]:
+    versions: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        data = gql(
+            source,
+            TEMPLATE_VERSIONS_QUERY,
+            {"code": code, "page": page, "perPage": TEMPLATE_VERSIONS_PAGE_SIZE},
+            "TemplateVersions",
+        )
+        t = data["templateByCode"]
+        if t is None:
+            return []
+        pg = t["versions"]
+        versions.extend(pg["items"])
+        if page >= pg["totalPages"] or pg["totalPages"] == 0:
+            break
+        page += 1
+    return sorted(versions, key=lambda v: v["versionNumber"])
+
+
+def _fetch_target_template_version_numbers(target: Client, code: str) -> set[int]:
+    out: set[int] = set()
+    page = 1
+    while True:
+        data = gql(
+            target,
+            TARGET_TEMPLATE_VERSIONS_QUERY,
+            {"code": code, "page": page, "perPage": TEMPLATE_VERSIONS_PAGE_SIZE},
+            "TargetTemplateVersions",
+        )
+        t = data["templateByCode"]
+        if t is None:
+            return out
+        pg = t["versions"]
+        for v in pg["items"]:
+            out.add(v["versionNumber"])
+        if page >= pg["totalPages"] or pg["totalPages"] == 0:
+            break
+        page += 1
+    return out
+
+
+def _fetch_pipeline_versions_by_number(
+    target: Client, pipeline_id: str
+) -> dict[int, str]:
+    out: dict[int, str] = {}
+    page = 1
+    while True:
+        data = gql(
+            target,
+            HOST_PIPELINE_VERSIONS_QUERY,
+            {"id": pipeline_id, "page": page, "perPage": PIPELINE_VERSIONS_PAGE_SIZE},
+            "HostPipelineVersions",
+        )
+        p = data["pipeline"]
+        if p is None:
+            return out
+        pg = p["versions"]
+        for v in pg["items"]:
+            out[v["versionNumber"]] = v["id"]
+        if page >= pg["totalPages"] or pg["totalPages"] == 0:
+            break
+        page += 1
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Metadata
+# ---------------------------------------------------------------------------
+
+
+def _apply_metadata(
+    target: Client,
+    src_template: dict[str, Any],
+    target_template_id: str,
+    reporter: ProgressReporter,
+) -> None:
+    tags = [t["name"] for t in (src_template.get("tags") or [])]
+    input_: dict[str, Any] = {
+        "id": target_template_id,
+        "description": src_template.get("description") or None,
+        "functionalType": src_template.get("functionalType") or None,
+        "tags": tags or None,
+    }
+    input_ = {k: v for k, v in input_.items() if v is not None}
+    if list(input_.keys()) == ["id"]:
+        return
+
+    data = gql(
+        target,
+        UPDATE_TEMPLATE_MUTATION,
+        {"input": input_},
+        "UpdateTemplate",
+    )
+    upd = data["updatePipelineTemplate"]
+    if not upd["success"]:
+        reporter.warning(
+            f"       updatePipelineTemplate failed for "
+            f"'{src_template['name']}': " + ",".join(upd.get("errors") or [])
+        )

--- a/backend/hexa/workspace_copier/templates/admin/workspace_copier/copy_templates.html
+++ b/backend/hexa/workspace_copier/templates/admin/workspace_copier/copy_templates.html
@@ -1,0 +1,53 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+    &rsaquo; <a href="{% url 'admin:pipeline_templates_pipelinetemplate_changelist' %}">{% trans 'Pipeline templates' %}</a>
+    &rsaquo; {% trans 'Copy pipeline templates' %}
+</div>
+{% endblock %}
+
+{% block content %}
+<p>
+    Copy every pipeline template from a source server to a target server.
+    Templates are server-wide, so this runs once per target server. Source and
+    target ServiceAccount tokens are used only for this request and are never
+    stored.
+</p>
+<p>{% trans 'Example server URLs:' %}</p>
+<ul>
+    <li>{% trans 'Production (SaaS)' %}: <code>https://api.openhexa.org/graphql/</code></li>
+    <li>{% trans 'Demo' %}: <code>https://api.demo.openhexa.org/graphql/</code></li>
+    <li>{% trans 'Localhost' %}: <code>http://localhost:8000/graphql/</code></li>
+</ul>
+
+<form method="post">
+    {% csrf_token %}
+    <fieldset class="module aligned">
+        <h2 style="margin-bottom: 1rem;">{% trans 'Source' %}</h2>
+        {% include "admin/workspace_copier/_field_row.html" with field=form.source_url %}
+        {% include "admin/workspace_copier/_field_row.html" with field=form.source_token %}
+    </fieldset>
+    <fieldset class="module aligned">
+        <h2>{% trans 'Target' %}</h2>
+        {% include "admin/workspace_copier/_field_row.html" with field=form.target_url %}
+        {% include "admin/workspace_copier/_field_row.html" with field=form.target_token %}
+        {% include "admin/workspace_copier/_field_row.html" with field=form.target_organization %}
+    </fieldset>
+    <div class="submit-row">
+        <input type="submit" value="{% trans 'Run copy' %}" class="default">
+    </div>
+</form>
+
+{% if log %}
+<h2>{% trans 'Log' %}</h2>
+<pre>{{ log }}</pre>
+{% endif %}
+
+{% if summary %}
+<h2>{% trans 'Summary' %}</h2>
+<pre>{{ summary }}</pre>
+{% endif %}
+{% endblock %}

--- a/backend/hexa/workspace_copier/tests/test_service.py
+++ b/backend/hexa/workspace_copier/tests/test_service.py
@@ -11,6 +11,7 @@ from hexa.workspace_copier.service import (
     _verify_endpoints,
     _verify_side,
     run_copy,
+    run_template_copy,
 )
 from hexa.workspace_copier.transport import GraphQLError
 
@@ -147,3 +148,54 @@ class RunCopyTest(SimpleTestCase):
             run_copy(reporter=NullReporter(), **_kwargs())
 
         mock_dup.assert_not_called()
+
+
+def _template_kwargs(**overrides):
+    data = {
+        "source_url": "http://src/graphql/",
+        "source_token": "src-token",
+        "target_url": "http://tgt/graphql/",
+        "target_token": "tgt-token",
+        "target_organization_id": "org-1",
+    }
+    data.update(overrides)
+    return data
+
+
+class RunTemplateCopyTest(SimpleTestCase):
+    @patch("hexa.workspace_copier.service.copy_templates")
+    @patch("hexa.workspace_copier.service.build_client")
+    def test_proceeds_to_copy_after_successful_verification(
+        self, mock_build, mock_copy
+    ):
+        mock_build.side_effect = [MagicMock(), MagicMock()]
+        sentinel = object()
+        mock_copy.return_value = sentinel
+
+        result = run_template_copy(reporter=NullReporter(), **_template_kwargs())
+
+        self.assertIs(result, sentinel)
+        mock_copy.assert_called_once()
+
+    @patch("hexa.workspace_copier.service.copy_templates")
+    @patch("hexa.workspace_copier.service.build_client")
+    def test_blank_url_is_a_credential_error_remote_only(self, mock_build, mock_copy):
+        # Templates copy is remote→remote; a blank URL is rejected up front
+        # rather than falling back to the local server.
+        with self.assertRaises(CredentialError) as ctx:
+            run_template_copy(
+                reporter=NullReporter(), **_template_kwargs(source_url="")
+            )
+
+        self.assertIn("source server URL is required.", ctx.exception.errors)
+        mock_copy.assert_not_called()
+
+    @patch("hexa.workspace_copier.service.copy_templates")
+    @patch("hexa.workspace_copier.service.build_client")
+    def test_bad_credentials_abort_before_copy(self, mock_build, mock_copy):
+        mock_build.side_effect = GraphQLError("source authentication failed: bad")
+
+        with self.assertRaises(CredentialError):
+            run_template_copy(reporter=NullReporter(), **_template_kwargs())
+
+        mock_copy.assert_not_called()


### PR DESCRIPTION
This add a script that copies all template pipelines from an OH instance (by default our prod SaaS instance) to an OH instance of your choice.

Since template pipelines are linked to workspaces, it creates a new workspace "Template pipelines" on the target instance, and then continues to add all template pipelines and their versions to this workspace.

Re-running the script will check all pipelines, create new ones where they're missing, and add new versions if there are missing versions on the target.

Two entrypoints again: a CLI command and a Django admin command.

Example usage for CLI (`--source-url` defaults to production):

```bash
# copy from prod to demo
./manage.py copy_templates \
	--source-token 'my-prod-token' \
	--target-url https://api.demo.openhexa.org/graphql/ \
	--target-token 'my-demo-token' \
	--target-organization 002f2f74-7cdb-452c-8ef5-28cc27c04fbe

# copy from prod to your localhost
./manage.py copy_templates \
        --source-token 'my-prod-token' \
        --target-url http://app:8000/graphql/ \
	--target-token 'my-localhost-token' \
        --target-organization a6dfd796-7d2a-4857-9638-e35d88243132
```

### How to test

**Context:** The context for this is to be able to easily set up template pipelines on localhosting instances. We do not want to invest a lot of time into this. So testing should only be functional, no need to read every line of code.

### Screenshots
#### Admin interface
<img width="2289" height="1149" alt="image" src="https://github.com/user-attachments/assets/f8092b7a-8cdf-4acb-84c0-672395f13323" />

#### Example CLI output
<img width="1881" height="603" alt="image" src="https://github.com/user-attachments/assets/2cfd0384-75f1-4e34-a97f-58d5092350e3" />

