### PR TITLE
fix: saved query dialog flickering (HEXA-1762)

### DIFF
--- a/frontend/src/core/components/Dialog/Dialog.tsx
+++ b/frontend/src/core/components/Dialog/Dialog.tsx
@@ -16,6 +16,13 @@ import {
 } from "react";
 
 type DialogProps = {
+  // Always render this component and drive visibility from here — never guard it
+  // with `{condition && <Dialog …>}`. Headless UI wraps the dialog in a
+  // `Transition` whose `appear` defaults to false, so a dialog that mounts
+  // already open skips its enter transition and the panel flashes in at full
+  // opacity; unmounting on close kills the leave transition the same way.
+  // Anything the dialog needs conditionally (a selected row, an id) belongs in
+  // its props, not in a mount guard.
   open: boolean;
   onClose: (value: any) => void;
   centered?: boolean;

--- a/frontend/src/workspaces/features/DataStudioEditor/DataStudioEditor.test.tsx
+++ b/frontend/src/workspaces/features/DataStudioEditor/DataStudioEditor.test.tsx
@@ -25,6 +25,19 @@ jest.mock("./useSavedQueryEditor", () => ({
   useSavedQueryEditor: () => mockEditorState,
 }));
 
+// The dialog owns its own mutations (covered by its suite); stub it down to the
+// props this file cares about so no ApolloProvider is needed.
+jest.mock("workspaces/features/SavedQueries/SaveQueryDialog", () => ({
+  __esModule: true,
+  default: ({ open, mode }: { open: boolean; mode: string }) => (
+    <div
+      data-testid="save-query-dialog"
+      data-open={String(open)}
+      data-mode={mode}
+    />
+  ),
+}));
+
 // The schema browser and results grid are covered by their own tests; stub them
 // so this file exercises only the editor's orchestration logic.
 jest.mock("./DataStudioSchemaBrowser", () => ({
@@ -142,7 +155,7 @@ beforeEach(() => {
     isDirty: false,
     saving: false,
     canUpdate: false,
-    dialog: null,
+    dialog: { open: false, mode: "create" },
     save: jest.fn(),
     saveAsNew: jest.fn(),
     editDetails: mockEditDetails,
@@ -295,6 +308,24 @@ describe("DataStudioEditor", () => {
       "data-loading",
       "true",
     );
+  });
+
+  // Headless UI skips the enter transition of a dialog that mounts already open,
+  // so the dialog has to stay mounted and be driven by `open`.
+  it("keeps the save dialog mounted while it is closed", () => {
+    renderEditor();
+
+    const dialog = screen.getByTestId("save-query-dialog");
+    expect(dialog).toHaveAttribute("data-open", "false");
+  });
+
+  it("passes the open state and mode of the dialog through", () => {
+    mockEditorState.dialog = { open: true, mode: "edit-details" };
+    renderEditor();
+
+    const dialog = screen.getByTestId("save-query-dialog");
+    expect(dialog).toHaveAttribute("data-open", "true");
+    expect(dialog).toHaveAttribute("data-mode", "edit-details");
   });
 
   it("opens the edit-details dialog from the pencil next to a saved query name", async () => {

--- a/frontend/src/workspaces/features/DataStudioEditor/DataStudioEditor.tsx
+++ b/frontend/src/workspaces/features/DataStudioEditor/DataStudioEditor.tsx
@@ -193,17 +193,17 @@ const DataStudioEditor = ({
           </div>
         </div>
       </div>
-      {editor.dialog && (
-        <SaveQueryDialog
-          open
-          mode={editor.dialog.mode}
-          workspaceSlug={workspaceSlug}
-          content={query}
-          savedQuery={editor.savedQuery}
-          onClose={editor.closeDialog}
-          onSaved={editor.onDialogSaved}
-        />
-      )}
+      {/* Kept mounted and toggled through `open`: Headless UI skips its enter
+          transition for a dialog that mounts already open. */}
+      <SaveQueryDialog
+        open={editor.dialog.open}
+        mode={editor.dialog.mode}
+        workspaceSlug={workspaceSlug}
+        content={query}
+        savedQuery={editor.savedQuery}
+        onClose={editor.closeDialog}
+        onSaved={editor.onDialogSaved}
+      />
     </>
   );
 };

--- a/frontend/src/workspaces/features/DataStudioEditor/DataStudioEditor.tsx
+++ b/frontend/src/workspaces/features/DataStudioEditor/DataStudioEditor.tsx
@@ -10,7 +10,7 @@ import CodeEditor, {
 } from "core/components/CodeEditor/CodeEditor";
 import useIsMac from "core/hooks/useIsMac";
 import { useTranslation } from "next-i18next";
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import SaveQueryDialog from "workspaces/features/SavedQueries/SaveQueryDialog";
 import { SavedQuery_SavedQueryFragment } from "workspaces/features/SavedQueries/SavedQueries.generated";
 import { buildCsv, downloadCsv } from "./csv";
@@ -44,6 +44,13 @@ const DataStudioEditor = ({
     content: query,
     initialSavedQuery: savedQuery,
   });
+
+  // Stable so the memoised schema browser is not re-rendered by every keystroke
+  // in the editor. Goes through the imperative handle, so it needs no deps.
+  const insertIntoEditor = useCallback(
+    (text: string) => editorRef.current?.insertText(text),
+    [],
+  );
 
   const runShortcutLabel = isMac ? "⌘+Enter" : "Ctrl+Enter";
   // Compact form for the in-button pill: the return glyph reads cleanly next to
@@ -83,7 +90,7 @@ const DataStudioEditor = ({
         <DataStudioSchemaBrowser
           workspaceSlug={workspaceSlug}
           className="w-[240px] shrink-0 border-r border-gray-200"
-          onInsert={(text) => editorRef.current?.insertText(text)}
+          onInsert={insertIntoEditor}
         />
         <div className="flex min-w-0 flex-1 flex-col">
           {/* Toolbar: controls right-aligned, Run at the far right. */}

--- a/frontend/src/workspaces/features/DataStudioEditor/DataStudioResults.tsx
+++ b/frontend/src/workspaces/features/DataStudioEditor/DataStudioResults.tsx
@@ -7,6 +7,7 @@ import {
 } from "core/helpers/errors";
 import { ExecuteSqlError } from "graphql/types";
 import { useTranslation } from "next-i18next";
+import { memo } from "react";
 import { ExecuteWorkspaceSqlQuery } from "./DataStudioEditor.generated";
 import ResultsTable from "./ResultsTable";
 
@@ -194,4 +195,9 @@ const DataStudioResults = ({
   );
 };
 
-export default DataStudioResults;
+// Memoised because the SQL text lives in DataStudioEditor's state: without this,
+// every keystroke re-renders the grid, reconciling up to MAX_DISPLAYED_ROWS rows
+// worth of cells for an input this component does not even read. Apollo keeps
+// `data` referentially stable between renders and `onRetry` is memoised in
+// useDataStudioQuery, so the props only change when a query actually resolves.
+export default memo(DataStudioResults);

--- a/frontend/src/workspaces/features/DataStudioEditor/DataStudioSchemaBrowser.tsx
+++ b/frontend/src/workspaces/features/DataStudioEditor/DataStudioSchemaBrowser.tsx
@@ -10,7 +10,7 @@ import {
 import Spinner from "core/components/Spinner";
 import clsx from "clsx";
 import { useTranslation } from "next-i18next";
-import { KeyboardEvent, useMemo, useRef, useState } from "react";
+import { KeyboardEvent, memo, useMemo, useRef, useState } from "react";
 import { useWorkspaceDataStudioSchemaQuery } from "./DataStudioSchemaBrowser.generated";
 
 type SchemaColumn = { name: string; type: string };
@@ -267,4 +267,7 @@ DataStudioSchemaBrowser.queries = {
   `,
 };
 
-export default DataStudioSchemaBrowser;
+// Memoised for the same reason as DataStudioResults: the SQL text lives in
+// DataStudioEditor's state, so without this the whole table/column tree
+// re-renders on every keystroke. Requires callers to pass a stable `onInsert`.
+export default memo(DataStudioSchemaBrowser);

--- a/frontend/src/workspaces/features/DataStudioEditor/useSavedQueryEditor.test.tsx
+++ b/frontend/src/workspaces/features/DataStudioEditor/useSavedQueryEditor.test.tsx
@@ -58,7 +58,7 @@ describe("useSavedQueryEditor", () => {
       await result.current.save();
     });
 
-    expect(result.current.dialog).toEqual({ mode: "create" });
+    expect(result.current.dialog).toEqual({ open: true, mode: "create" });
     expect(updateMock).not.toHaveBeenCalled();
   });
 
@@ -104,7 +104,7 @@ describe("useSavedQueryEditor", () => {
     const { result } = renderEditor("SELECT 42", null);
 
     act(() => result.current.saveAsNew());
-    expect(result.current.dialog).toEqual({ mode: "create" });
+    expect(result.current.dialog).toEqual({ open: true, mode: "create" });
 
     act(() => result.current.onDialogSaved({ ...savedQuery, id: "new-1" }));
 
@@ -119,7 +119,7 @@ describe("useSavedQueryEditor", () => {
     const { result } = renderEditor("SELECT 1");
 
     act(() => result.current.editDetails());
-    expect(result.current.dialog).toEqual({ mode: "edit-details" });
+    expect(result.current.dialog).toEqual({ open: true, mode: "edit-details" });
 
     act(() => result.current.onDialogSaved({ ...savedQuery, name: "Renamed" }));
 
@@ -127,11 +127,22 @@ describe("useSavedQueryEditor", () => {
     expect(mockRouter.asPath).toBe("/");
   });
 
-  it("closes the dialog", () => {
+  it("starts with the dialog closed", () => {
+    const { result } = renderEditor("SELECT 1");
+    expect(result.current.dialog.open).toBe(false);
+  });
+
+  // The mode has to outlive the close so the title does not change while the
+  // dialog fades out.
+  it("closes the dialog while keeping its mode", () => {
     const { result } = renderEditor("SELECT 1");
     act(() => result.current.editDetails());
-    expect(result.current.dialog).not.toBeNull();
+    expect(result.current.dialog.open).toBe(true);
+
     act(() => result.current.closeDialog());
-    expect(result.current.dialog).toBeNull();
+    expect(result.current.dialog).toEqual({
+      open: false,
+      mode: "edit-details",
+    });
   });
 });

--- a/frontend/src/workspaces/features/DataStudioEditor/useSavedQueryEditor.ts
+++ b/frontend/src/workspaces/features/DataStudioEditor/useSavedQueryEditor.ts
@@ -2,11 +2,15 @@ import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import { useCallback, useState } from "react";
 import { toast } from "react-toastify";
+import { SaveQueryDialogMode } from "workspaces/features/SavedQueries/SaveQueryDialog";
 import { SavedQuery_SavedQueryFragment } from "workspaces/features/SavedQueries/SavedQueries.generated";
 import { useSavedQueryMutations } from "workspaces/features/SavedQueries/useSavedQueryMutations";
 import { dataStudioRoutes } from "workspaces/helpers/dataStudio";
 
-type DialogState = { mode: "create" | "edit-details" } | null;
+// The dialog stays mounted and is toggled through `open` (so Headless UI can run
+// its enter/leave transitions), hence the mode is kept alongside it: it must
+// survive the leave transition or the title would change while fading out.
+type DialogState = { open: boolean; mode: SaveQueryDialogMode };
 
 type UseSavedQueryEditorArgs = {
   workspaceSlug: string;
@@ -29,7 +33,10 @@ export const useSavedQueryEditor = ({
     useState<SavedQuery_SavedQueryFragment | null>(initialSavedQuery ?? null);
   // Baseline the dirty check compares against; advances on each in-place save.
   const [baseline, setBaseline] = useState(initialSavedQuery?.content ?? "");
-  const [dialog, setDialog] = useState<DialogState>(null);
+  const [dialog, setDialog] = useState<DialogState>({
+    open: false,
+    mode: "create",
+  });
   const { update, updating: saving } = useSavedQueryMutations();
 
   const canUpdate = savedQuery?.permissions.update ?? false;
@@ -39,7 +46,7 @@ export const useSavedQueryEditor = ({
   // content of the loaded query in place.
   const save = useCallback(async () => {
     if (!savedQuery) {
-      setDialog({ mode: "create" });
+      setDialog({ open: true, mode: "create" });
       return;
     }
     if (!canUpdate || saving) {
@@ -59,16 +66,22 @@ export const useSavedQueryEditor = ({
     }
   }, [savedQuery, canUpdate, saving, content, update, t]);
 
-  const saveAsNew = useCallback(() => setDialog({ mode: "create" }), []);
-  const editDetails = useCallback(
-    () => setDialog({ mode: "edit-details" }),
+  const saveAsNew = useCallback(
+    () => setDialog({ open: true, mode: "create" }),
     [],
   );
-  const closeDialog = useCallback(() => setDialog(null), []);
+  const editDetails = useCallback(
+    () => setDialog({ open: true, mode: "edit-details" }),
+    [],
+  );
+  const closeDialog = useCallback(
+    () => setDialog((current) => ({ ...current, open: false })),
+    [],
+  );
 
   const onDialogSaved = useCallback(
     (sq: SavedQuery_SavedQueryFragment) => {
-      if (dialog?.mode === "edit-details") {
+      if (dialog.mode === "edit-details") {
         // Only metadata changed; the content baseline is untouched.
         setSavedQuery(sq);
       } else {

--- a/frontend/src/workspaces/features/SavedQueries/SaveQueryDialog.test.tsx
+++ b/frontend/src/workspaces/features/SavedQueries/SaveQueryDialog.test.tsx
@@ -152,6 +152,32 @@ describe("SaveQueryDialog", () => {
     expect(toast.success).toHaveBeenCalledWith("Query updated");
   });
 
+  // The dialog is not remounted between opens (it stays mounted so it can
+  // animate), so each open has to re-seed the form from the current props.
+  it("re-seeds the form on every open", async () => {
+    const props = {
+      mode: "create" as const,
+      workspaceSlug: "ws-1",
+      content: "SELECT 1",
+      savedQuery: null,
+      onClose: jest.fn(),
+      onSaved: jest.fn(),
+    };
+    const { rerender } = render(<SaveQueryDialog open {...props} />);
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Abandoned draft" },
+    });
+    rerender(<SaveQueryDialog open={false} {...props} />);
+    rerender(<SaveQueryDialog open {...props} />);
+
+    await waitFor(() =>
+      expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe(
+        "",
+      ),
+    );
+  });
+
   it("surfaces a permission error without navigating", async () => {
     createMock.mockResolvedValue({
       data: {

--- a/frontend/src/workspaces/features/SavedQueries/SaveQueryDialog.tsx
+++ b/frontend/src/workspaces/features/SavedQueries/SaveQueryDialog.tsx
@@ -95,12 +95,13 @@ const SaveQueryDialog = ({
     },
   });
 
-  // Re-seed the form from the current props each time the dialog opens.
+  // The dialog stays mounted between opens (so its transitions can run), so the
+  // form has to be re-seeded from the current props each time it opens.
   useEffect(() => {
     if (open) {
       form.resetForm();
     }
-  }, [open]);
+  }, [open, form]);
 
   const title = mode === "create" ? t("Save query") : t("Edit details");
   const submitLabel = mode === "create" ? t("Save query") : t("Save");

--- a/frontend/src/workspaces/features/SavedQueries/SaveQueryDialog.tsx
+++ b/frontend/src/workspaces/features/SavedQueries/SaveQueryDialog.tsx
@@ -96,12 +96,14 @@ const SaveQueryDialog = ({
   });
 
   // The dialog stays mounted between opens (so its transitions can run), so the
-  // form has to be re-seeded from the current props each time it opens.
+  // form has to be re-seeded from the current props each time it opens. Keyed on
+  // `open` alone on purpose: re-running this on a new `form` identity would wipe
+  // whatever the user has typed.
   useEffect(() => {
     if (open) {
       form.resetForm();
     }
-  }, [open, form]);
+  }, [open]);
 
   const title = mode === "create" ? t("Save query") : t("Edit details");
   const submitLabel = mode === "create" ? t("Save query") : t("Save");


### PR DESCRIPTION
Fix saved query modal to flicker. The reason it happened is because the modal would mount just as it was opened, resulting in flickering the first time as it is still "creating itself" while opening

## Changes

- Mount modal on page load, keep hidden until opened

## How/what to test

Open the saved query, ensure it's not flickering as in the video in [HEXA-1762](https://bluesquare.atlassian.net/browse/HEXA-1762)

[HEXA-1762]: https://bluesquare.atlassian.net/browse/HEXA-1762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ