### PR TITLE
fix: Workspace copier small improvements (HEXA-1756)

### DIFF
--- a/backend/hexa/workspace_copier/README.md
+++ b/backend/hexa/workspace_copier/README.md
@@ -30,7 +30,7 @@ order (see `orchestrator.WORKSPACE_COPIERS`):
 | `files`       | `FilesCopier`             | bucket objects (streamed through a temp file — see [Large files](#large-files)); the target bucket is listed first and files matching by key + size are skipped, as is anything under a `SKIPPED_DIRECTORIES` scratch dir |
 | `database`    | `DatabaseCopier`          | native pg copy only if **both** sides LOCAL; else skipped + warned. Local copy not yet implemented |
 | `connections` | `ConnectionsCopier`       | connections + secret fields                                                                        |
-| `pipelines`   | `PipelinesCopier`         | pipelines + versions (depends on `files` for notebook pipelines)                                   |
+| `pipelines`   | `PipelinesCopier`         | pipelines + versions (+ the `.ipynb` file for notebook pipelines)                                  |
 | `datasets`    | `DatasetsCopier`          | datasets **owned** by the workspace                                                                |
 
 Template pipelines are **not** in this registry — they are server-wide, not a

--- a/backend/hexa/workspace_copier/README.md
+++ b/backend/hexa/workspace_copier/README.md
@@ -30,7 +30,7 @@ order (see `orchestrator.WORKSPACE_COPIERS`):
 | `files`       | `FilesCopier`             | bucket objects (streamed through a temp file — see [Large files](#large-files)); the target bucket is listed first and files matching by key + size are skipped, as is anything under a `SKIPPED_DIRECTORIES` scratch dir |
 | `database`    | `DatabaseCopier`          | native pg copy only if **both** sides LOCAL; else skipped + warned. Local copy not yet implemented |
 | `connections` | `ConnectionsCopier`       | connections + secret fields                                                                        |
-| `pipelines`   | `PipelinesCopier`         | pipelines + versions (+ the `.ipynb` file for notebook pipelines)                                  |
+| `pipelines`   | `PipelinesCopier`         | pipelines + versions<br>Notes: The `.ipynb` file is copied for notebook pipelines<br>Schedules are not copied to avoid them running immediately after a copy. This allows a human to validate the copied pipeline and schedule it manually.
 | `datasets`    | `DatasetsCopier`          | datasets **owned** by the workspace                                                                |
 
 Template pipelines are **not** in this registry — they are server-wide, not a

--- a/backend/hexa/workspace_copier/admin.py
+++ b/backend/hexa/workspace_copier/admin.py
@@ -51,13 +51,14 @@ def copy_workspace_view(request):
                     reporter=reporter,
                 )
                 summary = format_summary(result)
-                log = reporter.render()
                 messages.success(request, "Workspace copy finished.")
             except CredentialError as exc:
                 for err in exc.errors:
                     messages.error(request, err)
             except (GraphQLError, NotImplementedError) as exc:
                 messages.error(request, f"Copy failed: {exc}")
+            finally:
+                log = reporter.render()
     else:
         form = CopyWorkspaceForm()
 
@@ -94,13 +95,14 @@ def copy_templates_view(request):
                     reporter=reporter,
                 )
                 summary = format_templates_summary(result)
-                log = reporter.render()
                 messages.success(request, "Template copy finished.")
             except CredentialError as exc:
                 for err in exc.errors:
                     messages.error(request, err)
             except GraphQLError as exc:
                 messages.error(request, f"Copy failed: {exc}")
+            finally:
+                log = reporter.render()
     else:
         form = CopyTemplatesForm()
 

--- a/backend/hexa/workspace_copier/orchestrator.py
+++ b/backend/hexa/workspace_copier/orchestrator.py
@@ -9,6 +9,8 @@ so this orchestration is written once and shared by every flow (CLI + admin).
 
 from collections.abc import Iterable
 
+from django.utils import timezone
+
 from hexa.workspace_copier.endpoints import Endpoint
 from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.progress import ProgressReporter
@@ -64,7 +66,7 @@ def copy_workspace(
     """
     selected = _resolve_selection(WORKSPACE_COPIERS, resources)
     selected_names = {c.name for c in selected}
-    result = CopyResult()
+    result = CopyResult(started_at=timezone.localtime())
     for copier in selected:
         for dep in copier.depends_on:
             if dep not in selected_names:
@@ -73,4 +75,9 @@ def copy_workspace(
                 reporter.warning(message)
         reporter.info(f"=> Copying {copier.name} ...")
         copier.copy(source, target, result, reporter, options=options)
+        # Every line is timestamped, so bracketing each copier with a start and
+        # a finish line is what makes "how long did files take" answerable —
+        # including for the last copier, which has no successor line.
+        reporter.info(f"   {copier.name} finished")
+    result.finished_at = timezone.localtime()
     return result

--- a/backend/hexa/workspace_copier/orchestrator.py
+++ b/backend/hexa/workspace_copier/orchestrator.py
@@ -2,9 +2,9 @@
 
 Owns the ordered registry of resource copiers and runs the selected ones in
 dependency order: workspace metadata first (it creates the target and yields its
-handle), files before pipelines (notebook pipelines need their .ipynb present
-first). The medium (ORM vs GraphQL) is decided per endpoint inside each copier,
-so this orchestration is written once and shared by every flow (CLI + admin).
+handle), then the rest. The medium (ORM vs GraphQL) is decided per endpoint
+inside each copier, so this orchestration is written once and shared by every
+flow (CLI + admin).
 """
 
 from collections.abc import Iterable
@@ -25,7 +25,7 @@ from hexa.workspace_copier.results import CopyResult
 
 WORKSPACE_COPIERS: list[ResourceCopier] = [
     WorkspaceMetadataCopier(),  # Mandatory first step
-    FilesCopier(),  # Before pipelines, needed for .ipynb files (notebook pipelines)
+    FilesCopier(),
     DatabaseCopier(),  # LOCAL→LOCAL: native pg; else skip + warning
     ConnectionsCopier(),
     PipelinesCopier(),

--- a/backend/hexa/workspace_copier/progress.py
+++ b/backend/hexa/workspace_copier/progress.py
@@ -27,7 +27,8 @@ def format_entry(timestamp: datetime, level: str, message: str) -> str:
 
 @runtime_checkable
 class ProgressReporter(Protocol):
-    def log(self, message: str, *, level: str = "INFO") -> None: ...
+    def log(self, message: str, *, level: str = "INFO") -> None:
+        ...
 
 
 class BaseReporter:

--- a/backend/hexa/workspace_copier/progress.py
+++ b/backend/hexa/workspace_copier/progress.py
@@ -10,16 +10,24 @@ entrypoint supplies:
   record; see :class:`BufferReporter` for the shape such a class would follow.
 """
 
+from datetime import datetime
 from typing import Protocol, runtime_checkable
+
+from django.utils import timezone
 
 # Ordered low -> high so a reporter can filter by a minimum level.
 LEVELS = ("INFO", "WARNING", "ERROR")
 
 
+def format_entry(timestamp: datetime, level: str, message: str) -> str:
+    """Render one log line, shared by every reporter so they can't drift apart."""
+    prefix = "" if level == "INFO" else f"[{level}] "
+    return f"{timestamp.strftime('%H:%M:%S')} {prefix}{message}"
+
+
 @runtime_checkable
 class ProgressReporter(Protocol):
-    def log(self, message: str, *, level: str = "INFO") -> None:
-        ...
+    def log(self, message: str, *, level: str = "INFO") -> None: ...
 
 
 class BaseReporter:
@@ -53,8 +61,8 @@ class StreamReporter(BaseReporter):
         self.stream = stream
 
     def log(self, message: str, *, level: str = "INFO") -> None:
-        prefix = "" if level == "INFO" else f"[{level}] "
-        self.stream.write(f"{prefix}{message}\n")
+        self.stream.write(f"{format_entry(timezone.localtime(), level, message)}\n")
+        self.stream.flush()
 
 
 class BufferReporter(BaseReporter):
@@ -66,13 +74,13 @@ class BufferReporter(BaseReporter):
     """
 
     def __init__(self):
-        self.entries: list[tuple[str, str]] = []
+        self.entries: list[tuple[datetime, str, str]] = []
 
     def log(self, message: str, *, level: str = "INFO") -> None:
-        self.entries.append((level, message))
+        self.entries.append((timezone.localtime(), level, message))
 
     def render(self) -> str:
         return "\n".join(
-            msg if level == "INFO" else f"[{level}] {msg}"
-            for level, msg in self.entries
+            format_entry(timestamp, level, message)
+            for timestamp, level, message in self.entries
         )

--- a/backend/hexa/workspace_copier/resources/datasets.py
+++ b/backend/hexa/workspace_copier/resources/datasets.py
@@ -26,7 +26,7 @@ from hexa.workspace_copier.endpoints import Endpoint
 from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.progress import ProgressReporter
 from hexa.workspace_copier.resources.base import ResourceCopier
-from hexa.workspace_copier.results import CopyResult, DatasetsResult
+from hexa.workspace_copier.results import CopyResult, DatasetsResult, format_bytes
 from hexa.workspace_copier.transport import GraphQLError, gql
 
 DATASETS_PAGE_SIZE = 50
@@ -644,7 +644,7 @@ def _copy_versions(
                 ) from exc
             ds_result.files_copied += 1
             ds_result.bytes_copied += size
-            reporter.info(f"      copied {uri} ({size} bytes)")
+            reporter.info(f"      copied {uri} ({format_bytes(size)})")
 
         copied.append(version["name"])
     return copied

--- a/backend/hexa/workspace_copier/resources/pipelines.py
+++ b/backend/hexa/workspace_copier/resources/pipelines.py
@@ -10,6 +10,7 @@ rather than relying on the files copier having run.
 """
 
 import base64
+import tempfile
 from typing import Any
 
 import httpx
@@ -22,7 +23,7 @@ from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.progress import ProgressReporter
 from hexa.workspace_copier.resources.base import ResourceCopier
 from hexa.workspace_copier.resources.files import download, upload
-from hexa.workspace_copier.results import CopyResult, PipelinesResult
+from hexa.workspace_copier.results import CopyResult, PipelinesResult, format_bytes
 from hexa.workspace_copier.transport import GraphQLError, gql
 
 PIPELINES_PAGE_SIZE = 50
@@ -304,9 +305,11 @@ def _copy_notebook_file(
     reporter: ProgressReporter,
 ) -> None:
     """Transfer a notebook pipeline's ``.ipynb`` to the target bucket."""
-    content = download(source.client, source.slug, notebook_path, http_client)
-    upload(target.client, target.slug, notebook_path, content, http_client)
-    reporter.info(f"   copied notebook {notebook_path} ({len(content)} bytes)")
+    with tempfile.TemporaryFile() as buffer:
+        size = download(source.client, source.slug, notebook_path, http_client, buffer)
+        buffer.seek(0)
+        upload(target.client, target.slug, notebook_path, buffer, http_client)
+    reporter.info(f"   copied notebook {notebook_path} ({format_bytes(size)})")
 
 
 def _create_on_target(

--- a/backend/hexa/workspace_copier/resources/pipelines.py
+++ b/backend/hexa/workspace_copier/resources/pipelines.py
@@ -183,6 +183,14 @@ class PipelinesCopier(ResourceCopier):
         )
 
         _update_settings(target.client, target_pid, detail, scheduled_version_id)
+
+        # schedule deliberately left unset on the target
+        src_schedule = detail.get("schedule")
+        if src_schedule:
+            schedule_wrn_msg = f"pipeline '{target_code}' schedule '{src_schedule}' not copied — set it manually once validated"
+            pipes_result.warnings.append(schedule_wrn_msg)
+            reporter.warning(f"   {schedule_wrn_msg}")
+
         pipes_result.created.append((target_code, uploaded_names))
         reporter.info(
             f"   created pipeline '{target_code}' ({len(uploaded_names)} version(s))"
@@ -394,10 +402,13 @@ def _update_settings(
     src_pipeline: dict[str, Any],
     scheduled_version_id: str | None,
 ) -> None:
-    """Apply pipeline-level fields that createPipeline/uploadPipeline cannot set."""
+    """Apply pipeline-level fields that createPipeline/uploadPipeline cannot set.
+
+    Note: ``schedule`` is intentionally left out to avoid it running immediately
+    after the copy.
+    """
     input_: dict[str, Any] = {
         "id": target_pipeline_id,
-        "schedule": src_pipeline.get("schedule"),
         "webhookEnabled": src_pipeline.get("webhookEnabled"),
         "config": src_pipeline.get("config") or None,
         "scheduledPipelineVersionId": scheduled_version_id,

--- a/backend/hexa/workspace_copier/resources/pipelines.py
+++ b/backend/hexa/workspace_copier/resources/pipelines.py
@@ -4,14 +4,15 @@ REMOTE branch — ported from ``migrate_lib/pipelines.py``. The LOCAL (ORM) bran
 is implemented in a later phase. ``_upload_version`` is kept module-level because
 the template copier reuses it to back template versions.
 
-Declares ``depends_on=("files",)`` advisory dependency: *notebook* pipelines need
-their ``.ipynb`` present on the target before ``createPipeline`` succeeds, so the
-files copier should run first (zip pipelines don't need it).
+A *notebook* pipeline needs its ``.ipynb`` present on the target before
+``createPipeline`` succeeds, so this copier transfers that one file itself
+rather than relying on the files copier having run.
 """
 
 import base64
 from typing import Any
 
+import httpx
 from openhexa.graphql.graphql_client.client import Client
 from openhexa.graphql.graphql_client.input_types import CreatePipelineInput
 from slugify import slugify
@@ -20,6 +21,7 @@ from hexa.workspace_copier.endpoints import Endpoint
 from hexa.workspace_copier.options import CopyOptions
 from hexa.workspace_copier.progress import ProgressReporter
 from hexa.workspace_copier.resources.base import ResourceCopier
+from hexa.workspace_copier.resources.files import download, upload
 from hexa.workspace_copier.results import CopyResult, PipelinesResult
 from hexa.workspace_copier.transport import GraphQLError, gql
 
@@ -74,7 +76,6 @@ mutation UpdatePipeline($input: UpdatePipelineInput!) {
 class PipelinesCopier(ResourceCopier):
     name = "pipelines"
     label = "Pipelines (+versions)"
-    depends_on = ("files",)
 
     def copy(
         self,
@@ -107,33 +108,37 @@ class PipelinesCopier(ResourceCopier):
         assignments = _assign_target_codes(pipelines)
         existing_codes = _list_target_codes(target.client, target.slug)
 
-        for pipeline_id, src_code, target_name, target_code in assignments:
-            if target_code in existing_codes:
-                pipes_result.skipped.append(src_code)
-                reporter.info(f"   skipped pipeline '{src_code}' (already exists)")
-                continue
-            try:
-                reporter.info(f"   copying pipeline '{src_code}' ...")
-                self._copy_pipeline(
-                    source,
-                    target,
-                    pipeline_id,
-                    src_code,
-                    target_name,
-                    pipes_result,
-                    reporter,
-                )
-            except GraphQLError as exc:
-                # Collect and continue (like the datasets copier) so one bad
-                # pipeline doesn't abort the rest of the copy. The common
-                # case is a notebook pipeline whose .ipynb wasn't copied to the
-                # target (files deselected), which fails with FILE_NOT_FOUND.
-                pipes_result.failed.append(src_code)
-                pipes_result.warnings.append(
-                    f"pipeline '{src_code}' could not be copied — handle "
-                    f"manually ({exc})."
-                )
-                reporter.warning(f"   FAILED to copy pipeline '{src_code}' ({exc})")
+        # One shared client for the presigned notebook transfers, so the
+        # connection pool reuses TLS handshakes across pipelines.
+        with httpx.Client(timeout=300) as http_client:
+            for pipeline_id, src_code, target_name, target_code in assignments:
+                if target_code in existing_codes:
+                    pipes_result.skipped.append(src_code)
+                    reporter.info(f"   skipped pipeline '{src_code}' (already exists)")
+                    continue
+                try:
+                    reporter.info(f"   copying pipeline '{src_code}' ...")
+                    self._copy_pipeline(
+                        source,
+                        target,
+                        pipeline_id,
+                        src_code,
+                        target_name,
+                        pipes_result,
+                        reporter,
+                        http_client,
+                    )
+                except (GraphQLError, httpx.HTTPError) as exc:
+                    # Collect and continue (like the datasets copier) so one bad
+                    # pipeline doesn't abort the rest of the copy. The common
+                    # case is a notebook pipeline whose .ipynb is missing from
+                    # the source bucket, so it can't be put on the target.
+                    pipes_result.failed.append(src_code)
+                    pipes_result.warnings.append(
+                        f"pipeline '{src_code}' could not be copied — handle "
+                        f"manually ({exc})."
+                    )
+                    reporter.warning(f"   FAILED to copy pipeline '{src_code}' ({exc})")
 
     def _copy_pipeline(
         self,
@@ -144,6 +149,7 @@ class PipelinesCopier(ResourceCopier):
         target_name: str,
         pipes_result: PipelinesResult,
         reporter: ProgressReporter,
+        http_client: httpx.Client,
     ) -> None:
         detail = _fetch_source_detail(source.client, pipeline_id)
         is_notebook = detail.get("type") == "notebook"
@@ -157,6 +163,11 @@ class PipelinesCopier(ResourceCopier):
                 f"   skipped notebook pipeline '{src_code}' (no notebookPath)"
             )
             return
+
+        if is_notebook:  # if notebook, first copy the file
+            _copy_notebook_file(
+                source, target, detail["notebookPath"], http_client, reporter
+            )
 
         target_pid, target_code = _create_on_target(
             target.client, target.slug, detail, target_name
@@ -275,6 +286,19 @@ def _fetch_source_detail(source: Client, pipeline_id: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Target writes
 # ---------------------------------------------------------------------------
+
+
+def _copy_notebook_file(
+    source: Endpoint,
+    target: Endpoint,
+    notebook_path: str,
+    http_client: httpx.Client,
+    reporter: ProgressReporter,
+) -> None:
+    """Transfer a notebook pipeline's ``.ipynb`` to the target bucket."""
+    content = download(source.client, source.slug, notebook_path, http_client)
+    upload(target.client, target.slug, notebook_path, content, http_client)
+    reporter.info(f"   copied notebook {notebook_path} ({len(content)} bytes)")
 
 
 def _create_on_target(

--- a/backend/hexa/workspace_copier/results.py
+++ b/backend/hexa/workspace_copier/results.py
@@ -6,8 +6,11 @@ views render that aggregate via :func:`format_summary`.
 """
 
 from dataclasses import dataclass, field
+from datetime import datetime
 
 BYTE_UNITS = ("B", "KiB", "MiB", "GiB", "TiB", "PiB")
+
+TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S %Z"
 
 
 def format_bytes(size: int) -> str:
@@ -119,6 +122,9 @@ class TemplatesResult:
     warnings: list[str] = field(default_factory=list)
     """Human-readable warnings to print in the summary."""
 
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+
 
 @dataclass
 class CopyResult:
@@ -136,8 +142,23 @@ class CopyResult:
     datasets: DatasetsResult | None = None
     warnings: list[str] = field(default_factory=list)
 
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+
     def warn(self, message: str) -> None:
         self.warnings.append(message)
+
+
+def _format_run_window(
+    started_at: datetime | None, finished_at: datetime | None
+) -> list[str]:
+    """Render the "started / finished" header lines, if the run was timed."""
+    if started_at is None or finished_at is None:
+        return []
+    return [
+        f"Started:  {started_at.strftime(TIMESTAMP_FORMAT)}",
+        f"Finished: {finished_at.strftime(TIMESTAMP_FORMAT)}",
+    ]
 
 
 def format_summary(result: CopyResult) -> str:
@@ -146,6 +167,7 @@ def format_summary(result: CopyResult) -> str:
     lines.append(
         f"Workspace: {result.workspace_name!r} -> slug '{result.workspace_slug}'"
     )
+    lines.extend(_format_run_window(result.started_at, result.finished_at))
 
     if result.files is not None:
         total_bytes = sum(b for _, b in result.files.copied)
@@ -233,6 +255,7 @@ def format_summary(result: CopyResult) -> str:
 def format_templates_summary(result: TemplatesResult) -> str:
     """Render a human-readable summary of a template copy run."""
     lines: list[str] = ["=== Template copy summary ==="]
+    lines.extend(_format_run_window(result.started_at, result.finished_at))
     lines.append(f"Templates created on target: {len(result.created)}")
     lines.extend(f"  * {name}" for name in result.created)
 

--- a/backend/hexa/workspace_copier/templates.py
+++ b/backend/hexa/workspace_copier/templates.py
@@ -30,6 +30,7 @@ back template versions, and emits all progress through a
 import time
 from typing import Any
 
+from django.utils import timezone
 from openhexa.graphql.graphql_client.client import Client
 from openhexa.graphql.graphql_client.input_types import (
     CreatePipelineInput,
@@ -165,7 +166,7 @@ def copy_templates(
     pipelines" host workspace is created under when it doesn't already exist on
     the target.
     """
-    result = TemplatesResult()
+    result = TemplatesResult(started_at=timezone.localtime())
 
     reporter.info(f"=> Ensuring '{HOST_WORKSPACE_NAME}' workspace exists on target ...")
     host_ws_slug = _ensure_host_workspace(target, target_organization_id)
@@ -201,6 +202,7 @@ def copy_templates(
             result.warnings.append(msg)
             reporter.error(f"     FAILED: {msg}")
 
+    result.finished_at = timezone.localtime()
     return result
 
 

--- a/backend/hexa/workspace_copier/tests/resources/test_pipelines.py
+++ b/backend/hexa/workspace_copier/tests/resources/test_pipelines.py
@@ -121,12 +121,13 @@ class PipelinesCopierRemoteTest(SimpleTestCase):
             any("notebookPath" in w for w in self.result.pipelines.warnings)
         )
 
+    @patch("hexa.workspace_copier.resources.pipelines._copy_notebook_file")
     @patch("hexa.workspace_copier.resources.pipelines._list_target_codes")
     @patch("hexa.workspace_copier.resources.pipelines._create_on_target")
     @patch("hexa.workspace_copier.resources.pipelines._fetch_source_detail")
     @patch("hexa.workspace_copier.resources.pipelines._list_source_pipelines")
     def test_failed_pipeline_is_recorded_and_does_not_abort(
-        self, mock_list, mock_detail, mock_create, mock_target_codes
+        self, mock_list, mock_detail, mock_create, mock_target_codes, mock_notebook
     ):
         mock_list.return_value = [
             ("pid-1", "bad-one", "bad-one"),


### PR DESCRIPTION
Several small improvements to the workspace copier:

- Notebook pipeline copying: First copy the `.ipynb` file to avoid notebook pipeline copies from breaking when done _without_ doing the file copying first. (HEXA-1756)
- Pipeline copier: don't copy the schedule metadata: This can cause pipelines to immediately start running after a copy.
Usually you want a human to validate, change some connection settings etc, and then manually enable pipelines one by one.
- Output rendering:
  - Add timestamps
  - Human-readable file sizes for dataset files
  - fix: Also render output on failed run (for Django admin)

**Notes:**
- Intentionally light on testing, we'll redo the whole test approach soon so didn't want to spend time on this.
- Battle-tested on POLIO WS copy