### PR TITLE
fix: Set tool limit to 30, 10 was too low (HEXA-1786)

### DIFF
--- a/backend/hexa/assistant/agents/base.py
+++ b/backend/hexa/assistant/agents/base.py
@@ -162,7 +162,7 @@ class BaseAgent:
     instruction_set = InstructionSet.GENERAL
     tools: list = []
     max_tokens: int = 32768
-    max_requests: int = 10
+    max_requests: int = 30
     output_retries: int | None = None
     history_strip_tools: set[str] = set()
 


### PR DESCRIPTION
Agents would burn their tool limit while looking for files for example.

https://logfire-eu.pydantic.dev/openhexa/openhexa-app/issues/19