### PR TITLE
fix: Timestamp formatting and small Django SQL dashboard improvements

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -822,3 +822,8 @@ if "OAUTH2_ALLOWED_REDIRECT_URI_HOSTS" in os.environ:
     OAUTH2_ALLOWED_REDIRECT_URI_HOSTS.update(
         os.environ["OAUTH2_ALLOWED_REDIRECT_URI_HOSTS"].split(",")
     )
+
+# django-sql-dashboard additional settings
+# https://django-sql-dashboard.datasette.io/en/stable/setup.html#additional-settings
+DASHBOARD_ROW_LIMIT = 1000  # default 100
+DASHBOARD_ENABLE_FULL_EXPORT = True  # default False

--- a/backend/hexa/pipelines/models.py
+++ b/backend/hexa/pipelines/models.py
@@ -3,7 +3,6 @@ import secrets
 import time
 import typing
 import uuid
-from datetime import datetime
 
 from croniter import croniter
 from django.apps import apps
@@ -932,7 +931,7 @@ class PipelineRun(Base, WithStatus):
             {
                 "priority": priority if priority else "INFO",
                 "message": message,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": timezone.now().isoformat(),
             }
         )
         self.save()
@@ -946,7 +945,7 @@ class PipelineRun(Base, WithStatus):
                 "uri": uri,
                 "name": name,
                 "type": output_type,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": timezone.now().isoformat(),
             }
         )
         self.save()

--- a/frontend/server/index.mjs
+++ b/frontend/server/index.mjs
@@ -22,6 +22,7 @@ const API_PATHS = [
   "/mcp/",
   "/oauth/",
   "/.well-known/",
+  "/dashboard/", // django-sql-dashboard
 ];
 
 app.prepare().then(async () => {

--- a/frontend/src/core/components/Time/Time.test.tsx
+++ b/frontend/src/core/components/Time/Time.test.tsx
@@ -12,6 +12,20 @@ describe("Time", () => {
     expect(screen.getByText("2/20/2022, 10:11 AM")).toBeInTheDocument();
   });
 
+  it("treats a datetime without offset as UTC", async () => {
+    Settings.defaultLocale = "en";
+    const expected = DateTime.fromISO("2022-02-20T10:11:34Z")
+      .toLocal()
+      .toLocaleString(DateTime.DATETIME_SHORT_WITH_SECONDS);
+    render(
+      <Time
+        datetime="2022-02-20T10:11:34.123456"
+        format={DateTime.DATETIME_SHORT_WITH_SECONDS}
+      />,
+    );
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
   it("renders relative time", async () => {
     const dt = DateTime.local(2022, 2, 20, 10, 11, 34);
     nowMock.mockReturnValue(dt.plus({ hours: 0, minutes: 10 }).toMillis());

--- a/frontend/src/core/components/Time/Time.tsx
+++ b/frontend/src/core/components/Time/Time.tsx
@@ -12,8 +12,10 @@ type Props = {
 
 const Time = (props: Props) => {
   const datetime = useMemo(
-    // By default, all dates from the backend are in UTC
-    () => DateTime.fromISO(props.datetime).toLocal(),
+    // All dates from the backend are in UTC, but some (e.g. pipeline run message
+    // timestamps) carry no offset. Defaulting the zone to UTC keeps those from
+    // being read as local time; strings with an explicit offset are unaffected.
+    () => DateTime.fromISO(props.datetime, { zone: "utc" }).toLocal(),
     [props.datetime],
   );
 


### PR DESCRIPTION
- **Django SLQ dashboard**
  - Tweak a few settings: Let's just hardcode, no need to add ENV vars
  - Allow serving of Django dashboard on frontend domain: Right now a dashboard will only work on e.g. https://api.openhexa.org/dashboard/some-metrics/ This change will make it also serve on: https://app.openhexa.org/dashboard/some-metrics/
- **Pipeline run timestamps:** There were some discrepencies between PipelineRun "executed_at" and the
actual messages during the execution. The former was correctly shown in the user's timezone, the latter would display in UTC.

**Before:**
<img width="2828" height="1758" alt="image" src="https://github.com/user-attachments/assets/e0b19f47-bd4b-4c84-a877-f7a5d542b390" />


**After:**
<img width="2827" height="1737" alt="image" src="https://github.com/user-attachments/assets/8b728069-d9df-4bec-a418-82dfa97e83c7" />
