### PR TITLE
fix: Make DB speed improvements CI/test-only

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -36,6 +36,8 @@ jobs:
   test:
     name: Build & Test
     runs-on: ubuntu-latest
+    env:
+      COMPOSE_FILE: docker-compose.yaml:docker-compose.ci.yaml
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -37,7 +37,9 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     env:
-      COMPOSE_FILE: docker-compose.yaml:docker-compose.ci.yaml
+      # Layer the throwaway-DB overrides over the base compose file for every
+      # `docker compose` in this job.
+      COMPOSE_FILE: docker-compose.yaml:docker-compose.test.yaml
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Follow these guidelines when writing code:
 -   **Run tests**: `docker compose run app test --settings=config.settings.test`
 -   **Run specific test**: `docker compose run app test hexa.core.tests.CoreTest.test_ready_200 --settings=config.settings.test`
 -   **Exclude external tests**: `docker compose run app test --exclude-tag=external --settings=config.settings.test`
+-   **Run tests faster** (throwaway in-memory DB, ~30% quicker; the `-p` keeps it from recreating your dev `db` container): `docker compose -p openhexa-test -f docker-compose.yaml -f docker-compose.test.yaml run app test --settings=config.settings.test`
 -   **Run migrations**: `docker compose run app migrate`
 -   **Create fixtures**: `docker compose run app fixtures`
 -   **Lint code**: `pre-commit run --all` (uses ruff for Python)

--- a/README.md
+++ b/README.md
@@ -417,6 +417,18 @@ Use the following command to run the backend tests:
 docker compose --profile test run app test
 ```
 
+Layering `docker-compose.test.yaml` runs the tests against a throwaway in-memory
+database, which is roughly 30% faster on the full suite:
+
+```bash
+docker compose -p openhexa-test -f docker-compose.yaml -f docker-compose.test.yaml --profile test run app test
+```
+
+That database is a tmpfs: it lives in RAM and is discarded with the container, so it never
+touches your local `pgdata` volume. The `-p openhexa-test` project name keeps it in its own
+set of containers — without it, compose recreates your development `db` container with these
+settings, which makes your local database unavailable until you bring the stack back up.
+
 Some tests call external resources (such as the public DHIS2 API) and will slow down the suite. You can exclude them
 when running the test suite for unrelated parts of the codebase:
 

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -1,0 +1,9 @@
+# CI-only overrides, layered on top of docker-compose.yaml via COMPOSE_FILE.
+services:
+  db:
+    # Trade crash-durability for speed. Only safe on a throwaway database: with
+    # fsync off, a killed container can leave data pages ahead of the WAL and
+    # corrupt the cluster, so never use this on a local dev database. To get the
+    # same speedup for a local test run:
+    #   COMPOSE_FILE=docker-compose.yaml:docker-compose.ci.yaml docker compose run app test ...
+    command: postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -1,9 +1,0 @@
-# CI-only overrides, layered on top of docker-compose.yaml via COMPOSE_FILE.
-services:
-  db:
-    # Trade crash-durability for speed. Only safe on a throwaway database: with
-    # fsync off, a killed container can leave data pages ahead of the WAL and
-    # corrupt the cluster, so never use this on a local dev database. To get the
-    # same speedup for a local test run:
-    #   COMPOSE_FILE=docker-compose.yaml:docker-compose.ci.yaml docker compose run app test ...
-    command: postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,0 +1,15 @@
+# Throwaway test database, layered on top of docker-compose.yaml. The data
+# directory is a tmpfs, so it lives in RAM and dies with the container — that is
+# what makes the durability settings below safe to use anywhere, including
+# locally. Measured ~30% faster than the durable configuration on the full suite.
+services:
+  db:
+    command: postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off
+    volumes:
+      # Replaces the pgdata volume from the base file (compose merges mounts by
+      # target). Peak usage is ~600MB with 8 parallel worker databases; tmpfs
+      # allocates lazily, so this is a ceiling, not a reservation.
+      - type: tmpfs
+        target: /var/lib/postgresql/data
+        tmpfs:
+          size: 2147483648

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,9 +33,6 @@ services:
   db:
     platform: linux/amd64
     image: postgis/postgis:16-3.5
-    # Trade crash-durability for speed: fine for a dev/CI database, do not
-    # reuse for production deployments.
-    command: postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off
     env_file:
       - path: ./.env
         required: true


### PR DESCRIPTION
My local dev DB got corrupted because of these settings (a known risk). Small improvement is to just do this config for CI, and not for local development.


Martin edit:
Fix for DB corruption:
```shell
docker compose down && docker volume rm openhexa-app_pgdata
docker compose run app fixtures
```