### PR TITLE
fix: archiving a workspace should rotate db user passwords (HEXA-1773)

### DIFF
--- a/backend/hexa/workspaces/models.py
+++ b/backend/hexa/workspaces/models.py
@@ -324,6 +324,8 @@ class Workspace(Base):
             raise PermissionDenied
         if not principal.has_perm("workspaces.archive_workspace", self):
             raise PermissionDenied
+        self.generate_new_database_password(principal=principal)
+        self.generate_new_database_ro_password(principal=principal)
         self.archived = True
         self.archived_at = timezone.now()
         self.save()

--- a/backend/hexa/workspaces/models.py
+++ b/backend/hexa/workspaces/models.py
@@ -313,8 +313,10 @@ class Workspace(Base):
     def delete_if_has_perm(self, *, principal: User):
         if not principal.has_perm("workspaces.delete_workspace", self):
             raise PermissionDenied
-        # TODO: clarify workspace deletion workflow - buckets are not deleted for now
-        # delete_database(self.db_name)
+        # TODO: clarify workspace deletion workflow - buckets and the database are not deleted for now
+        #  until we decide, just rotate passwords to prevent access
+        self.generate_new_database_password(principal=principal)
+        self.generate_new_database_ro_password(principal=principal)
         self.delete()
 
     def archive_if_has_perm(self, *, principal: User):

--- a/backend/hexa/workspaces/tests/test_schema/test_workspace.py
+++ b/backend/hexa/workspaces/tests/test_schema/test_workspace.py
@@ -727,22 +727,26 @@ class WorkspaceTest(GraphQLTestCase):
     # @patch("hexa.workspaces.models.delete_database")
     # def test_delete_workspace(self, mock_delete_database):
     def test_delete_workspace(self):
+        previous_db_password = self.WORKSPACE.db_password
+        previous_db_ro_password = self.WORKSPACE.db_ro_password
+
         self.client.force_login(self.USER_WORKSPACE_ADMIN)
-        r = self.run_query(
-            """
-            mutation deleteWorkspace($input: DeleteWorkspaceInput!) {
-                deleteWorkspace(input: $input) {
-                    success
-                    errors
+        with patch("hexa.workspaces.models.update_database_password") as mock_update:
+            r = self.run_query(
+                """
+                mutation deleteWorkspace($input: DeleteWorkspaceInput!) {
+                    deleteWorkspace(input: $input) {
+                        success
+                        errors
+                    }
                 }
-            }
-            """,
-            {
-                "input": {
-                    "slug": self.WORKSPACE.slug,
-                }
-            },
-        )
+                """,
+                {
+                    "input": {
+                        "slug": self.WORKSPACE.slug,
+                    }
+                },
+            )
         # self.assertTrue(mock_delete_database.called)
         self.assertEqual(
             {
@@ -751,6 +755,18 @@ class WorkspaceTest(GraphQLTestCase):
             },
             r["data"]["deleteWorkspace"],
         )
+        self.assertEqual(
+            [
+                mock.call(self.WORKSPACE.db_name, mock.ANY),
+                mock.call(self.WORKSPACE.db_ro_username, mock.ANY),
+            ],
+            mock_update.call_args_list,
+        )
+        self.assertNotEqual(previous_db_password, mock_update.call_args_list[0][0][1])
+        self.assertNotEqual(
+            previous_db_ro_password, mock_update.call_args_list[1][0][1]
+        )
+        self.assertFalse(Workspace.objects.filter(id=self.WORKSPACE.id).exists())
 
     def test_archive_workspace_not_found(self):
         self.client.force_login(self.USER_SABRINA)

--- a/backend/hexa/workspaces/tests/test_schema/test_workspace.py
+++ b/backend/hexa/workspaces/tests/test_schema/test_workspace.py
@@ -1,6 +1,7 @@
 import base64
 import html
 import uuid
+from unittest import mock
 from unittest.mock import patch
 from urllib.parse import urlencode
 
@@ -777,22 +778,26 @@ class WorkspaceTest(GraphQLTestCase):
         )
 
     def test_archive_workspace(self):
+        previous_db_password = self.WORKSPACE.db_password
+        previous_db_ro_password = self.WORKSPACE.db_ro_password
+
         self.client.force_login(self.USER_WORKSPACE_ADMIN)
-        r = self.run_query(
-            """
-            mutation archiveWorkspace($input: ArchiveWorkspaceInput!) {
-                archiveWorkspace(input: $input) {
-                    success
-                    errors
+        with patch("hexa.workspaces.models.update_database_password") as mock_update:
+            r = self.run_query(
+                """
+                mutation archiveWorkspace($input: ArchiveWorkspaceInput!) {
+                    archiveWorkspace(input: $input) {
+                        success
+                        errors
+                    }
                 }
-            }
-            """,
-            {
-                "input": {
-                    "slug": self.WORKSPACE.slug,
-                }
-            },
-        )
+                """,
+                {
+                    "input": {
+                        "slug": self.WORKSPACE.slug,
+                    }
+                },
+            )
         self.assertEqual(
             {
                 "success": True,
@@ -800,6 +805,18 @@ class WorkspaceTest(GraphQLTestCase):
             },
             r["data"]["archiveWorkspace"],
         )
+        self.assertEqual(
+            [
+                mock.call(self.WORKSPACE.db_name, mock.ANY),
+                mock.call(self.WORKSPACE.db_ro_username, mock.ANY),
+            ],
+            mock_update.call_args_list,
+        )
+
+        self.WORKSPACE.refresh_from_db()
+        self.assertTrue(self.WORKSPACE.archived)
+        self.assertNotEqual(previous_db_password, self.WORKSPACE.db_password)
+        self.assertNotEqual(previous_db_ro_password, self.WORKSPACE.db_ro_password)
 
     def test_add_workspace_member(self):
         self.client.force_login(self.USER_WORKSPACE_ADMIN)


### PR DESCRIPTION
To prevent access to the databases, for now we will just rotate credentials