### PR TITLE
feat: add the copying of datasets to the duplication script (HEXA-1715)

### DIFF
--- a/backend/hexa/workspace_copier/README.md
+++ b/backend/hexa/workspace_copier/README.md
@@ -25,12 +25,13 @@ Each module is the single home for one resource across both mediums. Registry
 order (see `orchestrator.WORKSPACE_COPIERS`):
 
 | name          | copier                    | notes                                                                                              |
-| ------------- | ------------------------- | -------------------------------------------------------------------------------------------------- |
+| ------------- | ------------------------- |----------------------------------------------------------------------------------------------------|
 | `workspace`   | `WorkspaceMetadataCopier` | **mandatory** — creates the target, yields its handle                                              |
 | `files`       | `FilesCopier`             | bucket objects                                                                                     |
 | `database`    | `DatabaseCopier`          | native pg copy only if **both** sides LOCAL; else skipped + warned. Local copy not yet implemented |
 | `connections` | `ConnectionsCopier`       | connections + secret fields                                                                        |
 | `pipelines`   | `PipelinesCopier`         | pipelines + versions (depends on `files` for notebook pipelines)                                   |
+| `datasets`    | `DatasetsCopier`          | datasets **owned** by the workspace                                                                |
 
 Template pipelines are **not** in this registry — they are server-wide, not a
 per-workspace resource, so they are copied by a separate flow (see
@@ -65,7 +66,8 @@ Example usage:
 	--target-url https://api.demo.openhexa.org/graphql/ \
 	--target-organization 002f2f74-7cdb-452c-8ef5-28cc27c04fbe \ # BLSQ org
 	--target-workspace-name "My Workspace (copy)" \
-	--target-token 'my-demo-service-account-token'
+	--target-token 'my-demo-service-account-token' \
+	--all-dataset-versions # optional; default copies only each dataset's latest version
 ```
 
 Tokens are ServiceAccount tokens (managed under Django admin → Service accounts). A remote side needs one with permission to read the source workspace / create under the target organization. `--target-workspace-name` is optional and defaults to the same name as the source workspace.

--- a/backend/hexa/workspace_copier/admin.py
+++ b/backend/hexa/workspace_copier/admin.py
@@ -12,6 +12,7 @@ from django.core.exceptions import PermissionDenied
 from django.template.response import TemplateResponse
 
 from hexa.workspace_copier.forms import CopyTemplatesForm, CopyWorkspaceForm
+from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.progress import BufferReporter
 from hexa.workspace_copier.results import format_summary, format_templates_summary
 from hexa.workspace_copier.service import (
@@ -43,6 +44,9 @@ def copy_workspace_view(request):
                     target_organization_id=data["target_organization"],
                     target_workspace_name=data["target_workspace_name"] or None,
                     resources=set(data["resources"]),
+                    options=CopyOptions(
+                        all_dataset_versions=data["all_dataset_versions"]
+                    ),
                     reporter=reporter,
                 )
                 summary = format_summary(result)

--- a/backend/hexa/workspace_copier/forms.py
+++ b/backend/hexa/workspace_copier/forms.py
@@ -65,6 +65,11 @@ class CopyWorkspaceForm(forms.Form):
         widget=forms.CheckboxSelectMultiple,
         help_text="The workspace-metadata copier always runs.",
     )
+    all_dataset_versions = forms.BooleanField(
+        required=False,
+        label="Copy all dataset versions",
+        help_text="Off by default: only each dataset's latest version is copied.",
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/backend/hexa/workspace_copier/forms.py
+++ b/backend/hexa/workspace_copier/forms.py
@@ -18,6 +18,25 @@ def _mandatory_resources() -> set[str]:
     return {c.name for c in WORKSPACE_COPIERS if c.mandatory}
 
 
+def _option_fields() -> dict[str, tuple[str, ...]]:
+    return {c.name: c.option_fields for c in WORKSPACE_COPIERS if c.option_fields}
+
+
+class ResourceSelect(forms.CheckboxSelectMultiple):
+    """Checkbox list where a mandatory copier is checked and locked.
+
+    ``clean`` adds those back whatever is submitted, so an enabled box would
+    offer a choice that doesn't exist.
+    """
+
+    def create_option(self, name, value, *args, **kwargs):
+        option = super().create_option(name, value, *args, **kwargs)
+        if str(value) in _mandatory_resources():
+            option["attrs"]["checked"] = True
+            option["attrs"]["disabled"] = True
+        return option
+
+
 class CopyWorkspaceForm(forms.Form):
     """Pick a source endpoint, a target endpoint, and the resources to copy.
 
@@ -62,18 +81,35 @@ class CopyWorkspaceForm(forms.Form):
     resources = forms.MultipleChoiceField(
         required=False,
         choices=_resource_choices,
-        widget=forms.CheckboxSelectMultiple,
-        help_text="The workspace-metadata copier always runs.",
+        widget=ResourceSelect,
     )
     all_dataset_versions = forms.BooleanField(
         required=False,
         label="Copy all dataset versions",
+        label_suffix="",
         help_text="Off by default: only each dataset's latest version is copied.",
     )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["resources"].initial = _default_resources()
+
+    def resource_rows(self):
+        """Pair each resource checkbox with the option fields tuning that resource.
+
+        Lets the template nest a copier's options under its own checkbox instead
+        of listing them all after the resource list, where nothing says which
+        resource they affect.
+        """
+        option_fields = _option_fields()
+        mandatory = _mandatory_resources()
+        for checkbox in self["resources"]:
+            name = str(checkbox.data["value"])
+            yield {
+                "checkbox": checkbox,
+                "mandatory": name in mandatory,
+                "options": [self[field] for field in option_fields.get(name, ())],
+            }
 
     def _clean_endpoint_credentials(self, side: str) -> None:
         url = self.cleaned_data.get(f"{side}_url")

--- a/backend/hexa/workspace_copier/management/commands/copy_workspace.py
+++ b/backend/hexa/workspace_copier/management/commands/copy_workspace.py
@@ -9,6 +9,7 @@ Auth (per remote side): a ServiceAccount token, sent as an
 
 from django.core.management.base import BaseCommand, CommandError
 
+from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.orchestrator import WORKSPACE_COPIERS
 from hexa.workspace_copier.progress import StreamReporter
 from hexa.workspace_copier.results import format_summary
@@ -66,6 +67,11 @@ class Command(BaseCommand):
             help="Comma-separated resources to copy (default: all). "
             f"Known: {','.join(sorted(_known_resource_names()))}.",
         )
+        parser.add_argument(
+            "--all-dataset-versions",
+            action="store_true",
+            help="Copy every version of each dataset instead of only the latest one.",
+        )
 
     def _resolve_resources(self, resources: str | None):
         known = _known_resource_names()
@@ -97,6 +103,9 @@ class Command(BaseCommand):
                 target_organization_id=options["target_organization"],
                 target_workspace_name=options["target_workspace_name"],
                 resources=resources,
+                options=CopyOptions(
+                    all_dataset_versions=options["all_dataset_versions"]
+                ),
                 reporter=reporter,
             )
         except CredentialError as exc:

--- a/backend/hexa/workspace_copier/options.py
+++ b/backend/hexa/workspace_copier/options.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CopyOptions:
+    all_dataset_versions: bool = False
+    """Copy every version of each dataset instead of only the latest one."""

--- a/backend/hexa/workspace_copier/orchestrator.py
+++ b/backend/hexa/workspace_copier/orchestrator.py
@@ -10,10 +10,12 @@ so this orchestration is written once and shared by every flow (CLI + admin).
 from collections.abc import Iterable
 
 from hexa.workspace_copier.endpoints import Endpoint
+from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.progress import ProgressReporter
 from hexa.workspace_copier.resources.base import ResourceCopier
 from hexa.workspace_copier.resources.connections import ConnectionsCopier
 from hexa.workspace_copier.resources.database import DatabaseCopier
+from hexa.workspace_copier.resources.datasets import DatasetsCopier
 from hexa.workspace_copier.resources.files import FilesCopier
 from hexa.workspace_copier.resources.pipelines import PipelinesCopier
 from hexa.workspace_copier.resources.workspace import WorkspaceMetadataCopier
@@ -25,7 +27,7 @@ WORKSPACE_COPIERS: list[ResourceCopier] = [
     DatabaseCopier(),  # LOCAL→LOCAL: native pg; else skip + warning
     ConnectionsCopier(),
     PipelinesCopier(),
-    # DatasetsCopier(),  # future — append here
+    DatasetsCopier(),
 ]
 
 
@@ -49,13 +51,16 @@ def copy_workspace(
     reporter: ProgressReporter,
     *,
     resources: set[str] | None = None,
+    options: CopyOptions = CopyOptions(),
 ) -> CopyResult:
     """Copy a workspace from ``source`` to ``target``.
 
     Runs the selected copiers in registry (dependency) order, recording the
     outcome on a single :class:`CopyResult`. Live progress is emitted
     through ``reporter``; pass a :class:`~hexa.workspace_copier.progress.NullReporter`
-    to discard it.
+    to discard it. ``options`` carries the run-wide switches (see
+    :class:`~hexa.workspace_copier.options.CopyOptions`); every copier receives
+    them and reads only what concerns it.
     """
     selected = _resolve_selection(WORKSPACE_COPIERS, resources)
     selected_names = {c.name for c in selected}
@@ -67,5 +72,5 @@ def copy_workspace(
                 result.warn(message)
                 reporter.warning(message)
         reporter.info(f"=> Copying {copier.name} ...")
-        copier.copy(source, target, result, reporter)
+        copier.copy(source, target, result, reporter, options=options)
     return result

--- a/backend/hexa/workspace_copier/resources/base.py
+++ b/backend/hexa/workspace_copier/resources/base.py
@@ -9,6 +9,7 @@ did/skipped/failed on the shared :class:`CopyResult`.
 from abc import ABC, abstractmethod
 
 from hexa.workspace_copier.endpoints import Endpoint
+from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.progress import ProgressReporter
 from hexa.workspace_copier.results import CopyResult
 
@@ -33,5 +34,7 @@ class ResourceCopier(ABC):
         target: Endpoint,
         result: CopyResult,
         reporter: ProgressReporter,
+        *,
+        options: CopyOptions = CopyOptions(),
     ) -> None:
         ...

--- a/backend/hexa/workspace_copier/resources/base.py
+++ b/backend/hexa/workspace_copier/resources/base.py
@@ -27,6 +27,9 @@ class ResourceCopier(ABC):
     depends_on: tuple[str, ...] = ()
     """Advisory: a warning is emitted if a declared dependency is deselected."""
 
+    option_fields: tuple[str, ...] = ()
+    """``CopyWorkspaceForm`` fields tuning this copier, rendered under its checkbox."""
+
     @abstractmethod
     def copy(
         self,

--- a/backend/hexa/workspace_copier/resources/connections.py
+++ b/backend/hexa/workspace_copier/resources/connections.py
@@ -26,6 +26,7 @@ from openhexa.graphql.graphql_client.input_types import (
 )
 
 from hexa.workspace_copier.endpoints import Endpoint
+from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.progress import ProgressReporter
 from hexa.workspace_copier.resources.base import ResourceCopier
 from hexa.workspace_copier.results import ConnectionsResult, CopyResult
@@ -55,6 +56,8 @@ class ConnectionsCopier(ResourceCopier):
         target: Endpoint,
         result: CopyResult,
         reporter: ProgressReporter,
+        *,
+        options: CopyOptions = CopyOptions(),
     ) -> None:
         if source.is_remote and target.is_remote:
             self._copy_remote(source, target, result, reporter)

--- a/backend/hexa/workspace_copier/resources/database.py
+++ b/backend/hexa/workspace_copier/resources/database.py
@@ -7,6 +7,7 @@ native local copy is implemented in a later phase.
 """
 
 from hexa.workspace_copier.endpoints import Endpoint
+from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.progress import ProgressReporter
 from hexa.workspace_copier.resources.base import ResourceCopier
 from hexa.workspace_copier.results import CopyResult
@@ -22,6 +23,8 @@ class DatabaseCopier(ResourceCopier):
         target: Endpoint,
         result: CopyResult,
         reporter: ProgressReporter,
+        *,
+        options: CopyOptions = CopyOptions(),
     ) -> None:
         if source.is_remote or target.is_remote:
             message = (

--- a/backend/hexa/workspace_copier/resources/datasets.py
+++ b/backend/hexa/workspace_copier/resources/datasets.py
@@ -1,0 +1,650 @@
+"""Dataset copier: copy every dataset *owned* by the workspace, with its versions.
+
+Only the latest version is copied by default; ``CopyOptions.all_dataset_versions``
+copies every version instead. Versions are always created oldest-first and a
+version's files are all uploaded before the next version is created, because
+``generateDatasetUploadUrl`` / ``createDatasetVersionFile`` reject any version
+that is not the dataset's *latest* one (``LOCKED_VERSION``): a version stops
+accepting content the moment a newer one exists. The same rule is why a failed
+file transfer abandons the whole dataset instead of moving on — see
+``_copy_versions``.
+
+Everything goes through raw ``gql()``. The pinned SDK's dataset methods predate
+what this needs: ``create_dataset`` doesn't select the new dataset's ``id``
+(required to create versions), ``UpdateDatasetInput`` has no
+``sharedWithOrganization``, and there are no version/file mutations at all.
+"""
+
+import tempfile
+from typing import Any
+
+import httpx
+from openhexa.graphql.graphql_client.client import Client
+from slugify import slugify
+
+from hexa.workspace_copier.endpoints import Endpoint
+from hexa.workspace_copier.options import CopyOptions
+from hexa.workspace_copier.progress import ProgressReporter
+from hexa.workspace_copier.resources.base import ResourceCopier
+from hexa.workspace_copier.results import CopyResult, DatasetsResult
+from hexa.workspace_copier.transport import GraphQLError, gql
+
+DATASETS_PAGE_SIZE = 50
+VERSIONS_PAGE_SIZE = 50
+FILES_PAGE_SIZE = 50
+
+FILE_TRANSFER_TIMEOUT = 300
+SPOOL_MAX_SIZE = 32 * 1024 * 1024
+"""Bytes a file transfer may hold in memory before spilling to a temp file."""
+
+
+LIST_DATASETS_QUERY = """
+query ListWorkspaceDatasets($slug: String!, $page: Int!, $perPage: Int!) {
+    workspace(slug: $slug) {
+        datasets(page: $page, perPage: $perPage) {
+            totalPages
+            items {
+                dataset {
+                    id slug name
+                    workspace { slug }
+                }
+            }
+        }
+    }
+}
+"""
+
+DATASET_DETAIL_QUERY = """
+query DatasetDetail($id: ID!) {
+    dataset(id: $id) {
+        id slug name description sharedWithOrganization
+        latestVersion { id name changelog }
+    }
+}
+"""
+
+DATASET_VERSIONS_QUERY = """
+query DatasetVersions($id: ID!, $page: Int!, $perPage: Int!) {
+    dataset(id: $id) {
+        versions(page: $page, perPage: $perPage) {
+            totalPages
+            items { id name changelog createdAt }
+        }
+    }
+}
+"""
+
+VERSION_FILES_QUERY = """
+query DatasetVersionFiles($id: ID!, $page: Int!, $perPage: Int!) {
+    datasetVersion(id: $id) {
+        files(page: $page, perPage: $perPage) {
+            totalPages
+            items { id uri filename contentType }
+        }
+    }
+}
+"""
+
+CREATE_DATASET_MUTATION = """
+mutation CreateDataset($input: CreateDatasetInput!) {
+    createDataset(input: $input) {
+        success errors
+        dataset { id slug }
+    }
+}
+"""
+
+UPDATE_DATASET_MUTATION = """
+mutation UpdateDataset($input: UpdateDatasetInput!) {
+    updateDataset(input: $input) { success errors }
+}
+"""
+
+CREATE_VERSION_MUTATION = """
+mutation CreateDatasetVersion($input: CreateDatasetVersionInput!) {
+    createDatasetVersion(input: $input) {
+        success errors
+        version { id name }
+    }
+}
+"""
+
+PREPARE_FILE_DOWNLOAD_MUTATION = """
+mutation PrepareVersionFileDownload($input: PrepareVersionFileDownloadInput!) {
+    prepareVersionFileDownload(input: $input) { success errors downloadUrl }
+}
+"""
+
+GENERATE_UPLOAD_URL_MUTATION = """
+mutation GenerateDatasetUploadUrl($input: GenerateDatasetUploadUrlInput!) {
+    generateDatasetUploadUrl(input: $input) { success errors uploadUrl headers }
+}
+"""
+
+CREATE_VERSION_FILE_MUTATION = """
+mutation CreateDatasetVersionFile($input: CreateDatasetVersionFileInput!) {
+    createDatasetVersionFile(input: $input) { success errors file { id uri } }
+}
+"""
+
+
+class DatasetsCopier(ResourceCopier):
+    name = "datasets"
+    label = "Datasets (+versions)"
+    option_fields = ("all_dataset_versions",)
+
+    def copy(
+        self,
+        source: Endpoint,
+        target: Endpoint,
+        result: CopyResult,
+        reporter: ProgressReporter,
+        *,
+        options: CopyOptions = CopyOptions(),
+    ) -> None:
+        if source.is_remote and target.is_remote:
+            self._copy_remote(source, target, result, reporter, options)
+        else:
+            raise NotImplementedError(
+                "LOCAL datasets copy (native ORM clone) is implemented in a "
+                "later phase"
+            )
+
+    def _copy_remote(
+        self,
+        source: Endpoint,
+        target: Endpoint,
+        result: CopyResult,
+        reporter: ProgressReporter,
+        options: CopyOptions,
+    ) -> None:
+        ds_result = DatasetsResult()
+        result.datasets = ds_result
+
+        datasets = _list_source_datasets(source.client, source.slug)
+        assignments = _assign_target_names(datasets)
+        existing_slugs = _list_target_slugs(target.client, target.slug)
+
+        # One shared client for every presigned download/upload, as in the files
+        # copier: it reuses connections across files and carries no auth headers
+        # (presigned URLs are self-authenticating and some storage backends
+        # reject requests that also send an Authorization header).
+        with httpx.Client(timeout=FILE_TRANSFER_TIMEOUT) as http_client:
+            for dataset_id, src_slug, target_name, target_slug in assignments:
+                if target_slug in existing_slugs:
+                    ds_result.skipped.append(src_slug)
+                    reporter.info(f"   skipped dataset '{src_slug}' (already exists)")
+                    continue
+                try:
+                    reporter.info(f"   copying dataset '{src_slug}' ...")
+                    self._copy_dataset(
+                        source,
+                        target,
+                        dataset_id,
+                        target_name,
+                        ds_result,
+                        reporter,
+                        options,
+                        http_client,
+                    )
+                except GraphQLError as exc:
+                    # Collect and continue (like the pipelines copier) so one bad
+                    # dataset doesn't abort the rest of the copy.
+                    ds_result.failed.append(src_slug)
+                    ds_result.warnings.append(
+                        f"dataset '{src_slug}' could not be copied — handle "
+                        f"manually ({exc})."
+                    )
+                    reporter.warning(f"   FAILED to copy dataset '{src_slug}' ({exc})")
+
+    def _copy_dataset(
+        self,
+        source: Endpoint,
+        target: Endpoint,
+        dataset_id: str,
+        target_name: str,
+        ds_result: DatasetsResult,
+        reporter: ProgressReporter,
+        options: CopyOptions,
+        http_client: httpx.Client,
+    ) -> None:
+        detail = _fetch_source_detail(source.client, dataset_id)
+        versions = _select_versions(
+            source.client, dataset_id, detail, options.all_dataset_versions
+        )
+
+        target_id, target_slug = _create_on_target(
+            target.client, target.slug, detail, target_name
+        )
+        _apply_sharing(target.client, target_id, detail, ds_result)
+
+        copied = _copy_versions(
+            source,
+            target,
+            dataset_id,
+            target_id,
+            versions,
+            ds_result,
+            reporter,
+            http_client,
+        )
+        ds_result.created.append((target_slug, copied))
+        reporter.info(f"   created dataset '{target_slug}' ({len(copied)} version(s))")
+
+
+# ---------------------------------------------------------------------------
+# Source fetch
+# ---------------------------------------------------------------------------
+
+
+def _list_source_datasets(source: Client, slug: str) -> list[tuple[str, str, str]]:
+    """Return [(dataset_id, slug, name), ...] for datasets *owned* by the workspace.
+
+    ``workspace.datasets`` is a page of *links*, so it also lists datasets merely
+    shared with the workspace (via a link or org-wide sharing). Only datasets
+    whose owning workspace is this one are ours to copy.
+    """
+    datasets = []
+    page = 1
+    while True:
+        data = gql(
+            source,
+            LIST_DATASETS_QUERY,
+            {"slug": slug, "page": page, "perPage": DATASETS_PAGE_SIZE},
+            "ListWorkspaceDatasets",
+        )
+        workspace = data["workspace"]
+        if workspace is None:
+            raise GraphQLError(
+                f"source workspace '{slug}' not found while listing datasets"
+            )
+        page_data = workspace["datasets"]
+        for item in page_data["items"]:
+            dataset = item["dataset"]
+            owner = (dataset.get("workspace") or {}).get("slug")
+            if owner == slug:
+                datasets.append((str(dataset["id"]), dataset["slug"], dataset["name"]))
+        if page >= page_data["totalPages"] or page_data["totalPages"] == 0:
+            break
+        page += 1
+    return datasets
+
+
+def _assign_target_names(
+    datasets: list[tuple[str, str, str]],
+) -> list[tuple[str, str, str, str]]:
+    """Assign each source dataset a deterministic, clash-free target slug.
+
+    The target server derives a dataset's slug from ``slugify(name)`` and, on a
+    clash within the workspace, appends a *random* hex suffix (see
+    ``create_dataset_slug`` in datasets/models.py). That randomness makes target
+    slugs unpredictable, so — exactly as the pipelines copier does for codes — we
+    disambiguate clashing names ourselves, appending " (2)", " (3)", ..., which
+    keeps the server on the plain ``slugify(name)`` path.
+
+    Datasets are processed in a stable order (by source slug) so a given dataset
+    always receives the same number, hence the same slug, across runs.
+
+    Returns [(dataset_id, src_slug, target_name, target_slug), ...].
+    """
+    assignments = []
+    used_slugs = set()
+    for dataset_id, src_slug, name in sorted(datasets, key=lambda d: d[1]):
+        target_name = name
+        target_slug = slugify(name)
+        n = 2
+        while target_slug in used_slugs:
+            target_name = f"{name} ({n})"
+            target_slug = slugify(target_name)
+            n += 1
+        used_slugs.add(target_slug)
+        assignments.append((dataset_id, src_slug, target_name, target_slug))
+    return assignments
+
+
+def _list_target_slugs(target: Client, target_slug: str) -> set[str]:
+    """Return the slugs of datasets already owned by the target workspace."""
+    return {
+        dataset_slug
+        for _id, dataset_slug, _name in _list_source_datasets(target, target_slug)
+    }
+
+
+def _fetch_source_detail(source: Client, dataset_id: str) -> dict[str, Any]:
+    data = gql(source, DATASET_DETAIL_QUERY, {"id": dataset_id}, "DatasetDetail")
+    detail = data["dataset"]
+    if detail is None:
+        raise GraphQLError(f"source dataset id={dataset_id} disappeared")
+    return detail
+
+
+def _select_versions(
+    source: Client,
+    dataset_id: str,
+    detail: dict[str, Any],
+    all_versions: bool,
+) -> list[dict[str, Any]]:
+    """Return the source versions to copy, oldest first.
+
+    Default is the latest version alone, which is also why the cheap
+    ``latestVersion`` field is part of the detail query. A dataset with no
+    version at all yields an empty list: it is still created on the target, just
+    without any version.
+    """
+    if not all_versions:
+        latest = detail.get("latestVersion")
+        return [latest] if latest else []
+
+    versions: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        data = gql(
+            source,
+            DATASET_VERSIONS_QUERY,
+            {"id": dataset_id, "page": page, "perPage": VERSIONS_PAGE_SIZE},
+            "DatasetVersions",
+        )
+        dataset = data["dataset"]
+        if dataset is None:
+            raise GraphQLError(f"source dataset id={dataset_id} disappeared")
+        page_data = dataset["versions"]
+        versions.extend(page_data["items"])
+        if page >= page_data["totalPages"] or page_data["totalPages"] == 0:
+            break
+        page += 1
+    # `versions` comes back newest-first (DatasetVersion.Meta.ordering); the
+    # target only accepts files for its latest version, so replay oldest-first.
+    return sorted(versions, key=lambda v: v["createdAt"])
+
+
+def _list_version_files(source: Client, version_id: str) -> list[dict[str, Any]]:
+    files: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        data = gql(
+            source,
+            VERSION_FILES_QUERY,
+            {"id": version_id, "page": page, "perPage": FILES_PAGE_SIZE},
+            "DatasetVersionFiles",
+        )
+        version = data["datasetVersion"]
+        if version is None:
+            raise GraphQLError(f"source dataset version id={version_id} disappeared")
+        page_data = version["files"]
+        files.extend(page_data["items"])
+        if page >= page_data["totalPages"] or page_data["totalPages"] == 0:
+            break
+        page += 1
+    return files
+
+
+def _relative_uri(file: dict[str, Any], dataset_id: str, version_id: str) -> str:
+    """Strip the source's ``{dataset_id}/{version_id}/`` prefix off a file uri.
+
+    The stored uri is absolute within the datasets bucket (see
+    ``DatasetVersion.get_full_uri``) and the target rebuilds that prefix from its
+    own ids, so it must be handed the relative part. Stripping the prefix rather
+    than reading ``filename`` preserves any subdirectory in the uri.
+    """
+    uri = file["uri"]
+    prefix = f"{dataset_id}/{version_id}/"
+    if uri.startswith(prefix):
+        return uri[len(prefix) :]
+    return file["filename"]
+
+
+# ---------------------------------------------------------------------------
+# Target writes
+# ---------------------------------------------------------------------------
+
+
+def _create_on_target(
+    target: Client, target_slug: str, detail: dict[str, Any], name: str
+) -> tuple[str, str]:
+    """Create an empty dataset on the target and return (id, slug).
+
+    ``name`` is the disambiguated name chosen by :func:`_assign_target_names` so
+    the server produces a predictable slug; the actual slug is still read back
+    from the response as the source of truth.
+    """
+    input_ = {
+        "workspaceSlug": target_slug,
+        "name": name,
+        "description": detail.get("description") or "",
+    }
+    data = gql(target, CREATE_DATASET_MUTATION, {"input": input_}, "CreateDataset")
+    result = data["createDataset"]
+    if not result["success"] or result.get("dataset") is None:
+        raise GraphQLError(
+            f"createDataset failed for '{detail['slug']}': "
+            + ",".join(result.get("errors") or [])
+        )
+    created = result["dataset"]
+    return str(created["id"]), created["slug"]
+
+
+def _apply_sharing(
+    target: Client,
+    target_dataset_id: str,
+    detail: dict[str, Any],
+    ds_result: DatasetsResult,
+) -> None:
+    """Mirror ``sharedWithOrganization``, which createDataset cannot set.
+
+    A failure here is a warning rather than an error: the dataset and its
+    versions are worth keeping even if the sharing flag didn't take.
+    """
+    if not detail.get("sharedWithOrganization"):
+        return
+    input_ = {"datasetId": target_dataset_id, "sharedWithOrganization": True}
+    data = gql(target, UPDATE_DATASET_MUTATION, {"input": input_}, "UpdateDataset")
+    result = data["updateDataset"]
+    if not result["success"]:
+        ds_result.warnings.append(
+            f"dataset '{detail['slug']}' is shared with its organization on the "
+            "source but the flag could not be set on the target ("
+            + ",".join(result.get("errors") or [])
+            + ") — set it manually."
+        )
+
+
+def _create_version(
+    target: Client, target_dataset_id: str, version: dict[str, Any]
+) -> str:
+    """Create one version on the target dataset and return its id."""
+    input_ = {
+        "datasetId": target_dataset_id,
+        "name": version["name"],
+        "changelog": version.get("changelog") or "",
+    }
+    data = gql(
+        target, CREATE_VERSION_MUTATION, {"input": input_}, "CreateDatasetVersion"
+    )
+    result = data["createDatasetVersion"]
+    if not result["success"] or result.get("version") is None:
+        raise GraphQLError(
+            f"createDatasetVersion failed for '{version['name']}': "
+            + ",".join(result.get("errors") or [])
+        )
+    return str(result["version"]["id"])
+
+
+def _prepare_download(source: Client, file_id: str, uri: str) -> str | None:
+    """Return a presigned download URL, or None if the file has no content.
+
+    ``FILE_NOT_UPLOADED`` means the source has a file row whose blob was never
+    written (an interrupted upload); there is nothing to transfer, so the caller
+    skips it instead of failing the dataset.
+    """
+    data = gql(
+        source,
+        PREPARE_FILE_DOWNLOAD_MUTATION,
+        {"input": {"fileId": file_id}},
+        "PrepareVersionFileDownload",
+    )
+    result = data["prepareVersionFileDownload"]
+    errors = result.get("errors") or []
+    if "FILE_NOT_UPLOADED" in errors:
+        return None
+    if not result["success"] or not result.get("downloadUrl"):
+        raise GraphQLError(
+            f"prepareVersionFileDownload failed for '{uri}': " + ",".join(errors)
+        )
+    return result["downloadUrl"]
+
+
+def _prepare_upload(
+    target: Client, target_version_id: str, uri: str, content_type: str
+) -> tuple[str, dict[str, str]]:
+    data = gql(
+        target,
+        GENERATE_UPLOAD_URL_MUTATION,
+        {
+            "input": {
+                "versionId": target_version_id,
+                "uri": uri,
+                "contentType": content_type,
+            }
+        },
+        "GenerateDatasetUploadUrl",
+    )
+    result = data["generateDatasetUploadUrl"]
+    if not result["success"] or not result.get("uploadUrl"):
+        raise GraphQLError(
+            f"generateDatasetUploadUrl failed for '{uri}': "
+            + ",".join(result.get("errors") or [])
+        )
+    headers = dict(result.get("headers") or {})
+    headers.setdefault("Content-Type", content_type)
+    return result["uploadUrl"], headers
+
+
+def _register_uploaded_file(
+    target: Client, target_version_id: str, uri: str, content_type: str
+) -> None:
+    """Record the uploaded blob as a file of the target version.
+
+    Called *after* the bytes are in place, like the web upload flow does: this
+    mutation queues sample/metadata generation, which reads the blob.
+    """
+    data = gql(
+        target,
+        CREATE_VERSION_FILE_MUTATION,
+        {
+            "input": {
+                "versionId": target_version_id,
+                "uri": uri,
+                "contentType": content_type,
+            }
+        },
+        "CreateDatasetVersionFile",
+    )
+    result = data["createDatasetVersionFile"]
+    if not result["success"]:
+        raise GraphQLError(
+            f"createDatasetVersionFile failed for '{uri}': "
+            + ",".join(result.get("errors") or [])
+        )
+
+
+def _transfer_file(
+    target: Endpoint,
+    file: dict[str, Any],
+    uri: str,
+    target_version_id: str,
+    download_url: str,
+    http_client: httpx.Client,
+) -> int:
+    """Stream one file from source storage to target storage, returning its size.
+
+    Dataset files are the largest artefacts in a workspace, so the body is
+    spooled (to memory up to :data:`SPOOL_MAX_SIZE`, then to disk) instead of
+    being held whole in memory. httpx reads the spooled file in chunks and sets
+    ``Content-Length`` from it, which the storage backends require on a
+    presigned PUT.
+    """
+    content_type = file["contentType"] or "application/octet-stream"
+    with tempfile.SpooledTemporaryFile(max_size=SPOOL_MAX_SIZE) as buffer:
+        with http_client.stream("GET", download_url) as response:
+            if not response.is_success:
+                response.read()
+                raise GraphQLError(
+                    f"download of '{uri}' returned HTTP {response.status_code}: "
+                    f"{response.text[:500]}"
+                )
+            for chunk in response.iter_bytes():
+                buffer.write(chunk)
+        size = buffer.tell()
+
+        upload_url, headers = _prepare_upload(
+            target.client, target_version_id, uri, content_type
+        )
+        buffer.seek(0)
+        response = http_client.put(upload_url, content=buffer, headers=headers)
+        if not response.is_success:
+            raise GraphQLError(
+                f"upload of '{uri}' returned HTTP {response.status_code}: "
+                f"{response.text[:500]}"
+            )
+
+    _register_uploaded_file(target.client, target_version_id, uri, content_type)
+    return size
+
+
+def _copy_versions(
+    source: Endpoint,
+    target: Endpoint,
+    source_dataset_id: str,
+    target_dataset_id: str,
+    versions: list[dict[str, Any]],
+    ds_result: DatasetsResult,
+    reporter: ProgressReporter,
+    http_client: httpx.Client,
+) -> list[str]:
+    """Recreate ``versions`` (oldest first) on the target dataset.
+
+    A version's files must all be uploaded before the next version is created:
+    creating a version makes it the dataset's latest, which locks the previous
+    one out of any further upload. That is also why a failed file transfer
+    raises instead of being collected — going on to the next version would seal
+    the incomplete one forever, while stopping leaves it as the latest version so
+    the missing file can still be uploaded by hand on the target.
+    """
+    copied: list[str] = []
+    for version in versions:
+        target_version_id = _create_version(target.client, target_dataset_id, version)
+        reporter.info(f"      created version '{version['name']}'")
+
+        for file in _list_version_files(source.client, version["id"]):
+            uri = _relative_uri(file, source_dataset_id, version["id"])
+            download_url = _prepare_download(source.client, file["id"], uri)
+            if download_url is None:
+                ds_result.warnings.append(
+                    f"file '{uri}' of version '{version['name']}' has no content "
+                    "on the source (never uploaded) — skipped."
+                )
+                reporter.warning(f"      skipped {uri} (no content on source)")
+                continue
+            try:
+                size = _transfer_file(
+                    target,
+                    file,
+                    uri,
+                    target_version_id,
+                    download_url,
+                    http_client,
+                )
+            except (GraphQLError, httpx.HTTPError) as exc:
+                raise GraphQLError(
+                    f"file '{uri}' of version '{version['name']}' failed "
+                    f"({exc.__class__.__name__}: {exc}); later versions were not "
+                    "copied. The target dataset exists but is incomplete: upload "
+                    "the missing file while that version is still the latest one, "
+                    "or delete the dataset on the target and re-run"
+                ) from exc
+            ds_result.files_copied += 1
+            ds_result.bytes_copied += size
+            reporter.info(f"      copied {uri} ({size} bytes)")
+
+        copied.append(version["name"])
+    return copied

--- a/backend/hexa/workspace_copier/resources/files.py
+++ b/backend/hexa/workspace_copier/resources/files.py
@@ -13,6 +13,7 @@ import httpx
 from openhexa.graphql.graphql_client.client import Client
 
 from hexa.workspace_copier.endpoints import Endpoint
+from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.progress import ProgressReporter
 from hexa.workspace_copier.resources.base import ResourceCopier
 from hexa.workspace_copier.results import CopyResult, FilesResult
@@ -171,6 +172,8 @@ class FilesCopier(ResourceCopier):
         target: Endpoint,
         result: CopyResult,
         reporter: ProgressReporter,
+        *,
+        options: CopyOptions = CopyOptions(),
     ) -> None:
         files_result = FilesResult()
         result.files = files_result

--- a/backend/hexa/workspace_copier/resources/pipelines.py
+++ b/backend/hexa/workspace_copier/resources/pipelines.py
@@ -17,6 +17,7 @@ from openhexa.graphql.graphql_client.input_types import CreatePipelineInput
 from slugify import slugify
 
 from hexa.workspace_copier.endpoints import Endpoint
+from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.progress import ProgressReporter
 from hexa.workspace_copier.resources.base import ResourceCopier
 from hexa.workspace_copier.results import CopyResult, PipelinesResult
@@ -81,6 +82,8 @@ class PipelinesCopier(ResourceCopier):
         target: Endpoint,
         result: CopyResult,
         reporter: ProgressReporter,
+        *,
+        options: CopyOptions = CopyOptions(),
     ) -> None:
         if source.is_remote and target.is_remote:
             self._copy_remote(source, target, result, reporter)

--- a/backend/hexa/workspace_copier/resources/workspace.py
+++ b/backend/hexa/workspace_copier/resources/workspace.py
@@ -16,6 +16,7 @@ from openhexa.graphql.graphql_client.input_types import (
 )
 
 from hexa.workspace_copier.endpoints import Endpoint
+from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.progress import ProgressReporter
 from hexa.workspace_copier.resources.base import ResourceCopier
 from hexa.workspace_copier.results import CopyResult
@@ -33,6 +34,8 @@ class WorkspaceMetadataCopier(ResourceCopier):
         target: Endpoint,
         result: CopyResult,
         reporter: ProgressReporter,
+        *,
+        options: CopyOptions = CopyOptions(),
     ) -> None:
         src_ws = self._read_source(source)
         result.workspace_name = target.workspace_name or src_ws.name

--- a/backend/hexa/workspace_copier/results.py
+++ b/backend/hexa/workspace_copier/results.py
@@ -54,6 +54,26 @@ class PipelinesResult:
 
 
 @dataclass
+class DatasetsResult:
+    """What the datasets copier did, for the summary."""
+
+    created: list[tuple[str, list[str]]] = field(default_factory=list)
+    """(dataset_slug, [version_name, ...]) for each dataset created on target."""
+
+    skipped: list[str] = field(default_factory=list)
+    """Dataset slugs that already existed on target."""
+
+    failed: list[str] = field(default_factory=list)
+    """Dataset slugs whose copy failed; user must handle manually."""
+
+    files_copied: int = 0
+    bytes_copied: int = 0
+
+    warnings: list[str] = field(default_factory=list)
+    """Human-readable warnings to print in the summary."""
+
+
+@dataclass
 class TemplatesResult:
     """What a template copy run did, for the summary.
 
@@ -88,6 +108,7 @@ class CopyResult:
     files: FilesResult | None = None
     connections: ConnectionsResult | None = None
     pipelines: PipelinesResult | None = None
+    datasets: DatasetsResult | None = None
     warnings: list[str] = field(default_factory=list)
 
     def warn(self, message: str) -> None:
@@ -148,6 +169,28 @@ def format_summary(result: CopyResult) -> str:
         if pipes.warnings:
             lines.append("Pipeline warnings:")
             lines.extend(f"  - {w}" for w in pipes.warnings)
+
+    if result.datasets is not None:
+        datasets = result.datasets
+        lines.append(
+            f"Datasets created: {len(datasets.created)} "
+            f"({datasets.files_copied} file(s), {datasets.bytes_copied} bytes)"
+        )
+        for slug, vnames in datasets.created:
+            lines.append(f"  * {slug}")
+            lines.extend(f"      - {vn}" for vn in vnames)
+        if datasets.skipped:
+            lines.append(f"Datasets skipped (already existed): {len(datasets.skipped)}")
+            lines.extend(f"  * {slug}" for slug in datasets.skipped)
+        if datasets.failed:
+            lines.append(
+                f"Datasets that could NOT be copied "
+                f"({len(datasets.failed)} — handle manually):"
+            )
+            lines.extend(f"  * {slug}" for slug in datasets.failed)
+        if datasets.warnings:
+            lines.append("Dataset warnings:")
+            lines.extend(f"  - {w}" for w in datasets.warnings)
 
     if result.warnings:
         lines.append("Warnings:")

--- a/backend/hexa/workspace_copier/service.py
+++ b/backend/hexa/workspace_copier/service.py
@@ -22,6 +22,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from openhexa.graphql.graphql_client.client import Client
 
 from hexa.workspace_copier.endpoints import Endpoint
+from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.orchestrator import copy_workspace
 from hexa.workspace_copier.progress import ProgressReporter
 from hexa.workspace_copier.results import CopyResult, TemplatesResult
@@ -137,6 +138,7 @@ def run_copy(
     target_organization_id: str,
     target_workspace_name: str | None = None,
     resources: set[str] | None = None,
+    options: CopyOptions = CopyOptions(),
     reporter: ProgressReporter,
 ) -> CopyResult:
     """Verify both endpoints, then copy the workspace, returning the result."""
@@ -149,7 +151,9 @@ def run_copy(
         target_organization_id=target_organization_id,
         target_workspace_name=target_workspace_name,
     )
-    return copy_workspace(source, target, reporter, resources=resources)
+    return copy_workspace(
+        source, target, reporter, resources=resources, options=options
+    )
 
 
 def run_template_copy(

--- a/backend/hexa/workspace_copier/templates/admin/workspace_copier/copy_workspace.html
+++ b/backend/hexa/workspace_copier/templates/admin/workspace_copier/copy_workspace.html
@@ -40,6 +40,7 @@
     <fieldset class="module aligned">
         <h2>{% trans 'Resources' %}</h2>
         {% include "admin/workspace_copier/_field_row.html" with field=form.resources %}
+        {% include "admin/workspace_copier/_field_row.html" with field=form.all_dataset_versions %}
     </fieldset>
     <div class="submit-row">
         <input type="submit" value="{% trans 'Run copy' %}" class="default">

--- a/backend/hexa/workspace_copier/templates/admin/workspace_copier/copy_workspace.html
+++ b/backend/hexa/workspace_copier/templates/admin/workspace_copier/copy_workspace.html
@@ -1,6 +1,19 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
 
+{% block extrastyle %}{{ block.super }}
+<style>
+    .copier-resources { margin: 0; padding: 0; list-style: none; }
+    .copier-resources > li { padding: 0.2rem 0; }
+    .copier-resources label { display: inline; width: auto; float: none; }
+    .copier-always { color: var(--body-quiet-color, #666); font-size: 0.8125rem; margin-left: 0.5rem; }
+    .copier-option { margin: 0.2rem 0 0.6rem 1.7rem; }
+    .copier-option label { margin-left: 0.35rem; }
+    .copier-option .help { margin: 0; padding: 0; }
+    .copier-option.is-disabled { opacity: 0.45; }
+</style>
+{% endblock %}
+
 {% block breadcrumbs %}
 <div class="breadcrumbs">
     <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
@@ -37,15 +50,56 @@
         {% include "admin/workspace_copier/_field_row.html" with field=form.target_organization %}
         {% include "admin/workspace_copier/_field_row.html" with field=form.target_workspace_name %}
     </fieldset>
-    <fieldset class="module aligned">
+    <fieldset class="module">
         <h2>{% trans 'Resources' %}</h2>
-        {% include "admin/workspace_copier/_field_row.html" with field=form.resources %}
-        {% include "admin/workspace_copier/_field_row.html" with field=form.all_dataset_versions %}
+        <div class="form-row field-resources{% if form.resources.errors %} errors{% endif %}">
+            {{ form.resources.errors }}
+            <ul class="copier-resources">
+                {% for row in form.resource_rows %}
+                <li>
+                    {{ row.checkbox }}
+                    {% if row.mandatory %}<span class="copier-always">{% trans 'always runs' %}</span>{% endif %}
+                    {% for option in row.options %}
+                    <div class="copier-option{% if option.errors %} errors{% endif %}">
+                        {{ option.errors }}
+                        {{ option }}{{ option.label_tag }}
+                        {% if option.help_text %}<div class="help" id="{{ option.id_for_label }}_helptext">{{ option.help_text }}</div>{% endif %}
+                    </div>
+                    {% endfor %}
+                </li>
+                {% endfor %}
+            </ul>
+        </div>
     </fieldset>
     <div class="submit-row">
         <input type="submit" value="{% trans 'Run copy' %}" class="default">
     </div>
 </form>
+
+<script>
+// A resource's nested options only mean something when that resource is copied:
+// disabling them keeps them out of the POST, so the backend can't receive an
+// option for a copier that never runs.
+(function () {
+    document.querySelectorAll(".copier-resources > li").forEach(function (item) {
+        var box = item.querySelector('input[name="resources"]');
+        var options = item.querySelectorAll(".copier-option");
+        if (!box || !options.length) return;
+
+        function sync() {
+            options.forEach(function (option) {
+                option.classList.toggle("is-disabled", !box.checked);
+                option.querySelectorAll("input").forEach(function (input) {
+                    input.disabled = !box.checked;
+                });
+            });
+        }
+
+        box.addEventListener("change", sync);
+        sync();
+    });
+})();
+</script>
 
 {% if log %}
 <h2>{% trans 'Log' %}</h2>

--- a/backend/hexa/workspace_copier/tests/resources/test_datasets.py
+++ b/backend/hexa/workspace_copier/tests/resources/test_datasets.py
@@ -1,0 +1,400 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from hexa.workspace_copier.endpoints import Endpoint
+from hexa.workspace_copier.options import CopyOptions
+from hexa.workspace_copier.progress import NullReporter
+from hexa.workspace_copier.resources.datasets import (
+    DatasetsCopier,
+    _assign_target_names,
+    _copy_versions,
+    _list_source_datasets,
+    _relative_uri,
+    _select_versions,
+)
+from hexa.workspace_copier.results import CopyResult, DatasetsResult
+from hexa.workspace_copier.transport import GraphQLError
+
+
+def _detail(slug="my-dataset", **overrides):
+    detail = {
+        "id": "sd-1",
+        "slug": slug,
+        "name": slug,
+        "description": "",
+        "sharedWithOrganization": False,
+        "latestVersion": {"id": "sv-2", "name": "v2", "changelog": ""},
+    }
+    detail.update(overrides)
+    return detail
+
+
+class DatasetsCopierRemoteTest(SimpleTestCase):
+    def setUp(self):
+        self.source = Endpoint.remote(MagicMock(), "src")
+        self.target = Endpoint.remote(MagicMock(), "tgt")
+        self.result = CopyResult()
+
+    @patch("hexa.workspace_copier.resources.datasets._copy_versions")
+    @patch("hexa.workspace_copier.resources.datasets._apply_sharing")
+    @patch("hexa.workspace_copier.resources.datasets._create_on_target")
+    @patch("hexa.workspace_copier.resources.datasets._fetch_source_detail")
+    @patch("hexa.workspace_copier.resources.datasets._list_target_slugs")
+    @patch("hexa.workspace_copier.resources.datasets._list_source_datasets")
+    def test_creates_new_dataset(
+        self,
+        mock_list,
+        mock_target_slugs,
+        mock_detail,
+        mock_create,
+        mock_sharing,
+        mock_versions,
+    ):
+        mock_list.return_value = [("sd-1", "my-dataset", "My Dataset")]
+        mock_target_slugs.return_value = set()
+        mock_detail.return_value = _detail()
+        mock_create.return_value = ("td-1", "my-dataset")
+        mock_versions.return_value = ["v2"]
+
+        DatasetsCopier().copy(self.source, self.target, self.result, NullReporter())
+
+        self.assertEqual(self.result.datasets.created, [("my-dataset", ["v2"])])
+        self.assertEqual(self.result.datasets.failed, [])
+        mock_sharing.assert_called_once()
+
+    @patch("hexa.workspace_copier.resources.datasets._list_target_slugs")
+    @patch("hexa.workspace_copier.resources.datasets._list_source_datasets")
+    def test_skips_existing_dataset(self, mock_list, mock_target_slugs):
+        mock_list.return_value = [("sd-1", "my-dataset", "My Dataset")]
+        # slugify("My Dataset") == "my-dataset" is already on the target.
+        mock_target_slugs.return_value = {"my-dataset"}
+
+        DatasetsCopier().copy(self.source, self.target, self.result, NullReporter())
+
+        self.assertEqual(self.result.datasets.skipped, ["my-dataset"])
+        self.assertEqual(self.result.datasets.created, [])
+
+    @patch("hexa.workspace_copier.resources.datasets._copy_versions")
+    @patch("hexa.workspace_copier.resources.datasets._apply_sharing")
+    @patch("hexa.workspace_copier.resources.datasets._create_on_target")
+    @patch("hexa.workspace_copier.resources.datasets._fetch_source_detail")
+    @patch("hexa.workspace_copier.resources.datasets._list_target_slugs")
+    @patch("hexa.workspace_copier.resources.datasets._list_source_datasets")
+    def test_failed_dataset_is_recorded_and_does_not_abort(
+        self,
+        mock_list,
+        mock_target_slugs,
+        mock_detail,
+        mock_create,
+        mock_sharing,
+        mock_versions,
+    ):
+        mock_list.return_value = [
+            ("sd-1", "bad-one", "bad-one"),
+            ("sd-2", "good-one", "good-one"),
+        ]
+        mock_target_slugs.return_value = set()
+        mock_detail.side_effect = [_detail("bad-one"), _detail("good-one")]
+        mock_create.side_effect = [("td-1", "bad-one"), ("td-2", "good-one")]
+        mock_versions.side_effect = [
+            GraphQLError("file 'a.csv' of version 'v2' failed"),
+            ["v2"],
+        ]
+
+        DatasetsCopier().copy(self.source, self.target, self.result, NullReporter())
+
+        self.assertEqual(self.result.datasets.failed, ["bad-one"])
+        self.assertEqual(self.result.datasets.created, [("good-one", ["v2"])])
+        self.assertTrue(any("bad-one" in w for w in self.result.datasets.warnings))
+
+    @patch("hexa.workspace_copier.resources.datasets._copy_versions")
+    @patch("hexa.workspace_copier.resources.datasets._apply_sharing")
+    @patch("hexa.workspace_copier.resources.datasets._create_on_target")
+    @patch("hexa.workspace_copier.resources.datasets._fetch_source_detail")
+    @patch("hexa.workspace_copier.resources.datasets._list_target_slugs")
+    @patch("hexa.workspace_copier.resources.datasets._list_source_datasets")
+    def test_versionless_dataset_is_still_created(
+        self,
+        mock_list,
+        mock_target_slugs,
+        mock_detail,
+        mock_create,
+        mock_sharing,
+        mock_versions,
+    ):
+        mock_list.return_value = [("sd-1", "empty", "empty")]
+        mock_target_slugs.return_value = set()
+        mock_detail.return_value = _detail("empty", latestVersion=None)
+        mock_create.return_value = ("td-1", "empty")
+        mock_versions.return_value = []
+
+        DatasetsCopier().copy(self.source, self.target, self.result, NullReporter())
+
+        self.assertEqual(self.result.datasets.created, [("empty", [])])
+        self.assertEqual(mock_versions.call_args.args[4], [])
+
+    def test_local_endpoint_not_yet_implemented(self):
+        with self.assertRaises(NotImplementedError):
+            DatasetsCopier().copy(
+                Endpoint.local("src"), self.target, self.result, NullReporter()
+            )
+
+
+class ListSourceDatasetsTest(SimpleTestCase):
+    @patch("hexa.workspace_copier.resources.datasets.gql")
+    def test_only_datasets_owned_by_the_workspace_are_listed(self, mock_gql):
+        # The workspace's dataset page also lists datasets it merely has access
+        # to: one owned by another workspace, one whose workspace is gone.
+        mock_gql.return_value = {
+            "workspace": {
+                "datasets": {
+                    "totalPages": 1,
+                    "items": [
+                        {
+                            "dataset": {
+                                "id": "sd-1",
+                                "slug": "mine",
+                                "name": "Mine",
+                                "workspace": {"slug": "src"},
+                            }
+                        },
+                        {
+                            "dataset": {
+                                "id": "sd-2",
+                                "slug": "theirs",
+                                "name": "Theirs",
+                                "workspace": {"slug": "other-ws"},
+                            }
+                        },
+                        {
+                            "dataset": {
+                                "id": "sd-3",
+                                "slug": "orphan",
+                                "name": "Orphan",
+                                "workspace": None,
+                            }
+                        },
+                    ],
+                }
+            }
+        }
+
+        datasets = _list_source_datasets(MagicMock(), "src")
+
+        self.assertEqual(datasets, [("sd-1", "mine", "Mine")])
+
+
+class AssignTargetNamesTest(SimpleTestCase):
+    def test_same_named_datasets_get_distinct_predictable_slugs(self):
+        # Two source datasets share a name. The second must not be dropped as
+        # "already existing": we disambiguate the name so the target server
+        # produces a slug we can predict instead of a random suffix.
+        assignments = _assign_target_names(
+            [
+                ("sd-1", "population-a1b2c3", "Population"),
+                ("sd-2", "population", "Population"),
+            ]
+        )
+
+        self.assertEqual(
+            assignments,
+            [
+                ("sd-2", "population", "Population", "population"),
+                ("sd-1", "population-a1b2c3", "Population (2)", "population-2"),
+            ],
+        )
+
+
+class SelectVersionsTest(SimpleTestCase):
+    def test_default_takes_the_latest_version_only(self):
+        client = MagicMock()
+        versions = _select_versions(client, "sd-1", _detail(), all_versions=False)
+
+        self.assertEqual(versions, [{"id": "sv-2", "name": "v2", "changelog": ""}])
+        client.execute.assert_not_called()
+
+    def test_default_on_a_versionless_dataset_is_empty(self):
+        versions = _select_versions(
+            MagicMock(), "sd-1", _detail(latestVersion=None), all_versions=False
+        )
+
+        self.assertEqual(versions, [])
+
+    @patch("hexa.workspace_copier.resources.datasets.gql")
+    def test_all_versions_are_paged_and_returned_oldest_first(self, mock_gql):
+        # The API returns versions newest-first; the target only accepts files
+        # for its latest version, so they have to be replayed oldest-first.
+        mock_gql.side_effect = [
+            {
+                "dataset": {
+                    "versions": {
+                        "totalPages": 2,
+                        "items": [
+                            {"id": "sv-3", "name": "v3", "createdAt": "2024-03-01"},
+                            {"id": "sv-2", "name": "v2", "createdAt": "2024-02-01"},
+                        ],
+                    }
+                }
+            },
+            {
+                "dataset": {
+                    "versions": {
+                        "totalPages": 2,
+                        "items": [
+                            {"id": "sv-1", "name": "v1", "createdAt": "2024-01-01"}
+                        ],
+                    }
+                }
+            },
+        ]
+
+        versions = _select_versions(MagicMock(), "sd-1", _detail(), all_versions=True)
+
+        self.assertEqual([v["name"] for v in versions], ["v1", "v2", "v3"])
+
+
+class RelativeUriTest(SimpleTestCase):
+    def test_strips_the_source_dataset_and_version_prefix(self):
+        file = {"uri": "sd-1/sv-2/sub/dir/data.csv", "filename": "data.csv"}
+
+        self.assertEqual(_relative_uri(file, "sd-1", "sv-2"), "sub/dir/data.csv")
+
+    def test_falls_back_to_filename_when_the_prefix_is_absent(self):
+        file = {"uri": "unexpected/data.csv", "filename": "data.csv"}
+
+        self.assertEqual(_relative_uri(file, "sd-1", "sv-2"), "data.csv")
+
+
+class CopyVersionsTest(SimpleTestCase):
+    def setUp(self):
+        self.source = Endpoint.remote(MagicMock(), "src")
+        self.target = Endpoint.remote(MagicMock(), "tgt")
+        self.ds_result = DatasetsResult()
+
+    def _copy(self, versions):
+        return _copy_versions(
+            self.source,
+            self.target,
+            "sd-1",
+            "td-1",
+            versions,
+            self.ds_result,
+            NullReporter(),
+            MagicMock(),
+        )
+
+    @patch("hexa.workspace_copier.resources.datasets._transfer_file")
+    @patch("hexa.workspace_copier.resources.datasets._prepare_download")
+    @patch("hexa.workspace_copier.resources.datasets._list_version_files")
+    @patch("hexa.workspace_copier.resources.datasets._create_version")
+    def test_each_version_is_filled_before_the_next_one_is_created(
+        self, mock_create, mock_files, mock_download, mock_transfer
+    ):
+        # A version stops accepting files as soon as a newer one exists, so the
+        # order must be create v1, upload v1's files, create v2, ...
+        calls = []
+        mock_create.side_effect = lambda _client, _dataset_id, version: (
+            calls.append(f"create {version['name']}") or f"t{version['name']}"
+        )
+        mock_files.side_effect = [
+            [{"id": "f1", "uri": "sd-1/sv-1/a.csv", "filename": "a.csv"}],
+            [{"id": "f2", "uri": "sd-1/sv-2/b.csv", "filename": "b.csv"}],
+        ]
+        mock_download.return_value = "https://download"
+        mock_transfer.side_effect = lambda *args, **kwargs: (
+            calls.append(f"upload {args[2]}") or 10
+        )
+
+        copied = self._copy(
+            [
+                {"id": "sv-1", "name": "v1"},
+                {"id": "sv-2", "name": "v2"},
+            ]
+        )
+
+        self.assertEqual(copied, ["v1", "v2"])
+        self.assertEqual(
+            calls, ["create v1", "upload a.csv", "create v2", "upload b.csv"]
+        )
+        self.assertEqual(self.ds_result.files_copied, 2)
+        self.assertEqual(self.ds_result.bytes_copied, 20)
+
+    @patch("hexa.workspace_copier.resources.datasets._transfer_file")
+    @patch("hexa.workspace_copier.resources.datasets._prepare_download")
+    @patch("hexa.workspace_copier.resources.datasets._list_version_files")
+    @patch("hexa.workspace_copier.resources.datasets._create_version")
+    def test_a_failed_file_stops_before_the_next_version_is_created(
+        self, mock_create, mock_files, mock_download, mock_transfer
+    ):
+        # Creating v2 would lock the incomplete v1 out of any further upload, so
+        # the whole dataset is abandoned instead.
+        mock_create.return_value = "tv-1"
+        mock_files.return_value = [
+            {"id": "f1", "uri": "sd-1/sv-1/a.csv", "filename": "a.csv"}
+        ]
+        mock_download.return_value = "https://download"
+        mock_transfer.side_effect = GraphQLError("upload returned HTTP 500")
+
+        with self.assertRaises(GraphQLError) as ctx:
+            self._copy([{"id": "sv-1", "name": "v1"}, {"id": "sv-2", "name": "v2"}])
+
+        self.assertIn("a.csv", str(ctx.exception))
+        self.assertIn("later versions were not copied", str(ctx.exception))
+        self.assertEqual(mock_create.call_count, 1)
+
+    @patch("hexa.workspace_copier.resources.datasets._transfer_file")
+    @patch("hexa.workspace_copier.resources.datasets._prepare_download")
+    @patch("hexa.workspace_copier.resources.datasets._list_version_files")
+    @patch("hexa.workspace_copier.resources.datasets._create_version")
+    def test_a_file_with_no_content_on_source_is_warned_and_skipped(
+        self, mock_create, mock_files, mock_download, mock_transfer
+    ):
+        mock_create.return_value = "tv-1"
+        mock_files.return_value = [
+            {"id": "f1", "uri": "sd-1/sv-1/a.csv", "filename": "a.csv"}
+        ]
+        mock_download.return_value = None  # FILE_NOT_UPLOADED on the source
+
+        copied = self._copy([{"id": "sv-1", "name": "v1"}])
+
+        self.assertEqual(copied, ["v1"])
+        mock_transfer.assert_not_called()
+        self.assertEqual(self.ds_result.files_copied, 0)
+        self.assertTrue(any("a.csv" in w for w in self.ds_result.warnings))
+
+
+class DatasetsCopierOptionsTest(SimpleTestCase):
+    @patch("hexa.workspace_copier.resources.datasets._copy_versions")
+    @patch("hexa.workspace_copier.resources.datasets._apply_sharing")
+    @patch("hexa.workspace_copier.resources.datasets._create_on_target")
+    @patch("hexa.workspace_copier.resources.datasets._select_versions")
+    @patch("hexa.workspace_copier.resources.datasets._fetch_source_detail")
+    @patch("hexa.workspace_copier.resources.datasets._list_target_slugs")
+    @patch("hexa.workspace_copier.resources.datasets._list_source_datasets")
+    def test_all_dataset_versions_flag_reaches_the_version_selection(
+        self,
+        mock_list,
+        mock_target_slugs,
+        mock_detail,
+        mock_select,
+        mock_create,
+        mock_sharing,
+        mock_versions,
+    ):
+        mock_list.return_value = [("sd-1", "my-dataset", "My Dataset")]
+        mock_target_slugs.return_value = set()
+        mock_detail.return_value = _detail()
+        mock_create.return_value = ("td-1", "my-dataset")
+        mock_select.return_value = []
+        mock_versions.return_value = []
+
+        DatasetsCopier().copy(
+            Endpoint.remote(MagicMock(), "src"),
+            Endpoint.remote(MagicMock(), "tgt"),
+            CopyResult(),
+            NullReporter(),
+            options=CopyOptions(all_dataset_versions=True),
+        )
+
+        self.assertIs(mock_select.call_args.args[3], True)

--- a/backend/hexa/workspace_copier/tests/test_forms.py
+++ b/backend/hexa/workspace_copier/tests/test_forms.py
@@ -48,6 +48,28 @@ class CopyWorkspaceFormTest(SimpleTestCase):
         self.assertTrue(form.is_valid(), form.errors)
         self.assertIn("workspace", form.cleaned_data["resources"])
 
+    def test_resource_rows_nest_options_under_their_copier(self):
+        rows = {
+            row["checkbox"].data["value"]: row
+            for row in CopyWorkspaceForm().resource_rows()
+        }
+        self.assertEqual(
+            [option.name for option in rows["datasets"]["options"]],
+            ["all_dataset_versions"],
+        )
+        self.assertEqual(rows["connections"]["options"], [])
+
+    def test_mandatory_resource_renders_checked_and_locked(self):
+        rows = {
+            row["checkbox"].data["value"]: row
+            for row in CopyWorkspaceForm().resource_rows()
+        }
+        self.assertTrue(rows["workspace"]["mandatory"])
+        self.assertFalse(rows["datasets"]["mandatory"])
+        markup = str(rows["workspace"]["checkbox"])
+        self.assertIn("checked", markup)
+        self.assertIn("disabled", markup)
+
     def test_empty_resources_defaults_to_all(self):
         form = CopyWorkspaceForm(data=_base_data(resources=[]))
         self.assertTrue(form.is_valid(), form.errors)

--- a/backend/hexa/workspace_copier/tests/test_orchestrator.py
+++ b/backend/hexa/workspace_copier/tests/test_orchestrator.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from django.test import SimpleTestCase
 
 from hexa.workspace_copier import orchestrator
+from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.orchestrator import (
     WORKSPACE_COPIERS,
     _resolve_selection,
@@ -19,9 +20,11 @@ class FakeCopier(ResourceCopier):
         self.mandatory = mandatory
         self.depends_on = depends_on
         self.calls = []
+        self.options = {}
 
-    def copy(self, source, target, result, reporter):
+    def copy(self, source, target, result, reporter, *, options=CopyOptions()):
         self.calls.append((source, target))
+        self.options = options
         reporter.info(f"ran:{self.name}")
         result.warn(f"ran:{self.name}")
 
@@ -73,6 +76,13 @@ class CopyWorkspaceTest(SimpleTestCase):
         )
         # files copier did not run
         self.assertFalse(fakes[1].calls)
+
+    def test_options_reach_every_copier(self):
+        fakes = [FakeCopier("workspace", mandatory=True), FakeCopier("datasets")]
+        options = CopyOptions(all_dataset_versions=True)
+        with patch.object(orchestrator, "WORKSPACE_COPIERS", fakes):
+            copy_workspace(object(), object(), NullReporter(), options=options)
+        self.assertTrue(all(f.options is options for f in fakes))
 
     def test_no_warning_when_dependency_selected(self):
         fakes = [


### PR DESCRIPTION
Add the option to copy datasets. By default just copy the latest version.

The logic is mostly vibe-coded like this part of our code. Also I followed the pattern of using generic GQL queries instead of defining typed queries in our SDK client and using them here since this is the pattern used for other assets.