### PR TITLE
fix: Flicker on workspace tags modal + small mistake on documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ Follow these guidelines when writing code:
 
 -   **Comments**: Do not write comments that merely restate what the code does. Only add comments when explaining _why_ something is done a certain way, not _what_ it does.
 -   **Imports**: Place imports at the top of the file. Do not use inline/dynamic imports inside functions or methods unless strictly necessary (e.g., to break a circular import or to defer an optional/expensive dependency).
+-   **Documentation**: The docs are maintained in English (`docs/en/`) and French (`docs/fr/`). Any change to a page in one language must be applied to its counterpart in the other in the same change — never update only one side.
 
 ## Common Development Commands
 

--- a/docs/en/static-webapps.md
+++ b/docs/en/static-webapps.md
@@ -989,7 +989,6 @@ type Query {
 }
 
 input ExecuteSavedQueryInput {
-  workspaceSlug: String!
   slug: String!
   maxRows: Int
 }
@@ -1020,8 +1019,8 @@ enum ExecuteSQLError {
 </details>
 
 Find the slug in the Data Studio: it is the last segment of the saved query's
-URL. `SAVED_QUERY_NOT_FOUND` covers both an unknown slug and a workspace you
-cannot see, so it does not reveal what exists.
+URL. Note that the query must be shared with the workspace, a private one fails
+with `SAVED_QUERY_NOT_FOUND`.
 
 ```html
 <!DOCTYPE html>
@@ -1041,7 +1040,6 @@ cannot see, so it does not reveal what exists.
   <div id="out">Loading…</div>
 
   <script>
-    const { workspaceSlug } = window.OPENHEXA;
     const SAVED_QUERY_SLUG = "my-saved-query";
 
     async function gql(query, variables) {
@@ -1064,7 +1062,7 @@ cannot see, so it does not reveal what exists.
             success errors columns rows rowCount truncated
           }
         }
-      `, { input: { workspaceSlug, slug: SAVED_QUERY_SLUG, maxRows: 100 } });
+      `, { input: { slug: SAVED_QUERY_SLUG, maxRows: 100 } });
 
       if (!result.success) {
         out.textContent = "Error: " + result.errors.join(", ");

--- a/docs/fr/static-webapps.md
+++ b/docs/fr/static-webapps.md
@@ -682,7 +682,6 @@ type Query {
 }
 
 input ExecuteSavedQueryInput {
-  workspaceSlug: String!
   slug: String!
   maxRows: Int
 }
@@ -713,9 +712,8 @@ enum ExecuteSQLError {
 </details>
 
 Le slug se lit dans le Data Studio : c'est le dernier segment de l'URL de la
-requête enregistrée. `SAVED_QUERY_NOT_FOUND` couvre à la fois un slug inconnu et
-un workspace que vous ne pouvez pas voir, afin de ne rien révéler de ce qui
-existe.
+requête enregistrée. Notez que la requête doit être partagée avec le workspace ;
+une requête privée échoue avec `SAVED_QUERY_NOT_FOUND`.
 
 ```html
 <!DOCTYPE html>
@@ -735,7 +733,6 @@ existe.
   <div id="out">Chargement…</div>
 
   <script>
-    const { workspaceSlug } = window.OPENHEXA;
     const SAVED_QUERY_SLUG = "ma-requete-enregistree";
 
     async function gql(query, variables) {
@@ -758,7 +755,7 @@ existe.
             success errors columns rows rowCount truncated
           }
         }
-      `, { input: { workspaceSlug, slug: SAVED_QUERY_SLUG, maxRows: 100 } });
+      `, { input: { slug: SAVED_QUERY_SLUG, maxRows: 100 } });
 
       if (!result.success) {
         out.textContent = "Erreur : " + result.errors.join(", ");

--- a/frontend/src/organizations/features/ManageWorkspaceTagsDialog/ManageWorkspaceTagsDialog.test.tsx
+++ b/frontend/src/organizations/features/ManageWorkspaceTagsDialog/ManageWorkspaceTagsDialog.test.tsx
@@ -45,18 +45,23 @@ const AVAILABLE_TAGS = ["analytics", "covid", "malaria"];
 const useUpdateWorkspaceTagsMutationMock =
   useUpdateWorkspaceTagsMutation as unknown as jest.Mock;
 
-const renderDialog = (onClose: jest.Mock) =>
-  render(
-    <TestApp mocks={[]}>
-      <ManageWorkspaceTagsDialog
-        open={true}
-        onClose={onClose}
-        workspace={WORKSPACE}
-        organizationId={ORGANIZATION_ID}
-        availableTags={AVAILABLE_TAGS}
-      />
-    </TestApp>,
-  );
+const dialog = (
+  onClose: jest.Mock,
+  open: boolean = true,
+  workspace: typeof WORKSPACE | null = WORKSPACE,
+) => (
+  <TestApp mocks={[]}>
+    <ManageWorkspaceTagsDialog
+      open={open}
+      onClose={onClose}
+      workspace={workspace}
+      organizationId={ORGANIZATION_ID}
+      availableTags={AVAILABLE_TAGS}
+    />
+  </TestApp>
+);
+
+const renderDialog = (onClose: jest.Mock) => render(dialog(onClose));
 
 const mockMutationResult = (result: any) => {
   const mutate = jest.fn().mockResolvedValue(result);
@@ -258,6 +263,37 @@ describe("ManageWorkspaceTagsDialog", () => {
     });
 
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  // The dialog is mounted by the page even when closed - a mount guard would
+  // make the panel skip its enter transition and flash in - so it has to cope
+  // with not having a workspace yet.
+  it("renders while closed without a workspace", () => {
+    expect(() => render(dialog(onClose, false, null))).not.toThrow();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("picks up the tags of the workspace it is reopened for", async () => {
+    const other = {
+      slug: "other-workspace",
+      name: "Other Workspace",
+      tags: [{ name: "malaria" }],
+    };
+
+    const { rerender } = render(dialog(onClose, false, null));
+
+    rerender(dialog(onClose, true, WORKSPACE));
+    await waitFor(() => {
+      expect(screen.getByText("covid")).toBeInTheDocument();
+    });
+
+    rerender(dialog(onClose, false, WORKSPACE));
+    rerender(dialog(onClose, true, other));
+
+    await waitFor(() => {
+      expect(screen.getByText("malaria")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("covid")).not.toBeInTheDocument();
   });
 
   it("closes without saving when cancelled", async () => {

--- a/frontend/src/organizations/features/ManageWorkspaceTagsDialog/ManageWorkspaceTagsDialog.tsx
+++ b/frontend/src/organizations/features/ManageWorkspaceTagsDialog/ManageWorkspaceTagsDialog.tsx
@@ -7,6 +7,7 @@ import useCacheKey from "core/hooks/useCacheKey";
 import useForm from "core/hooks/useForm";
 import { UpdateWorkspaceError } from "graphql/types";
 import { useTranslation } from "next-i18next";
+import { useEffect } from "react";
 import { toast } from "react-toastify";
 import { useUpdateWorkspaceTagsMutation } from "./ManageWorkspaceTagsDialog.generated";
 
@@ -19,7 +20,7 @@ type WorkspaceForDialog = {
 type ManageWorkspaceTagsDialogProps = {
   open: boolean;
   onClose(): void;
-  workspace: WorkspaceForDialog;
+  workspace: WorkspaceForDialog | null;
   organizationId: string;
   availableTags: string[];
 };
@@ -43,6 +44,7 @@ const ManageWorkspaceTagsDialog = ({
 
   const form = useForm<Form>({
     onSubmit: async (values) => {
+      if (!workspace) return;
       const result = await updateWorkspaceTags({
         variables: { input: { slug: workspace.slug, tags: values.tags } },
       });
@@ -67,8 +69,18 @@ const ManageWorkspaceTagsDialog = ({
       clearCache();
       onClose();
     },
-    initialState: { tags: workspace.tags.map((tag) => tag.name) },
+    getInitialState: () => ({
+      tags: workspace?.tags.map((tag) => tag.name) ?? [],
+    }),
   });
+
+  // The dialog stays mounted between opens (so its transitions can run), so the
+  // form has to be re-seeded from the current workspace each time it opens.
+  useEffect(() => {
+    if (open) {
+      form.resetForm();
+    }
+  }, [open]);
 
   return (
     <Dialog
@@ -83,7 +95,7 @@ const ManageWorkspaceTagsDialog = ({
           {t(
             "Tag {{name}} to organize and filter the workspaces of your organization.",
             {
-              name: workspace.name,
+              name: workspace?.name ?? "",
             },
           )}
         </p>

--- a/frontend/src/pages/organizations/[organizationId]/index.tsx
+++ b/frontend/src/pages/organizations/[organizationId]/index.tsx
@@ -44,6 +44,7 @@ const OrganizationPage: NextPageWithLayout<Props> = ({
   const [tagsFilter, setTagsFilter] = useState<string[]>([]);
   const [taggedWorkspace, setTaggedWorkspace] =
     useState<OrganizationWorkspace_WorkspaceFragment | null>(null);
+  const [isTagsDialogOpen, setIsTagsDialogOpen] = useState(false);
   const debouncedSearchQuery = useDebounce(searchQuery, 300);
   const perPage = 15;
 
@@ -76,6 +77,13 @@ const OrganizationPage: NextPageWithLayout<Props> = ({
     return null;
   }
   const totalWorkspaces = organization.workspaces?.totalItems ?? 0;
+
+  const handleManageTagsClick = (
+    workspace: OrganizationWorkspace_WorkspaceFragment,
+  ) => {
+    setTaggedWorkspace(workspace);
+    setIsTagsDialogOpen(true);
+  };
 
   const handleArchiveClick = (
     workspace: ArchiveWorkspace_WorkspaceFragment,
@@ -142,7 +150,7 @@ const OrganizationPage: NextPageWithLayout<Props> = ({
               totalPages={data?.workspaces?.totalPages || 0}
               totalItems={data?.workspaces?.totalItems || 0}
               onArchiveClick={handleArchiveClick}
-              onManageTagsClick={setTaggedWorkspace}
+              onManageTagsClick={handleManageTagsClick}
             />
           ) : (
             <WorkspacesListView
@@ -153,7 +161,7 @@ const OrganizationPage: NextPageWithLayout<Props> = ({
               totalPages={data?.workspaces?.totalPages || 0}
               totalItems={data?.workspaces?.totalItems || 0}
               onArchiveClick={handleArchiveClick}
-              onManageTagsClick={setTaggedWorkspace}
+              onManageTagsClick={handleManageTagsClick}
               canManageMembers={organization.permissions.manageMembers}
             />
           )}
@@ -166,15 +174,15 @@ const OrganizationPage: NextPageWithLayout<Props> = ({
         onClose={() => setIsCreateDialogOpen(false)}
       />
 
-      {taggedWorkspace && (
-        <ManageWorkspaceTagsDialog
-          open
-          workspace={taggedWorkspace}
-          organizationId={organization.id}
-          availableTags={organization.workspaceTags}
-          onClose={() => setTaggedWorkspace(null)}
-        />
-      )}
+      {/* `taggedWorkspace` is kept on close so the panel still has a name to
+          render while the leave transition plays. */}
+      <ManageWorkspaceTagsDialog
+        open={isTagsDialogOpen}
+        workspace={taggedWorkspace}
+        organizationId={organization.id}
+        availableTags={organization.workspaceTags}
+        onClose={() => setIsTagsDialogOpen(false)}
+      />
 
       {selectedWorkspace && (
         <ArchiveWorkspaceDialog


### PR DESCRIPTION
- fix: Correct small mistake in web apps documentation: On how to use the `executeSavedQuery` endpoint.
- fix: Flicker on the workspace tags modal