### PR TITLE
fix: git webapp clone sometimes directing users to Github (HEXA-1745)

### DIFF
--- a/backend/hexa/git/tests/test_views.py
+++ b/backend/hexa/git/tests/test_views.py
@@ -120,10 +120,15 @@ class GitAuthorizeViewTest(GitAuthMixin, TestCase):
         response = self._get(token=token, uri=self._read_uri())
         self.assertEqual(response.status_code, 401)
 
-    def test_wrong_scope_returns_403(self):
+    def test_wrong_scope_returns_401(self):
+        """401 so the proxy re-challenges: a wrongly scoped token is unusable,
+        and only the 401 path carries `WWW-Authenticate: Basic realm="Gitea"`,
+        which is what makes a credential helper fetch a git-scoped token instead
+        of prompting for a password.
+        """
         token = self._token(self.viewer, scope="openhexa:mcp")
         response = self._get(token=token, uri=self._read_uri())
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
 
     def test_viewer_can_read(self):
         response = self._get(token=self._token(self.viewer), uri=self._read_uri())

--- a/backend/hexa/git/views.py
+++ b/backend/hexa/git/views.py
@@ -105,7 +105,7 @@ def authorize(request: HttpRequest) -> HttpResponse:
         return HttpResponse(status=401)
 
     if GIT_SCOPE not in access_token.scope.split():
-        return HttpResponse(status=403)
+        return HttpResponse(status=401)
 
     user = access_token.user
 

--- a/frontend/public/locales/en/messages.json
+++ b/frontend/public/locales/en/messages.json
@@ -612,6 +612,7 @@
   "Open in Airflow": "Open in Airflow",
   "Opening pipeline editor": "Opening pipeline editor",
   "optional": "optional",
+  "Optional — run this to force Git Credential Manager to sign in through OpenHEXA:": "Optional — run this to force Git Credential Manager to sign in through OpenHEXA:",
   "Optional. Up to 5 uppercase letters. Auto-generated if left empty.": "Optional. Up to 5 uppercase letters. Auto-generated if left empty.",
   "or": "or",
   "Or create your own organization": "Or create your own organization",

--- a/frontend/public/locales/fr/messages.json
+++ b/frontend/public/locales/fr/messages.json
@@ -623,6 +623,7 @@
   "Open in Airflow": "Ouvert dans le flux d'air",
   "Opening pipeline editor": "Ouverture de l'éditeur de pipeline",
   "optional": "optionnel",
+  "Optional — run this to force Git Credential Manager to sign in through OpenHEXA:": "Facultatif — exécutez cette commande pour forcer Git Credential Manager à s'authentifier via OpenHEXA :",
   "Optional. Up to 5 uppercase letters. Auto-generated if left empty.": "Optionnel. Jusqu'à 5 lettres majuscules. Généré automatiquement si laissé vide.",
   "or": "ou",
   "Or create your own organization": "Ou créez votre propre organisation",

--- a/frontend/src/webapps/features/GitClonePopover/GitClonePopover.tsx
+++ b/frontend/src/webapps/features/GitClonePopover/GitClonePopover.tsx
@@ -19,6 +19,15 @@ const SectionLabel = ({ children }: { children: React.ReactNode }) => (
   </div>
 );
 
+const getProviderCommand = (repositoryUrl: string): string | null => {
+  try {
+    const { origin } = new URL(repositoryUrl);
+    return `git config --global credential.${origin}.provider generic`;
+  } catch {
+    return null;
+  }
+};
+
 type GitClonePopoverProps = {
   repositoryUrl: string;
 };
@@ -26,6 +35,7 @@ type GitClonePopoverProps = {
 const GitClonePopover = ({ repositoryUrl }: GitClonePopoverProps) => {
   const { t } = useTranslation();
   const cloneCommand = `git clone ${repositoryUrl}`;
+  const providerCommand = getProviderCommand(repositoryUrl);
 
   return (
     <Popover
@@ -96,6 +106,16 @@ const GitClonePopover = ({ repositoryUrl }: GitClonePopoverProps) => {
               </div>
             </Tabs.Tab>
           </Tabs>
+          {providerCommand && (
+            <div className="space-y-2 pt-1">
+              <p className="text-xs leading-relaxed text-gray-600">
+                {t(
+                  "Optional — run this to force Git Credential Manager to sign in through OpenHEXA:",
+                )}
+              </p>
+              <CommandBox command={providerCommand} />
+            </div>
+          )}
         </div>
       </div>
     </Popover>


### PR DESCRIPTION
Just add a command ensuring GCM picks our origin domain and not Github's one. Also ensure that wrong scope token are returning 401, giving a chance for the Git client to recover from the issue