### PR TITLE
fix: too much data for declared Content-Length

### DIFF
--- a/backend/hexa/core/middlewares.py
+++ b/backend/hexa/core/middlewares.py
@@ -38,6 +38,7 @@ PRECOMPRESSED_EXTENSIONS = (
 
 
 UNCOMPRESSIBLE_CONTENT_TYPES = frozenset({"text/event-stream"})
+BODYLESS_STATUS_CODES = frozenset({204, 304})
 
 
 def response_content_type(response) -> str:
@@ -55,6 +56,13 @@ def is_precompressed(content_type: str, path: str) -> bool:
     return path.lower().endswith(PRECOMPRESSED_EXTENSIONS)
 
 
+def is_bodyless(response) -> bool:
+    return (
+        response.status_code in BODYLESS_STATUS_CODES
+        or 100 <= response.status_code < 200
+    )
+
+
 def is_partial(response) -> bool:
     return response.status_code == 206 or response.has_header("Content-Range")
 
@@ -62,6 +70,8 @@ def is_partial(response) -> bool:
 def should_skip_compression(request, response) -> bool:
     """Whether gzipping this response would break it or gain nothing."""
     content_type = response_content_type(response)
+    if is_bodyless(response):
+        return True
     if content_type in UNCOMPRESSIBLE_CONTENT_TYPES:
         return True
     if is_partial(response):

--- a/backend/hexa/core/tests/test_middlewares.py
+++ b/backend/hexa/core/tests/test_middlewares.py
@@ -1,5 +1,8 @@
-from django.test import override_settings
+from django.conf import settings
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
 
+from hexa.core.middlewares import SSEAwareGZipMiddleware
 from hexa.core.test import TestCase
 
 
@@ -19,3 +22,28 @@ class RequestTooBigMiddlewareTest(TestCase):
             any("DATA_UPLOAD_MAX_MEMORY_SIZE" in line for line in cm.output),
             f"Expected security log to mention DATA_UPLOAD_MAX_MEMORY_SIZE, got {cm.output}",
         )
+
+
+@override_settings(STATIC_ROOT=settings.BASE_DIR / "hexa" / "static")
+class SSEAwareGZipMiddlewareTest(TestCase):
+    def test_conditional_static_request_is_not_compressed(self):
+        first = self.client.get("/static/img/favicon.png", HTTP_ACCEPT_ENCODING="gzip")
+        self.assertEqual(200, first.status_code)
+
+        response = self.client.get(
+            "/static/img/favicon.png",
+            HTTP_ACCEPT_ENCODING="gzip",
+            HTTP_IF_NONE_MATCH=first["ETag"],
+        )
+
+        self.assertEqual(304, response.status_code)
+        self.assertNotIn("Content-Encoding", response)
+        self.assertEqual(b"", b"".join(response.streaming_content))
+
+    def test_html_response_is_gzipped(self):
+        request = RequestFactory().get("/", HTTP_ACCEPT_ENCODING="gzip")
+        response = SSEAwareGZipMiddleware(
+            lambda r: HttpResponse("<html>" + "x" * 500)
+        ).process_response(request, HttpResponse("<html>" + "x" * 500))
+
+        self.assertEqual("gzip", response["Content-Encoding"])


### PR DESCRIPTION
Fix for https://bluesquareorg.sentry.io/issues/7695207720

Ensure that 304 responses are not requiring compression since they have empty body. That would result in a body greater than the original one.