### PR TITLE
chore: Truncate the preview_dataset_file tool (internal agent + MCP) (HEXA-1796)

### DIFF
--- a/backend/hexa/datasets/graphql/schema.graphql
+++ b/backend/hexa/datasets/graphql/schema.graphql
@@ -128,6 +128,10 @@ type DatasetVersionFile implements MetadataObject{
   size: BigInt!
   rows: Int
   fileSample: DatasetFileSample
+  """
+  Column names in file order, when profiling succeeded.
+  """
+  columns: [String!]
   properties: JSON
   attributes: [MetadataAttribute!]!
   targetId: OpaqueID!

--- a/backend/hexa/datasets/models.py
+++ b/backend/hexa/datasets/models.py
@@ -417,6 +417,20 @@ class DatasetVersionFile(MetadataMixin, Base):
     def full_uri(self):
         return self.dataset_version.get_full_uri(self.uri)
 
+    @property
+    def column_names(self) -> list[str] | None:
+        """Column names in file order.
+
+        `properties` keys columns by md5 hash because the hashes prefix the column
+        metadata attribute keys; most callers only need the names.
+        """
+        columns = self.properties.get("columns") or {}
+        if not columns:
+            return None
+        column_order = self.properties.get("column_order") or []
+        names = [columns[key] for key in column_order if key in columns]
+        return names or list(columns.values())
+
     @cached_property
     def size(self):
         blob = get_blob(self.uri)
@@ -503,6 +517,28 @@ class DatasetFileSample(Base):
         on_delete=models.CASCADE,
         related_name="sample_entry",
     )
+
+    @property
+    def ordered_sample(self):
+        """Sample rows with their keys in file order.
+
+        jsonb does not preserve key order, so stored rows come back with keys sorted
+        by Postgres. Columns the profiling could not handle are kept at the end so
+        the sample never loses data.
+        """
+        columns = self.dataset_version_file.column_names
+        if not columns or not isinstance(self.sample, list):
+            return self.sample
+        return [
+            self._order_row(row, columns) if isinstance(row, dict) else row
+            for row in self.sample
+        ]
+
+    @staticmethod
+    def _order_row(row: dict, columns: list[str]) -> dict:
+        ordered = {name: row[name] for name in columns if name in row}
+        ordered.update({key: value for key, value in row.items() if key not in ordered})
+        return ordered
 
 
 class DatasetLinkQuerySet(BaseQuerySet):

--- a/backend/hexa/datasets/schema/types.py
+++ b/backend/hexa/datasets/schema/types.py
@@ -23,6 +23,7 @@ dataset_permissions = ObjectType("DatasetPermissions")
 dataset_version_object = ObjectType("DatasetVersion")
 dataset_version_permissions = ObjectType("DatasetVersionPermissions")
 dataset_version_file_object = ObjectType("DatasetVersionFile")
+dataset_file_sample_object = ObjectType("DatasetFileSample")
 dataset_version_file_result_object = ObjectType("CreateDatasetVersionFileResult")
 dataset_link_object = ObjectType("DatasetLink")
 dataset_link_permissions = ObjectType("DatasetLinkPermissions")
@@ -245,6 +246,16 @@ def resolve_version_file_metadata(obj: DatasetVersionFile, info, **kwargs):
         return None
 
 
+@dataset_version_file_object.field("columns")
+def resolve_version_file_columns(obj: DatasetVersionFile, info, **kwargs):
+    return obj.column_names
+
+
+@dataset_file_sample_object.field("sample")
+def resolve_file_sample_rows(obj: DatasetFileSample, info, **kwargs):
+    return obj.ordered_sample
+
+
 @dataset_version_file_object.field("downloadUrl")
 def resolve_version_file_download_url(
     obj: DatasetVersionFile, info, attachment: bool = True, **kwargs
@@ -261,6 +272,7 @@ bindables = [
     dataset_version_permissions,
     dataset_link_permissions,
     dataset_version_file_object,
+    dataset_file_sample_object,
     dataset_version_file_result_object,
     dataset_link_object,
 ]

--- a/backend/hexa/datasets/tests/test_schema.py
+++ b/backend/hexa/datasets/tests/test_schema.py
@@ -867,6 +867,71 @@ class DatasetVersionTest(GraphQLTestCase, DatasetTestMixin):
             r["data"],
         )
 
+    COLUMN_HASHES = {
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": "country",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": "cases",
+    }
+    COLUMNS_AND_SAMPLE_QUERY = """
+        query GetDatasetVersionFile($id: ID!) {
+          datasetVersionFile(id: $id) {
+            columns
+            fileSample {
+              sample
+            }
+          }
+        }
+    """
+
+    def create_profiled_file(self, sample, properties=None):
+        self.test_create_dataset_version()
+        superuser = User.objects.get(email="superuser@blsq.com")
+        dataset = Dataset.objects.get(name="Dataset")
+        self.client.force_login(superuser)
+        file = DatasetVersionFile.objects.create(
+            dataset_version=dataset.latest_version,
+            uri=dataset.latest_version.get_full_uri("file.csv"),
+            created_by=superuser,
+            properties=properties or {},
+        )
+        DatasetFileSample.objects.create(
+            dataset_version_file=file,
+            sample=sample,
+            status=DatasetFileSample.STATUS_FINISHED,
+        )
+        return file
+
+    def test_get_file_columns_and_ordered_sample(self):
+        file = self.create_profiled_file(
+            # keys stored in jsonb order, not file order, plus an unprofiled column
+            sample=[{"cases": 0, "country": "c0", "notes": "n0"}],
+            properties={
+                "columns": self.COLUMN_HASHES,
+                "column_order": list(self.COLUMN_HASHES),
+            },
+        )
+        r = self.run_query(self.COLUMNS_AND_SAMPLE_QUERY, {"id": str(file.id)})
+        data = r["data"]["datasetVersionFile"]
+        self.assertEqual(data["columns"], ["country", "cases"])
+        self.assertEqual(
+            list(data["fileSample"]["sample"][0]), ["country", "cases", "notes"]
+        )
+
+    def test_get_file_columns_falls_back_to_columns_map(self):
+        file = self.create_profiled_file(
+            sample=[], properties={"columns": self.COLUMN_HASHES}
+        )
+        r = self.run_query(self.COLUMNS_AND_SAMPLE_QUERY, {"id": str(file.id)})
+        data = r["data"]["datasetVersionFile"]
+        self.assertEqual(data["columns"], ["country", "cases"])
+        self.assertEqual(data["fileSample"]["sample"], [])
+
+    def test_get_file_columns_without_properties(self):
+        file = self.create_profiled_file(sample=[{"cases": 0, "country": "c0"}])
+        r = self.run_query(self.COLUMNS_AND_SAMPLE_QUERY, {"id": str(file.id)})
+        data = r["data"]["datasetVersionFile"]
+        self.assertIsNone(data["columns"])
+        self.assertEqual(data["fileSample"]["sample"], [{"cases": 0, "country": "c0"}])
+
     def test_prepare_version_file_download(self):
         serena = self.create_user("sereba@blsq.org", is_superuser=True)
         workspace = self.create_workspace(

--- a/backend/hexa/mcp/graphql/datasets.graphql
+++ b/backend/hexa/mcp/graphql/datasets.graphql
@@ -76,7 +76,7 @@ query PreviewDatasetFile($id: ID!) {
     contentType
     size
     rows
-    properties
+    columns
     fileSample {
       sample
       status

--- a/backend/hexa/mcp/tests/test_datasets.py
+++ b/backend/hexa/mcp/tests/test_datasets.py
@@ -144,50 +144,18 @@ class PreviewDatasetFileTest(MCPTestCase):
         file_sample = self.preview()["fileSample"]
         self.assertEqual(len(file_sample["sample"]), 2)
 
-    def test_preview_dataset_file_orders_sample_by_column_order(self):
+    def test_preview_dataset_file_returns_columns_without_properties(self):
         self.create_sample(2)
-        self.set_properties()
-
-        file_sample = self.preview()["fileSample"]
-        # jsonb sorts the stored keys by length, so "cases" comes back before "country"
-        self.assertEqual(list(file_sample["sample"][0]), ["country", "cases"])
-
-    def test_preview_dataset_file_keeps_unprofiled_columns(self):
-        DatasetFileSample.objects.create(
-            dataset_version_file=self.DATASET_FILE,
-            sample=[{"country": "c0", "cases": 0, "notes": "n0"}],
-            status=DatasetFileSample.STATUS_FINISHED,
-        )
-        self.set_properties()
-
-        file_sample = self.preview()["fileSample"]
-        self.assertEqual(list(file_sample["sample"][0]), ["country", "cases", "notes"])
-
-    def test_preview_dataset_file_drops_properties_and_columns(self):
-        self.create_sample(2)
-        self.set_properties()
-
-        result = self.preview()
-        self.assertNotIn("properties", result)
-        # the sample rows already name every column
-        self.assertNotIn("columns", result)
-
-    def test_preview_dataset_file_returns_columns_without_sample_rows(self):
-        DatasetFileSample.objects.create(
-            dataset_version_file=self.DATASET_FILE,
-            sample=[],
-            status=DatasetFileSample.STATUS_FINISHED,
-        )
         self.set_properties()
 
         result = self.preview()
         self.assertEqual(result["columns"], ["country", "cases"])
+        self.assertNotIn("properties", result)
 
     def test_preview_dataset_file_without_sample(self):
         result = self.preview()
         self.assertIsNone(result["fileSample"])
-        self.assertNotIn("columns", result)
-        self.assertNotIn("properties", result)
+        self.assertIsNone(result["columns"])
 
 
 class CreateDatasetTest(MCPTestCase):

--- a/backend/hexa/mcp/tests/test_datasets.py
+++ b/backend/hexa/mcp/tests/test_datasets.py
@@ -2,9 +2,15 @@ import json
 
 from django.conf import settings
 
-from hexa.datasets.models import Dataset, DatasetVersion, DatasetVersionFile
+from hexa.datasets.models import (
+    Dataset,
+    DatasetFileSample,
+    DatasetVersion,
+    DatasetVersionFile,
+)
 from hexa.files import storage
 from hexa.mcp.tools.datasets import (
+    PREVIEW_SAMPLE_ROWS,
     create_dataset,
     create_dataset_version,
     get_dataset,
@@ -89,10 +95,25 @@ class GetDatasetTest(MCPTestCase):
 
 
 class PreviewDatasetFileTest(MCPTestCase):
-    def test_preview_dataset_file(self):
-        result = preview_dataset_file(
+    COLUMN_HASHES = {
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": "country",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": "cases",
+    }
+
+    def create_sample(self, rows):
+        return DatasetFileSample.objects.create(
+            dataset_version_file=self.DATASET_FILE,
+            sample=[{"country": f"c{i}", "cases": i} for i in range(rows)],
+            status=DatasetFileSample.STATUS_FINISHED,
+        )
+
+    def preview(self):
+        return preview_dataset_file(
             user=self.USER_ADMIN, file_id=str(self.DATASET_FILE.id)
         )
+
+    def test_preview_dataset_file(self):
+        result = self.preview()
         self.assertEqual(result["filename"], "test-file.csv")
         self.assertEqual(result["contentType"], "text/csv")
         self.assertIn("fileSample", result)
@@ -103,6 +124,44 @@ class PreviewDatasetFileTest(MCPTestCase):
             file_id="00000000-0000-0000-0000-000000000000",
         )
         self.assertEqual(result, {"error": "Dataset file not found"})
+
+    def test_preview_dataset_file_truncates_sample(self):
+        self.create_sample(12)
+        file_sample = self.preview()["fileSample"]
+        self.assertEqual(len(file_sample["sample"]), PREVIEW_SAMPLE_ROWS)
+        self.assertEqual(file_sample["sampleRowsAvailable"], 12)
+        self.assertEqual(file_sample["sample"][0], {"country": "c0", "cases": 0})
+        self.assertEqual(file_sample["status"], DatasetFileSample.STATUS_FINISHED)
+
+    def test_preview_dataset_file_keeps_short_sample(self):
+        self.create_sample(2)
+        file_sample = self.preview()["fileSample"]
+        self.assertEqual(len(file_sample["sample"]), 2)
+        self.assertEqual(file_sample["sampleRowsAvailable"], 2)
+
+    def test_preview_dataset_file_replaces_properties_with_columns(self):
+        self.create_sample(2)
+        self.DATASET_FILE.properties = {
+            "columns": self.COLUMN_HASHES,
+            "column_order": list(self.COLUMN_HASHES),
+        }
+        self.DATASET_FILE.save()
+
+        result = self.preview()
+        self.assertEqual(result["columns"], ["country", "cases"])
+        self.assertNotIn("properties", result)
+
+    def test_preview_dataset_file_columns_fall_back_to_sample_keys(self):
+        self.create_sample(2)
+        result = self.preview()
+        # jsonb does not preserve key order, so the fallback only guarantees the names
+        self.assertEqual(set(result["columns"]), {"country", "cases"})
+
+    def test_preview_dataset_file_without_sample(self):
+        result = self.preview()
+        self.assertIsNone(result["fileSample"])
+        self.assertNotIn("columns", result)
+        self.assertNotIn("properties", result)
 
 
 class CreateDatasetTest(MCPTestCase):

--- a/backend/hexa/mcp/tests/test_datasets.py
+++ b/backend/hexa/mcp/tests/test_datasets.py
@@ -107,6 +107,13 @@ class PreviewDatasetFileTest(MCPTestCase):
             status=DatasetFileSample.STATUS_FINISHED,
         )
 
+    def set_properties(self):
+        self.DATASET_FILE.properties = {
+            "columns": self.COLUMN_HASHES,
+            "column_order": list(self.COLUMN_HASHES),
+        }
+        self.DATASET_FILE.save()
+
     def preview(self):
         return preview_dataset_file(
             user=self.USER_ADMIN, file_id=str(self.DATASET_FILE.id)
@@ -139,23 +146,45 @@ class PreviewDatasetFileTest(MCPTestCase):
         self.assertEqual(len(file_sample["sample"]), 2)
         self.assertEqual(file_sample["sampleRowsAvailable"], 2)
 
-    def test_preview_dataset_file_replaces_properties_with_columns(self):
+    def test_preview_dataset_file_orders_sample_by_column_order(self):
         self.create_sample(2)
-        self.DATASET_FILE.properties = {
-            "columns": self.COLUMN_HASHES,
-            "column_order": list(self.COLUMN_HASHES),
-        }
-        self.DATASET_FILE.save()
+        self.set_properties()
+
+        file_sample = self.preview()["fileSample"]
+        # jsonb sorts the stored keys by length, so "cases" comes back before "country"
+        self.assertEqual(list(file_sample["sample"][0]), ["country", "cases"])
+
+    def test_preview_dataset_file_keeps_unprofiled_columns(self):
+        DatasetFileSample.objects.create(
+            dataset_version_file=self.DATASET_FILE,
+            sample=[{"country": "c0", "cases": 0, "notes": "n0"}],
+            status=DatasetFileSample.STATUS_FINISHED,
+        )
+        self.set_properties()
+
+        file_sample = self.preview()["fileSample"]
+        self.assertEqual(list(file_sample["sample"][0]), ["country", "cases", "notes"])
+
+    def test_preview_dataset_file_drops_properties_and_columns(self):
+        self.create_sample(2)
+        self.set_properties()
+
+        result = self.preview()
+        self.assertNotIn("properties", result)
+        # the sample rows already name every column
+        self.assertNotIn("columns", result)
+
+    def test_preview_dataset_file_returns_columns_without_sample_rows(self):
+        DatasetFileSample.objects.create(
+            dataset_version_file=self.DATASET_FILE,
+            sample=[],
+            status=DatasetFileSample.STATUS_FINISHED,
+        )
+        self.set_properties()
 
         result = self.preview()
         self.assertEqual(result["columns"], ["country", "cases"])
-        self.assertNotIn("properties", result)
-
-    def test_preview_dataset_file_columns_fall_back_to_sample_keys(self):
-        self.create_sample(2)
-        result = self.preview()
-        # jsonb does not preserve key order, so the fallback only guarantees the names
-        self.assertEqual(set(result["columns"]), {"country", "cases"})
+        self.assertEqual(result["fileSample"]["sampleRowsAvailable"], 0)
 
     def test_preview_dataset_file_without_sample(self):
         result = self.preview()

--- a/backend/hexa/mcp/tests/test_datasets.py
+++ b/backend/hexa/mcp/tests/test_datasets.py
@@ -136,7 +136,6 @@ class PreviewDatasetFileTest(MCPTestCase):
         self.create_sample(12)
         file_sample = self.preview()["fileSample"]
         self.assertEqual(len(file_sample["sample"]), PREVIEW_SAMPLE_ROWS)
-        self.assertEqual(file_sample["sampleRowsAvailable"], 12)
         self.assertEqual(file_sample["sample"][0], {"country": "c0", "cases": 0})
         self.assertEqual(file_sample["status"], DatasetFileSample.STATUS_FINISHED)
 
@@ -144,7 +143,6 @@ class PreviewDatasetFileTest(MCPTestCase):
         self.create_sample(2)
         file_sample = self.preview()["fileSample"]
         self.assertEqual(len(file_sample["sample"]), 2)
-        self.assertEqual(file_sample["sampleRowsAvailable"], 2)
 
     def test_preview_dataset_file_orders_sample_by_column_order(self):
         self.create_sample(2)
@@ -184,7 +182,6 @@ class PreviewDatasetFileTest(MCPTestCase):
 
         result = self.preview()
         self.assertEqual(result["columns"], ["country", "cases"])
-        self.assertEqual(result["fileSample"]["sampleRowsAvailable"], 0)
 
     def test_preview_dataset_file_without_sample(self):
         result = self.preview()

--- a/backend/hexa/mcp/tools/datasets.py
+++ b/backend/hexa/mcp/tools/datasets.py
@@ -92,7 +92,7 @@ def _ordered_row(row: dict, columns: list) -> dict:
 
 @tool
 def preview_dataset_file(user, file_id: str) -> dict:
-    """Preview the content of a dataset file by its ID (from get_dataset's file list). Returns file metadata and, for tabular files (CSV, Parquet, etc.), the first few rows of the stored sample, with the columns of each row in the order they appear in the file. When no sample row is available, the ordered 'columns' of the file are returned instead. This is a preview only: 'rows' is the row count of the whole file and 'fileSample.sampleRowsAvailable' the size of the stored sample, both usually larger than the number of rows returned here. The sample status can be PROCESSING (still generating), FINISHED (sample ready), or FAILED."""
+    """Preview the content of a dataset file by its ID (from get_dataset's file list). Returns file metadata and, for tabular files (CSV, Parquet, etc.), the first few rows of the stored sample, with the columns of each row in the order they appear in the file. When no sample row is available, the ordered 'columns' of the file are returned instead. This is a preview only: 'rows' is the row count of the whole file, usually larger than the number of rows returned here. The sample status can be PROCESSING (still generating), FINISHED (sample ready), or FAILED."""
     data = execute_graphql(user, "PreviewDatasetFile", {"id": file_id})
     if "errors" in data:
         return data
@@ -107,7 +107,6 @@ def preview_dataset_file(user, file_id: str) -> dict:
         file_sample["sample"] = [
             _ordered_row(row, columns) for row in rows[:PREVIEW_SAMPLE_ROWS]
         ]
-        file_sample["sampleRowsAvailable"] = len(rows)
     # The sample rows already name every column, so `columns` would only repeat them.
     if not rows and columns:
         file_data["columns"] = columns

--- a/backend/hexa/mcp/tools/datasets.py
+++ b/backend/hexa/mcp/tools/datasets.py
@@ -4,6 +4,10 @@ from hexa.mcp.protocol import tool
 
 from ._graphql import execute_graphql
 
+# LLM callers only need enough rows to infer the schema and value shapes; the stored
+# sample (WORKSPACE_DATASETS_FILE_SNAPSHOT_SIZE rows) is sized for the UI table.
+PREVIEW_SAMPLE_ROWS = 5
+
 
 @tool
 def list_datasets(user, workspace_slug: str, page: int = 1, per_page: int = 10) -> dict:
@@ -55,15 +59,55 @@ def get_dataset(
     return link["dataset"]
 
 
+def _sample_rows(file_data: dict) -> list:
+    file_sample = file_data.get("fileSample")
+    if not file_sample:
+        return []
+    return file_sample.get("sample") or []
+
+
+def _truncate_sample(file_data: dict) -> None:
+    file_sample = file_data.get("fileSample")
+    if not file_sample:
+        return
+    rows = _sample_rows(file_data)
+    file_sample["sample"] = rows[:PREVIEW_SAMPLE_ROWS]
+    file_sample["sampleRowsAvailable"] = len(rows)
+
+
+def _column_names(file_data: dict) -> list:
+    """Turn the stored profiling properties into a plain ordered list of column names.
+
+    `properties` maps md5 hashes to column names for the web UI; the hashes are
+    meaningless to a model, so only the names in file order are kept. Without
+    profiling we fall back to the sample keys, which jsonb returns unordered.
+    """
+    properties = file_data.pop("properties", None) or {}
+    columns = properties.get("columns") or {}
+    column_order = properties.get("column_order") or []
+    names = [columns[key] for key in column_order if key in columns]
+    if names:
+        return names
+    if columns:
+        return list(columns.values())
+    rows = _sample_rows(file_data)
+    return list(rows[0].keys()) if rows else []
+
+
 @tool
 def preview_dataset_file(user, file_id: str) -> dict:
-    """Preview the content of a dataset file by its ID (from get_dataset's file list). Returns a sample of the data for tabular files (CSV, Parquet, etc.), file properties, and metadata. The sample status can be PROCESSING (still generating), FINISHED (sample ready), or FAILED."""
+    """Preview the content of a dataset file by its ID (from get_dataset's file list). Returns file metadata, the ordered 'columns' of the file, and for tabular files (CSV, Parquet, etc.) the first few rows of the stored sample. This is a preview only: 'rows' is the row count of the whole file and 'fileSample.sampleRowsAvailable' the size of the stored sample, both usually larger than the number of rows returned here. The sample status can be PROCESSING (still generating), FINISHED (sample ready), or FAILED."""
     data = execute_graphql(user, "PreviewDatasetFile", {"id": file_id})
     if "errors" in data:
         return data
     file_data = data.get("datasetVersionFile")
     if file_data is None:
         return {"error": "Dataset file not found"}
+
+    columns = _column_names(file_data)
+    if columns:
+        file_data["columns"] = columns
+    _truncate_sample(file_data)
     return file_data
 
 

--- a/backend/hexa/mcp/tools/datasets.py
+++ b/backend/hexa/mcp/tools/datasets.py
@@ -59,40 +59,9 @@ def get_dataset(
     return link["dataset"]
 
 
-def _sample_rows(file_data: dict) -> list:
-    file_sample = file_data.get("fileSample")
-    if not file_sample:
-        return []
-    return file_sample.get("sample") or []
-
-
-def _column_names(file_data: dict) -> list:
-    """Turn the stored profiling properties into a plain ordered list of column names.
-
-    `properties` maps md5 hashes to column names for the web UI; the hashes are
-    meaningless to a model, so only the names in file order are kept.
-    """
-    properties = file_data.pop("properties", None) or {}
-    columns = properties.get("columns") or {}
-    column_order = properties.get("column_order") or []
-    names = [columns[key] for key in column_order if key in columns]
-    return names or list(columns.values())
-
-
-def _ordered_row(row: dict, columns: list) -> dict:
-    """Restore the file's column order, which jsonb does not preserve in the sample.
-
-    Columns the profiling could not handle are missing from `columns`; they are kept
-    at the end so the sample never loses data.
-    """
-    ordered = {name: row[name] for name in columns if name in row}
-    ordered.update({key: value for key, value in row.items() if key not in ordered})
-    return ordered
-
-
 @tool
 def preview_dataset_file(user, file_id: str) -> dict:
-    """Preview the content of a dataset file by its ID (from get_dataset's file list). Returns file metadata and, for tabular files (CSV, Parquet, etc.), the first few rows of the stored sample, with the columns of each row in the order they appear in the file. When no sample row is available, the ordered 'columns' of the file are returned instead. This is a preview only: 'rows' is the row count of the whole file, usually larger than the number of rows returned here. The sample status can be PROCESSING (still generating), FINISHED (sample ready), or FAILED."""
+    """Preview the content of a dataset file by its ID (from get_dataset's file list). Returns file metadata and, for tabular files (CSV, Parquet, etc.), the ordered 'columns' of the file and the first few rows of the stored sample. This is a preview only: 'rows' is the row count of the whole file, usually larger than the number of rows returned here. The sample status can be PROCESSING (still generating), FINISHED (sample ready), or FAILED."""
     data = execute_graphql(user, "PreviewDatasetFile", {"id": file_id})
     if "errors" in data:
         return data
@@ -100,16 +69,9 @@ def preview_dataset_file(user, file_id: str) -> dict:
     if file_data is None:
         return {"error": "Dataset file not found"}
 
-    columns = _column_names(file_data)
-    rows = _sample_rows(file_data)
     file_sample = file_data.get("fileSample")
-    if file_sample:
-        file_sample["sample"] = [
-            _ordered_row(row, columns) for row in rows[:PREVIEW_SAMPLE_ROWS]
-        ]
-    # The sample rows already name every column, so `columns` would only repeat them.
-    if not rows and columns:
-        file_data["columns"] = columns
+    if file_sample and file_sample.get("sample"):
+        file_sample["sample"] = file_sample["sample"][:PREVIEW_SAMPLE_ROWS]
     return file_data
 
 

--- a/backend/hexa/mcp/tools/datasets.py
+++ b/backend/hexa/mcp/tools/datasets.py
@@ -6,7 +6,7 @@ from ._graphql import execute_graphql
 
 # LLM callers only need enough rows to infer the schema and value shapes; the stored
 # sample (WORKSPACE_DATASETS_FILE_SNAPSHOT_SIZE rows) is sized for the UI table.
-PREVIEW_SAMPLE_ROWS = 5
+PREVIEW_SAMPLE_ROWS = 3
 
 
 @tool
@@ -66,37 +66,33 @@ def _sample_rows(file_data: dict) -> list:
     return file_sample.get("sample") or []
 
 
-def _truncate_sample(file_data: dict) -> None:
-    file_sample = file_data.get("fileSample")
-    if not file_sample:
-        return
-    rows = _sample_rows(file_data)
-    file_sample["sample"] = rows[:PREVIEW_SAMPLE_ROWS]
-    file_sample["sampleRowsAvailable"] = len(rows)
-
-
 def _column_names(file_data: dict) -> list:
     """Turn the stored profiling properties into a plain ordered list of column names.
 
     `properties` maps md5 hashes to column names for the web UI; the hashes are
-    meaningless to a model, so only the names in file order are kept. Without
-    profiling we fall back to the sample keys, which jsonb returns unordered.
+    meaningless to a model, so only the names in file order are kept.
     """
     properties = file_data.pop("properties", None) or {}
     columns = properties.get("columns") or {}
     column_order = properties.get("column_order") or []
     names = [columns[key] for key in column_order if key in columns]
-    if names:
-        return names
-    if columns:
-        return list(columns.values())
-    rows = _sample_rows(file_data)
-    return list(rows[0].keys()) if rows else []
+    return names or list(columns.values())
+
+
+def _ordered_row(row: dict, columns: list) -> dict:
+    """Restore the file's column order, which jsonb does not preserve in the sample.
+
+    Columns the profiling could not handle are missing from `columns`; they are kept
+    at the end so the sample never loses data.
+    """
+    ordered = {name: row[name] for name in columns if name in row}
+    ordered.update({key: value for key, value in row.items() if key not in ordered})
+    return ordered
 
 
 @tool
 def preview_dataset_file(user, file_id: str) -> dict:
-    """Preview the content of a dataset file by its ID (from get_dataset's file list). Returns file metadata, the ordered 'columns' of the file, and for tabular files (CSV, Parquet, etc.) the first few rows of the stored sample. This is a preview only: 'rows' is the row count of the whole file and 'fileSample.sampleRowsAvailable' the size of the stored sample, both usually larger than the number of rows returned here. The sample status can be PROCESSING (still generating), FINISHED (sample ready), or FAILED."""
+    """Preview the content of a dataset file by its ID (from get_dataset's file list). Returns file metadata and, for tabular files (CSV, Parquet, etc.), the first few rows of the stored sample, with the columns of each row in the order they appear in the file. When no sample row is available, the ordered 'columns' of the file are returned instead. This is a preview only: 'rows' is the row count of the whole file and 'fileSample.sampleRowsAvailable' the size of the stored sample, both usually larger than the number of rows returned here. The sample status can be PROCESSING (still generating), FINISHED (sample ready), or FAILED."""
     data = execute_graphql(user, "PreviewDatasetFile", {"id": file_id})
     if "errors" in data:
         return data
@@ -105,9 +101,16 @@ def preview_dataset_file(user, file_id: str) -> dict:
         return {"error": "Dataset file not found"}
 
     columns = _column_names(file_data)
-    if columns:
+    rows = _sample_rows(file_data)
+    file_sample = file_data.get("fileSample")
+    if file_sample:
+        file_sample["sample"] = [
+            _ordered_row(row, columns) for row in rows[:PREVIEW_SAMPLE_ROWS]
+        ]
+        file_sample["sampleRowsAvailable"] = len(rows)
+    # The sample rows already name every column, so `columns` would only repeat them.
+    if not rows and columns:
         file_data["columns"] = columns
-    _truncate_sample(file_data)
     return file_data
 
 

--- a/frontend/schema.generated.graphql
+++ b/frontend/schema.generated.graphql
@@ -1676,6 +1676,9 @@ type DatasetVersion implements MetadataObject {
 """A file in a dataset version."""
 type DatasetVersionFile implements MetadataObject {
   attributes: [MetadataAttribute!]!
+
+  """Column names in file order, when profiling succeeded."""
+  columns: [String!]
   contentType: String!
   createdAt: DateTime!
   createdBy: User

--- a/frontend/src/datasets/features/DatasetVersionFileSample/DatasetVersionFileSample.generated.tsx
+++ b/frontend/src/datasets/features/DatasetVersionFileSample/DatasetVersionFileSample.generated.tsx
@@ -8,7 +8,7 @@ export type GetDatasetVersionFileSampleQueryVariables = Types.Exact<{
 }>;
 
 
-export type GetDatasetVersionFileSampleQuery = { __typename?: 'Query', datasetVersionFile?: { __typename?: 'DatasetVersionFile', id: string, rows?: number | null, properties?: any | null, fileSample?: { __typename?: 'DatasetFileSample', sample?: any | null, status: Types.FileSampleStatus, statusReason?: string | null } | null } | null };
+export type GetDatasetVersionFileSampleQuery = { __typename?: 'Query', datasetVersionFile?: { __typename?: 'DatasetVersionFile', id: string, rows?: number | null, columns?: Array<string> | null, fileSample?: { __typename?: 'DatasetFileSample', sample?: any | null, status: Types.FileSampleStatus, statusReason?: string | null } | null } | null };
 
 export type DatasetVersionFileSample_FileFragment = { __typename?: 'DatasetVersionFile', id: string, filename: string, contentType: string, size: any, downloadUrl?: string | null };
 
@@ -39,7 +39,7 @@ export const GetDatasetVersionFileSampleDocument = gql`
   datasetVersionFile(id: $id) {
     id
     rows
-    properties
+    columns
     fileSample {
       sample
       status

--- a/frontend/src/datasets/features/DatasetVersionFileSample/DatasetVersionFileSample.tsx
+++ b/frontend/src/datasets/features/DatasetVersionFileSample/DatasetVersionFileSample.tsx
@@ -164,7 +164,7 @@ const GET_DATASET_VERSION_FILE_SAMPLE = gql`
     datasetVersionFile(id: $id) {
       id
       rows
-      properties
+      columns
       fileSample {
         sample
         status
@@ -210,18 +210,8 @@ export const DatasetVersionFileSample: ApolloComponent<
         (row: Record<string, unknown>) => mapValues(row, stringifyIfObject),
       );
       const rows = data.datasetVersionFile.rows;
-      const properties = data.datasetVersionFile.properties ?? {};
-      const columnOrder: string[] | undefined = properties.column_order;
-      const colsMapping: Record<string, string> = properties.columns ?? {};
-
-      let columns: string[];
-      if (columnOrder && colsMapping) {
-        columns = columnOrder.map((key: string) => colsMapping[key]);
-      } else if (sample.length > 0) {
-        columns = Object.keys(sample[0]);
-      } else {
-        columns = [];
-      }
+      const columns: string[] =
+        data.datasetVersionFile.columns ?? Object.keys(sample[0] ?? {});
 
       return {
         sample,

--- a/frontend/src/graphql/types.ts
+++ b/frontend/src/graphql/types.ts
@@ -1750,6 +1750,8 @@ export type DatasetVersionFilesArgs = {
 export type DatasetVersionFile = MetadataObject & {
   __typename?: 'DatasetVersionFile';
   attributes: Array<MetadataAttribute>;
+  /** Column names in file order, when profiling succeeded. */
+  columns?: Maybe<Array<Scalars['String']['output']>>;
   contentType: Scalars['String']['output'];
   createdAt: Scalars['DateTime']['output'];
   createdBy?: Maybe<User>;


### PR DESCRIPTION
While looking into traces on Logfire, the `preview_dataset_file` tool appears as a frequent cause of context overload.

## Changes

Changes are only to the tool, the GraphQL endpoint used by the frontend is not affected.

- Remove separate "columns" key with SHAs (useless for an LLM), keep ordering intact in the sample's keys
- Drop sample from 50 to 3 rows

## Impact on a real test dataset

**Before: `62,676 characters, ~15,669 tokens`**
```json
{
  "data": {
    "datasetVersionFile": {
      "id": "4360b152-e949-4990-b5b9-fe07a0c6d0a0",
      "filename": "something.csv",
      "contentType": "text/csv",
      "size": 20588,
      "rows": 70,
      "properties": {
        "columns": {
          "08ac28ead0d7f1d59eabb25471945121": "ITN_ACCESS_CI_UPPER_BOUND",
          "1e85baf2ade4293360c0b6665b431188": "MORBIDITY_RISK1",
          "20603301afda409105d1f3e8757d60e0": "ADM2_ID",
          "24bd86e0ac5ff5bc896dedfb70b83990": "ADM2",
          ...
        },
        "column_order": [
          "9d9e86a6e63f728c8354f129f0e7dd4e",
          "772dba222917155b6b905f825e04be33",
          "24bd86e0ac5ff5bc896dedfb70b83990",
          ...
        ]
      },
      "fileSample": {
        "sample": [
          ... 50 samples
        ],
        "status": "FINISHED",
        "statusReason": null
      }
    }
  }
}
```

**After: `3,525 characters, ~881 tokens`**

```json
{
  "id": "4360b152-e949-4990-b5b9-fe07a0c6d0a0",
  "filename": "BFA_WebApp.csv",
  "contentType": "text/csv",
  "size": 20588,
  "rows": 70,
  "fileSample": {
    "sample": [
      {
        "ADM1": "CENTRE OUEST",
        "ADM1_ID": "TMFuUYJyGPX",
        "ADM2": "DS NANORO",
        ...
      },
      ... 2 more samples
    ],
    "status": "FINISHED",
    "statusReason": null,
    "sampleRowsAvailable": 50
  }
}
```